### PR TITLE
Feature: Hint cover drag for first time users

### DIFF
--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -18,4 +18,6 @@ struct UserDefaultsConstants {
 
     static let rewindInterval = "userSettingsRewindInterval"
     static let forwardInterval = "userSettingsForwardInterval"
+
+    static let artworkJumpControlsUsed = "userSettingsArtworkJumpControlsUsed"
 }

--- a/BookPlayer/Player.storyboard
+++ b/BookPlayer/Player.storyboard
@@ -291,7 +291,7 @@
                             <constraint firstItem="Gof-rE-l9F" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="QMY-Lu-G0U"/>
                             <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="H18-ma-bZ0" secondAttribute="trailing" constant="2" id="ULW-oA-q4y"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="top" secondItem="vz5-r9-Aky" secondAttribute="bottom" id="WqH-5Y-92m"/>
-                            <constraint firstItem="vz5-r9-Aky" firstAttribute="bottom" secondItem="ssf-c8-jCZ" secondAttribute="bottom" constant="-72" id="XRd-yW-NqB"/>
+                            <constraint firstItem="vz5-r9-Aky" firstAttribute="bottom" secondItem="ssf-c8-jCZ" secondAttribute="bottom" priority="750" constant="-72" id="XRd-yW-NqB"/>
                             <constraint firstItem="QTx-fQ-j4r" firstAttribute="leading" secondItem="Gof-rE-l9F" secondAttribute="trailing" id="aN6-cq-tjX"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="centerX" secondItem="fdI-xo-0K2" secondAttribute="centerX" id="bq4-er-vcQ"/>
                             <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="QTx-fQ-j4r" secondAttribute="trailing" constant="25" id="fiP-SA-ujM"/>

--- a/BookPlayer/Player/Containers/PlayerControlsViewController.swift
+++ b/BookPlayer/Player/Containers/PlayerControlsViewController.swift
@@ -62,10 +62,18 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
         return duration
     }
 
+    private var artworkJumpControlsUsed: Bool = false {
+        didSet {
+            UserDefaults.standard.set(self.artworkJumpControlsUsed, forKey: UserDefaultsConstants.artworkJumpControlsUsed)
+        }
+    }
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        self.artworkJumpControlsUsed = UserDefaults.standard.bool(forKey: UserDefaultsConstants.artworkJumpControlsUsed)
 
         self.artworkControl.isPlaying = PlayerManager.shared.isPlaying
         self.artworkControl.onPlayPause = { control in
@@ -75,9 +83,17 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
         }
         self.artworkControl.onRewind = { _ in
             PlayerManager.shared.rewind()
+
+            if !self.artworkJumpControlsUsed {
+                self.artworkJumpControlsUsed = true
+            }
         }
         self.artworkControl.onForward = { _ in
             PlayerManager.shared.forward()
+
+            if !self.artworkJumpControlsUsed {
+                self.artworkJumpControlsUsed = true
+            }
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.onBookPlay), name: Notification.Name.AudiobookPlayer.bookPlayed, object: nil)
@@ -86,8 +102,12 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
         NotificationCenter.default.addObserver(self, selector: #selector(self.onPlayback), name: Notification.Name.AudiobookPlayer.bookPlaying, object: nil)
     }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if !UserDefaults.standard.bool(forKey: UserDefaultsConstants.artworkJumpControlsUsed) {
+            self.artworkControl.nudgeArtworkViewAnimated(0.5, duration: 0.3)
+        }
     }
 
     // MARK: - Notification Handlers

--- a/BookPlayer/Player/Containers/PlayerControlsViewController.swift
+++ b/BookPlayer/Player/Containers/PlayerControlsViewController.swift
@@ -105,7 +105,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if !UserDefaults.standard.bool(forKey: UserDefaultsConstants.artworkJumpControlsUsed) {
+        if !self.artworkJumpControlsUsed {
             self.artworkControl.nudgeArtworkViewAnimated(0.5, duration: 0.3)
         }
     }

