### PR TITLE
Detect added files via iTunes

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		41AB1C131D30298800AC1AA0 /* MBProgressHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41AB1C121D30298800AC1AA0 /* MBProgressHUD.framework */; };
 		41B2AC8E1D43CCE8005382A9 /* ChaptersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B2AC8D1D43CCE8005382A9 /* ChaptersViewController.swift */; };
 		41C3CF7E20AEA5E5007C3EF4 /* DataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */; };
+		41D4F2EB2101A278009F1B1E /* DirectoryWatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D4F2EA2101A278009F1B1E /* DirectoryWatcher.framework */; };
 		C30B085F209654E3003F325B /* UIColor+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */; };
 		C30B66AE20E2D8CF00FC0030 /* ArtworkControl.xib in Resources */ = {isa = PBXBuildFile; fileRef = C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */; };
 		C30CD2A1209791FA00258B09 /* UIColor+Sweetercolor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CD2A0209791FA00258B09 /* UIColor+Sweetercolor.swift */; };
@@ -83,7 +84,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		41B955451F9E552B000C9231 /* Embed Frameworks */ = {
+		41D4F2C92101464D009F1B1E /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
@@ -136,6 +137,7 @@
 		41AB1C121D30298800AC1AA0 /* MBProgressHUD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MBProgressHUD.framework; path = Carthage/Build/iOS/MBProgressHUD.framework; sourceTree = "<group>"; };
 		41B2AC8D1D43CCE8005382A9 /* ChaptersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChaptersViewController.swift; sourceTree = "<group>"; };
 		41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerTests.swift; sourceTree = "<group>"; };
+		41D4F2EA2101A278009F1B1E /* DirectoryWatcher.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DirectoryWatcher.framework; path = Carthage/Build/iOS/DirectoryWatcher.framework; sourceTree = "<group>"; };
 		C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BookPlayer.swift"; sourceTree = "<group>"; };
 		C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ArtworkControl.xib; sourceTree = "<group>"; };
 		C30CD2A0209791FA00258B09 /* UIColor+Sweetercolor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Sweetercolor.swift"; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				41D4F2EB2101A278009F1B1E /* DirectoryWatcher.framework in Frameworks */,
 				4150F80320A8DC34002EDB08 /* IDZSwiftCommonCrypto.framework in Frameworks */,
 				C318DDBF20A4DC7500C3A17B /* DeviceKit.framework in Frameworks */,
 				41AB1C131D30298800AC1AA0 /* MBProgressHUD.framework in Frameworks */,
@@ -252,6 +255,7 @@
 		41AABFFA1E705D18006BD2E0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				41D4F2EA2101A278009F1B1E /* DirectoryWatcher.framework */,
 				4150F80220A8DC34002EDB08 /* IDZSwiftCommonCrypto.framework */,
 				4165EE0D20A7AEC600616EDF /* SwiftReorder.framework */,
 				C318DDBE20A4DC7500C3A17B /* DeviceKit.framework */,
@@ -414,7 +418,7 @@
 				418B6CF51D2707F800F974FB /* Frameworks */,
 				418B6CF61D2707F800F974FB /* Resources */,
 				413616421D30100100E48944 /* Copy Frameworks managed by Carthage */,
-				41B955451F9E552B000C9231 /* Embed Frameworks */,
+				41D4F2C92101464D009F1B1E /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -530,6 +534,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/DeviceKit.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftReorder.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/IDZSwiftCommonCrypto.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/DirectoryWatcher.framework",
 			);
 			name = "Copy Frameworks managed by Carthage";
 			outputPaths = (
@@ -539,10 +544,11 @@
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/DeviceKit.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SwiftReorder.framework",
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/IDZSwiftCommonCrypto.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/DirectoryWatcher.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		C35BADEA20698A6D007687C1 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -9,11 +9,13 @@
 import UIKit
 import AVFoundation
 import MediaPlayer
+import DirectoryWatcher
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var wasPlayingBeforeInterruption: Bool = false
+    var watcher: DirectoryWatcher?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -47,6 +49,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // register for remote events
         self.setupMPRemoteCommands()
+        // register document's folder listener
+        self.setupDocumentListener()
 
         return true
     }
@@ -205,6 +209,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // End seeking
             PlayerManager.shared.rewind()
             return .success
+        }
+    }
+
+    func setupDocumentListener() {
+        let documentsUrl = DataManager.getDocumentsFolderURL()
+        self.watcher = DirectoryWatcher.watch(documentsUrl) {
+            DataManager.notifyPendingFiles()
         }
     }
 }

--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -25,6 +25,8 @@ class BaseListViewController: UIViewController {
         return self.library.items?.array as? [LibraryItem] ?? []
     }
 
+    var processingUrls = [URL]()
+
     let queue = OperationQueue()
     var token: NSKeyValueObservation?
 
@@ -224,10 +226,12 @@ class BaseListViewController: UIViewController {
 
     @objc func openURL(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
-            let fileURL = userInfo["fileURL"] as? URL else {
+            let fileURL = userInfo["fileURL"] as? URL,
+            !self.processingUrls.contains(fileURL) else {
                 return
         }
 
+        self.processingUrls.append(fileURL)
         MBProgressHUD.showAdded(to: self.view, animated: true)
 
         let destinationFolder = DataManager.getProcessedFolderURL()
@@ -240,6 +244,10 @@ class BaseListViewController: UIViewController {
 
             let bookUrl = BookURL(original: fileURL, processed: processedURL)
             self.loadFile(urls: [bookUrl])
+
+            if let index = self.processingUrls.index(where: { $0 == fileURL }) {
+                self.processingUrls.remove(at: index)
+            }
         }
     }
 }

--- a/Cartfile
+++ b/Cartfile
@@ -4,3 +4,4 @@ github "pixelogik/ColorCube" "master"
 github "dennisweissmann/DeviceKit" ~> 1.7
 github "GianniCarlo/SwiftReorder"
 github "iosdevzone/IDZSwiftCommonCrypto"
+github "GianniCarlo/DirectoryWatcher"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,6 @@
 github "pixelogik/ColorCube" "fe4168fd39e5f37839dcf2995c5da50c1a720515"
 github "dennisweissmann/DeviceKit" "1.7.0"
+github "GianniCarlo/DirectoryWatcher" "1.0.0"
 github "iosdevzone/IDZSwiftCommonCrypto" "0.10.0"
 github "jdg/MBProgressHUD" "0.9.2"
 github "cbpowell/MarqueeLabel" "3.1.6"


### PR DESCRIPTION
With this, we'll ensure that if the user has the app open and add files via iTunes, they will begin processing as soon as they are imported. Before, this check was only done once on the app launch.

This is one part of the fix for #209 , the second part would be to expand on the array of processing urls to properly display feedback