### PR TITLE
Feature: Delete empty playlists without confirmation

### DIFF
--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -120,7 +120,7 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
     }
 
     func handleDelete(playlist: Playlist, indexPath: IndexPath) {
-        if playlist.books?.count == 0 {
+        guard playlist.hasBooks() else {
             self.library.removeFromItems(playlist)
 
             DataManager.saveContext()
@@ -238,8 +238,8 @@ extension LibraryViewController {
         var title = "Delete…"
 
         // Remove the dots if trying to delete an empty playlist
-        if item is Playlist {
-            title = ((item as! Playlist).books?.count ?? 0) > 0 ? title : "Delete"
+        if let playlist = item as? Playlist {
+            title = playlist.hasBooks() ? title: "Delete"
         }
 
         let deleteAction = UITableViewRowAction(style: .default, title: title) { (_, indexPath) in

--- a/BookPlayer/Models/Playlist+CoreDataClass.swift
+++ b/BookPlayer/Models/Playlist+CoreDataClass.swift
@@ -42,6 +42,14 @@ public class Playlist: LibraryItem {
         return totalProgress / totalDuration
     }
 
+    func hasBooks() -> Bool {
+        guard let books = self.books else {
+            return false
+        }
+
+        return books.count > 0
+    }
+
     func getRemainingBooks() -> [Book] {
         guard
             let books = self.books?.array as? [Book], let firstUnfinishedBook = books.first(where: { (book) -> Bool in


### PR DESCRIPTION
There is little effort involved in recreating an empty playlist so it makes sense to skip the confirmation dialog.

Re #207 