### PR TITLE
Bugfix: Safeguard artwork color extraction

### DIFF
--- a/BookPlayer/Extensions/UIImage+BookPlayer.swift
+++ b/BookPlayer/Extensions/UIImage+BookPlayer.swift
@@ -9,16 +9,30 @@
 import UIKit
 
 extension UIImage {
-    func averageColor() -> UIColor {
+    func averageColor() -> UIColor? {
         var bitmap = [UInt8](repeating: 0, count: 4)
+        var inputImage: CIImage
+
+        if let ciImage = self.ciImage {
+            inputImage = ciImage
+        } else if let cgImage = self.cgImage {
+            inputImage = CoreImage.CIImage(cgImage: cgImage)
+        } else {
+            return nil
+        }
 
         // Get average color.
         let context = CIContext()
-        let inputImage: CIImage = ciImage ?? CoreImage.CIImage(cgImage: cgImage!)
         let extent = inputImage.extent
         let inputExtent = CIVector(x: extent.origin.x, y: extent.origin.y, z: extent.size.width, w: extent.size.height)
-        let filter = CIFilter(name: "CIAreaAverage", withInputParameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: inputExtent])!
-        let outputImage = filter.outputImage!
+
+        guard
+            let filter = CIFilter(name: "CIAreaAverage", withInputParameters: [kCIInputImageKey: inputImage, kCIInputExtentKey: inputExtent]),
+            let outputImage = filter.outputImage
+        else {
+            return nil
+        }
+
         let outputExtent = outputImage.extent
 
         assert(outputExtent.size.width == 1 && outputExtent.size.height == 1)


### PR DESCRIPTION
My wild guess is that it could be possible that the average color creation fails to retrive both ci and cg image and crashes. Since I haven't found a single book where this happens and none of our users responded to our requests, I hope this helps.

Re #215 