--- a/BookPlayer/Player/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Views/ArtworkControl.swift
@@ -160,14 +160,11 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         self.pan = UIPanGestureRecognizer(target: self, action: #selector(panAction))
         self.pan.delegate = self
         self.pan.maximumNumberOfTouches = 1
-        self.pan.cancelsTouchesInView = true
 
         self.addGestureRecognizer(self.pan!)
 
         self.tap = UITapGestureRecognizer(target: self, action: #selector(tapAction))
         self.tap.delegate = self
-        self.tap.numberOfTapsRequired = 1
-        self.tap.numberOfTouchesRequired = 1
 
         self.addGestureRecognizer(self.tap)
     }

--- a/BookPlayer/Player/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Views/ArtworkControl.swift
@@ -19,11 +19,14 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
     @IBOutlet private weak var artworkImage: BPArtworkView!
     @IBOutlet weak var artworkWidth: NSLayoutConstraint!
     @IBOutlet weak var artworkHeight: NSLayoutConstraint!
+    @IBOutlet weak var playPauseButtonWidth: NSLayoutConstraint!
+    @IBOutlet weak var playPauseButtonHeight: NSLayoutConstraint!
 
     private let playImage = UIImage(named: "playerIconPlay")
     private let pauseImage = UIImage(named: "playerIconPause")
 
     private var pan: UIPanGestureRecognizer!
+    private var tap: UITapGestureRecognizer!
 
     // Based on the design files for iPhone X where the regular artwork is 325dp and the paused state is 255dp in width
     private let artworkScalePaused: CGFloat = 255.0 / 325.0
@@ -85,6 +88,11 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         didSet {
             self.playPauseButton.setImage(self.isPlaying ? self.pauseImage : self.playImage, for: UIControlState())
 
+            let scale = self.isPlaying ? 1.0 : self.artworkScalePaused
+
+            self.playPauseButtonWidth.constant = self.artworkWidth.constant * scale - self.artworkWidth.constant
+            self.playPauseButtonHeight.constant = self.artworkHeight.constant * scale - self.artworkHeight.constant
+
             UIView.animate(
                 withDuration: 0.25,
                 delay: 0.0,
@@ -92,11 +100,9 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
                 initialSpringVelocity: 1.4,
                 options: .preferredFramesPerSecond60,
                 animations: {
-                    if self.isPlaying {
-                        self.artworkImage.transform = .identity
-                    } else {
-                        self.artworkImage.transform = CGAffineTransform(scaleX: self.artworkScalePaused, y: self.artworkScalePaused)
-                    }
+                    self.artworkImage.transform = CGAffineTransform(scaleX: scale, y: scale)
+
+                    self.playPauseButton.layoutIfNeeded()
 
                     self.setTransformForJumpIcons()
                 }
@@ -145,6 +151,11 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         self.artworkImage.layer.cornerRadius = 6.0
         self.artworkImage.layer.masksToBounds = true
 
+        let scale = self.isPlaying ? 1.0 : self.artworkScalePaused
+
+        self.playPauseButtonWidth.constant = self.artworkWidth.constant * scale - self.artworkWidth.constant
+        self.playPauseButtonHeight.constant = self.artworkHeight.constant * scale - self.artworkHeight.constant
+
         // Gestures
         self.pan = UIPanGestureRecognizer(target: self, action: #selector(panAction))
         self.pan.delegate = self
@@ -152,10 +163,13 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         self.pan.cancelsTouchesInView = true
 
         self.addGestureRecognizer(self.pan!)
-    }
 
-    override func layoutIfNeeded() {
+        self.tap = UITapGestureRecognizer(target: self, action: #selector(tapAction))
+        self.tap.delegate = self
+        self.tap.numberOfTapsRequired = 1
+        self.tap.numberOfTouchesRequired = 1
 
+        self.addGestureRecognizer(self.tap)
     }
 
     func setTransformForJumpIcons() {
@@ -254,7 +268,7 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         }
     }
 
-    func resetArtworkViewHorizontalConstraintAnimated() {
+    private func resetArtworkViewHorizontalConstraintAnimated() {
         UIView.animate(
             withDuration: 0.3,
             delay: 0.0,
@@ -276,6 +290,14 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         self.triggeredPanAction = false
     }
 
+    func nudgeArtworkViewAnimated(_ direction: CGFloat = 1.0, duration: TimeInterval = 0.15) {
+        UIView.animate(withDuration: duration, delay: 0.0, options: .curveEaseOut, animations: {
+            self.updateArtworkViewForTranslation(self.jumpIconOffset * direction)
+        }, completion: { _ in
+            self.resetArtworkViewHorizontalConstraintAnimated()
+        })
+    }
+
     @objc private func panAction(gestureRecognizer: UIPanGestureRecognizer) {
         guard gestureRecognizer.isEqual(self.pan) else {
             return
@@ -294,6 +316,23 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
                 self.resetArtworkViewHorizontalConstraintAnimated()
 
             case .possible: break
+        }
+    }
+
+    @objc private func tapAction(gestureRecognizer: UITapGestureRecognizer) {
+        guard gestureRecognizer.isEqual(self.tap) else {
+            return
+        }
+
+        if gestureRecognizer.state == .ended {
+            let touch = gestureRecognizer.location(in: self)
+            let inset = -self.jumpIconOffset
+
+            if self.rewindIcon.frame.insetBy(dx: inset, dy: inset).contains(touch) {
+                self.nudgeArtworkViewAnimated(0.5)
+            } else if self.forwardIcon.frame.insetBy(dx: inset, dy: inset).contains(touch) {
+                self.nudgeArtworkViewAnimated(-0.5)
+            }
         }
     }
 }

--- a/BookPlayer/Player/Views/ArtworkControl.xib
+++ b/BookPlayer/Player/Views/ArtworkControl.xib
@@ -19,6 +19,8 @@
                 <outlet property="contentView" destination="iN0-l3-epB" id="voY-pw-1zj"/>
                 <outlet property="forwardIcon" destination="6cy-7G-42S" id="NVB-er-7r7"/>
                 <outlet property="playPauseButton" destination="eBX-C3-3ce" id="Owy-s4-dRu"/>
+                <outlet property="playPauseButtonHeight" destination="6Ck-Qq-gnO" id="CgN-pl-WUu"/>
+                <outlet property="playPauseButtonWidth" destination="BhJ-SY-3ph" id="5Nb-AQ-LNs"/>
                 <outlet property="rewindIcon" destination="5e7-tW-iQd" id="o4s-xk-HQZ"/>
             </connections>
         </placeholder>
@@ -62,18 +64,15 @@
                         </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="eBX-C3-3ce" firstAttribute="leading" secondItem="38X-b3-v6y" secondAttribute="leading" id="23o-eW-dwE"/>
-                        <constraint firstAttribute="trailing" secondItem="eBX-C3-3ce" secondAttribute="trailing" id="2ta-Qm-Azo"/>
                         <constraint firstItem="b1B-eO-wd8" firstAttribute="centerX" secondItem="38X-b3-v6y" secondAttribute="centerX" id="623-gb-h8J"/>
-                        <constraint firstItem="eBX-C3-3ce" firstAttribute="height" secondItem="38X-b3-v6y" secondAttribute="height" id="6Ck-Qq-gnO"/>
-                        <constraint firstItem="eBX-C3-3ce" firstAttribute="width" secondItem="38X-b3-v6y" secondAttribute="width" id="BhJ-SY-3ph"/>
-                        <constraint firstItem="eBX-C3-3ce" firstAttribute="top" secondItem="38X-b3-v6y" secondAttribute="top" id="LzI-C4-pQD"/>
+                        <constraint firstItem="eBX-C3-3ce" firstAttribute="height" secondItem="b1B-eO-wd8" secondAttribute="height" id="6Ck-Qq-gnO"/>
+                        <constraint firstItem="eBX-C3-3ce" firstAttribute="width" secondItem="b1B-eO-wd8" secondAttribute="width" priority="750" id="BhJ-SY-3ph"/>
                         <constraint firstItem="b1B-eO-wd8" firstAttribute="centerY" secondItem="38X-b3-v6y" secondAttribute="centerY" id="bcV-fF-bGn"/>
-                        <constraint firstAttribute="bottom" secondItem="eBX-C3-3ce" secondAttribute="bottom" id="fIa-eP-dcv"/>
                     </constraints>
                 </view>
             </subviews>
             <constraints>
+                <constraint firstItem="eBX-C3-3ce" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="09S-XA-Xvg"/>
                 <constraint firstItem="38X-b3-v6y" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" id="24y-oW-qiT"/>
                 <constraint firstItem="38X-b3-v6y" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="4pK-UC-UFU"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="6cy-7G-42S" secondAttribute="trailing" id="8rK-lS-9RU"/>
@@ -82,6 +81,7 @@
                 <constraint firstItem="5e7-tW-iQd" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="Ybi-fz-Sbn"/>
                 <constraint firstItem="5e7-tW-iQd" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="eW5-rK-FxM"/>
                 <constraint firstItem="38X-b3-v6y" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" id="fPh-xl-Sdg"/>
+                <constraint firstItem="eBX-C3-3ce" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="spx-FO-obt"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>


### PR DESCRIPTION
This enables a drag hint that nudges the artwork every time the player is presented until the user uses the drag gesture to rewind or forward.

The same nudge is used when the icons behind the artwork are tapped in an attempt to jump that way.

This should provide enough feedback and encouragement to users that return from an earlier version and also convey a little achievement when they interact with the artwork the first time.

Re #196 