### PR TITLE
Bugfix: Deleting a book should dismiss Mini Player

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -373,18 +373,29 @@ class PlayerManager: NSObject {
     }
 
     func stop() {
+        self.audioPlayer?.stop()
+
         guard let book = self.currentBook else {
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: Notification.Name.AudiobookPlayer.bookStopped,
+                    object: nil
+                )
+            }
+
             return
         }
 
-        self.audioPlayer?.stop()
+        let userInfo = ["book": book]
 
         self.currentBooks = []
 
-        let userInfo = ["book": book]
-
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: Notification.Name.AudiobookPlayer.bookStopped, object: nil, userInfo: userInfo)
+            NotificationCenter.default.post(
+                name: Notification.Name.AudiobookPlayer.bookStopped,
+                object: nil,
+                userInfo: userInfo
+            )
         }
     }
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -375,18 +375,11 @@ class PlayerManager: NSObject {
     func stop() {
         self.audioPlayer?.stop()
 
-        guard let book = self.currentBook else {
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(
-                    name: Notification.Name.AudiobookPlayer.bookStopped,
-                    object: nil
-                )
-            }
+        var userInfo: [AnyHashable: Any]?
 
-            return
+        if let book = self.currentBook {
+            userInfo = ["book": book]
         }
-
-        let userInfo = ["book": book]
 
         self.currentBooks = []
 


### PR DESCRIPTION
More precisely: Calling stop() should send a notification in any case, which in turn will dismiss the Mini Player if the stop() happend for the current book

Re #182 