### PR TITLE
Enable time context toggling from inside the player, resolves #231

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				TargetAttributes = {
 					418B6CF71D2707F800F974FB = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = FV9NULGJG4;
+						DevelopmentTeam = S7TJSJXWUZ;
 						LastSwiftMigration = 0900;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
@@ -809,7 +809,7 @@
 				CODE_SIGN_ENTITLEMENTS = BookPlayer/BookPlayer.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = FV9NULGJG4;
+				DEVELOPMENT_TEAM = S7TJSJXWUZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -818,7 +818,7 @@
 				INFOPLIST_FILE = BookPlayer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.tortugapower.audiobookplayer.debug-stone";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tortugapower.audiobookplayer;
 				PRODUCT_NAME = BookPlayer;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -835,7 +835,7 @@
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CODE_SIGN_ENTITLEMENTS = BookPlayer/BookPlayer.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = FV9NULGJG4;
+				DEVELOPMENT_TEAM = S7TJSJXWUZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -844,7 +844,7 @@
 				INFOPLIST_FILE = BookPlayer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.tortugapower.audiobookplayer.debug-stone";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tortugapower.audiobookplayer;
 				PRODUCT_NAME = BookPlayer;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -943,7 +943,7 @@
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CODE_SIGN_ENTITLEMENTS = BookPlayer/BookPlayer.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = FV9NULGJG4;
+				DEVELOPMENT_TEAM = S7TJSJXWUZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -952,7 +952,7 @@
 				INFOPLIST_FILE = BookPlayer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.tortugapower.audiobookplayer.debug-stone";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tortugapower.audiobookplayer;
 				PRODUCT_NAME = BookPlayer;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = RELEASE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Perfrom first launch setup
         if !defaults.bool(forKey: Constants.UserDefaults.completedFirstLaunch.rawValue) {
             // Set default settings
+            defaults.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
             defaults.set(true, forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
             defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch.rawValue)
         }

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -13,6 +13,8 @@ enum Constants {
         case lastPlayedBook = "userSettingsLastPlayedBook"
 
         // User preferences
+        case chapterContextEnabled = "userSettingsChapterContext"
+        case remainingTimeEnabled = "userSettingsRemainingTime"
         case smartRewindEnabled = "userSettingsSmartRewind"
         case boostVolumeEnabled = "userSettingsBoostVolume"
         case globalSpeedEnabled = "userSettingsGlobalSpeed"

--- a/BookPlayer/Extensions/UIViewController+BookPlayer.swift
+++ b/BookPlayer/Extensions/UIViewController+BookPlayer.swift
@@ -27,7 +27,7 @@ extension UIViewController {
         durationFormatter.zeroFormattingBehavior = .pad
         durationFormatter.collapsesLargestUnit = false
 
-        if time > 3599.0 {
+        if abs(time) > 3599.0 {
             durationFormatter.allowedUnits = [ .hour, .minute, .second ]
         }
 

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -24,7 +24,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)${BUNDLE_ID_SUFFIX}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/BookPlayer/Player.storyboard
+++ b/BookPlayer/Player.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,11 +34,11 @@
                                 </connections>
                             </button>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yd3-5B-2dw" userLabel="A Spacer">
-                                <rect key="frame" x="0.0" y="88" width="375" height="51.666666666666657"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="52"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Od-bi-f9L" userLabel="Meta Container">
-                                <rect key="frame" x="0.0" y="139.66666666666666" width="375" height="63"/>
+                                <rect key="frame" x="0.0" y="140" width="375" height="63"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="63" id="BbS-cw-NAL"/>
                                 </constraints>
@@ -49,11 +47,11 @@
                                 </connections>
                             </containerView>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xRJ-B7-BuP" userLabel="B Spacer">
-                                <rect key="frame" x="0.0" y="202.66666666666666" width="375" height="20.666666666666657"/>
+                                <rect key="frame" x="0.0" y="203" width="375" height="20.666666666666657"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWJ-W6-gno" userLabel="Controls Contrainer">
-                                <rect key="frame" x="0.0" y="223.33333333333337" width="375" height="422"/>
+                                <rect key="frame" x="0.0" y="223.66666666666663" width="375" height="422"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="XWJ-W6-gno" secondAttribute="height" multiplier="1:1" constant="-47" id="DWR-i3-tsa"/>
                                 </constraints>
@@ -62,7 +60,7 @@
                                 </connections>
                             </containerView>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Udu-jl-e5s" userLabel="C Spacer">
-                                <rect key="frame" x="0.0" y="645.33333333333337" width="375" height="88.666666666666629"/>
+                                <rect key="frame" x="0.0" y="645.66666666666663" width="375" height="88.333333333333371"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="AqX-H1-RbL">
@@ -261,47 +259,59 @@
                                 </connections>
                             </slider>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="00:00:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pew-fS-sdj">
-                                <rect key="frame" x="24.999999999999993" y="395" width="87.333333333333314" height="17"/>
+                                <rect key="frame" x="25" y="395" width="87" height="17"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="00:00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QTx-fQ-j4r">
-                                <rect key="frame" x="263" y="395" width="86.666666666666686" height="17"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Chapter 999 of 999" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gof-rE-l9F">
-                                <rect key="frame" x="112.33333333333331" y="395" width="151" height="17"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2By-Fa-Kn1">
+                                <rect key="frame" x="263" y="395" width="87" height="17"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" priority="250" constant="151" id="qbO-8v-Ojc"/>
+                                    <constraint firstAttribute="height" constant="17" id="Y6E-EF-Yub"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                                <state key="normal" title="00:00:00">
+                                    <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="toggleMaxTime:" destination="68B-o2-0YS" eventType="touchUpInside" id="WMV-eF-Hoa"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LW8-1K-wDU">
+                                <rect key="frame" x="112" y="395" width="151" height="17"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" priority="250" constant="151" id="KKZ-pe-pby"/>
+                                    <constraint firstAttribute="height" constant="17" id="h0a-yl-Lzb"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                <state key="normal" title="Chapter 999 of 999">
+                                    <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="toggleProgressState:" destination="68B-o2-0YS" eventType="touchUpInside" id="Pco-M6-Do4"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vz5-r9-Aky" firstAttribute="width" secondItem="ssf-c8-jCZ" secondAttribute="width" constant="-50" id="0nz-kl-ENO"/>
                             <constraint firstAttribute="top" secondItem="vz5-r9-Aky" secondAttribute="top" constant="-25" id="1XY-T6-zwT"/>
+                            <constraint firstItem="LW8-1K-wDU" firstAttribute="leading" secondItem="pew-fS-sdj" secondAttribute="trailing" id="4F8-1g-dXQ"/>
                             <constraint firstItem="pew-fS-sdj" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="4v0-4T-fQD"/>
                             <constraint firstItem="H18-ma-bZ0" firstAttribute="top" secondItem="gcR-RG-Gq3" secondAttribute="bottom" constant="-10" id="7J6-pY-7OD"/>
-                            <constraint firstItem="pew-fS-sdj" firstAttribute="width" secondItem="QTx-fQ-j4r" secondAttribute="width" id="Kcz-V4-Jjt"/>
-                            <constraint firstItem="QTx-fQ-j4r" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="L04-fk-nNL"/>
+                            <constraint firstItem="LW8-1K-wDU" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="FbH-td-CoD"/>
+                            <constraint firstItem="2By-Fa-Kn1" firstAttribute="leading" secondItem="LW8-1K-wDU" secondAttribute="trailing" id="JUB-Ba-1Z3"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="width" secondItem="ssf-c8-jCZ" secondAttribute="width" id="P6V-BF-4mf"/>
                             <constraint firstItem="H18-ma-bZ0" firstAttribute="leading" secondItem="fdI-xo-0K2" secondAttribute="leading" constant="2" id="QB0-EO-jhz"/>
-                            <constraint firstItem="Gof-rE-l9F" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="QMY-Lu-G0U"/>
                             <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="H18-ma-bZ0" secondAttribute="trailing" constant="2" id="ULW-oA-q4y"/>
+                            <constraint firstItem="2By-Fa-Kn1" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="VBN-NU-1aI"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="top" secondItem="vz5-r9-Aky" secondAttribute="bottom" id="WqH-5Y-92m"/>
                             <constraint firstItem="vz5-r9-Aky" firstAttribute="bottom" secondItem="ssf-c8-jCZ" secondAttribute="bottom" priority="750" constant="-72" id="XRd-yW-NqB"/>
-                            <constraint firstItem="QTx-fQ-j4r" firstAttribute="leading" secondItem="Gof-rE-l9F" secondAttribute="trailing" id="aN6-cq-tjX"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="centerX" secondItem="fdI-xo-0K2" secondAttribute="centerX" id="bq4-er-vcQ"/>
-                            <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="QTx-fQ-j4r" secondAttribute="trailing" constant="25" id="fiP-SA-ujM"/>
+                            <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="2By-Fa-Kn1" secondAttribute="trailing" constant="25" id="eMt-ww-NiK"/>
+                            <constraint firstItem="2By-Fa-Kn1" firstAttribute="width" secondItem="pew-fS-sdj" secondAttribute="width" id="lOR-vA-oyE"/>
                             <constraint firstItem="pew-fS-sdj" firstAttribute="leading" secondItem="fdI-xo-0K2" secondAttribute="leading" constant="25" id="ld0-98-w3v"/>
                             <constraint firstItem="vz5-r9-Aky" firstAttribute="centerX" secondItem="ssf-c8-jCZ" secondAttribute="centerX" id="mMH-sg-q3r"/>
-                            <constraint firstItem="Gof-rE-l9F" firstAttribute="leading" secondItem="pew-fS-sdj" secondAttribute="trailing" id="wlO-tb-kaQ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="fdI-xo-0K2"/>
                     </view>
@@ -310,8 +320,8 @@
                         <outlet property="artworkControl" destination="vz5-r9-Aky" id="q8k-ad-2YL"/>
                         <outlet property="artworkHorizontal" destination="mMH-sg-q3r" id="fzs-5P-SkK"/>
                         <outlet property="currentTimeLabel" destination="pew-fS-sdj" id="8kJ-nc-syL"/>
-                        <outlet property="maxTimeLabel" destination="QTx-fQ-j4r" id="zNW-O3-lVp"/>
-                        <outlet property="progressLabel" destination="Gof-rE-l9F" id="ifK-26-YEv"/>
+                        <outlet property="maxTimeButton" destination="2By-Fa-Kn1" id="gNd-fx-Q8v"/>
+                        <outlet property="progressButton" destination="LW8-1K-wDU" id="WEe-G5-vHc"/>
                         <outlet property="progressSlider" destination="H18-ma-bZ0" id="V6t-wD-E5s"/>
                     </connections>
                 </viewController>

--- a/BookPlayer/Player.storyboard
+++ b/BookPlayer/Player.storyboard
@@ -50,15 +50,6 @@
                                 <rect key="frame" x="0.0" y="203" width="375" height="20.666666666666657"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWJ-W6-gno" userLabel="Controls Contrainer">
-                                <rect key="frame" x="0.0" y="223.66666666666663" width="375" height="422"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="XWJ-W6-gno" secondAttribute="height" multiplier="1:1" constant="-47" id="DWR-i3-tsa"/>
-                                </constraints>
-                                <connections>
-                                    <segue destination="68B-o2-0YS" kind="embed" id="wI0-FH-bve"/>
-                                </connections>
-                            </containerView>
                             <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Udu-jl-e5s" userLabel="C Spacer">
                                 <rect key="frame" x="0.0" y="645.66666666666663" width="375" height="88.333333333333371"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -102,6 +93,15 @@
                                 </items>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </toolbar>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWJ-W6-gno" userLabel="Controls Contrainer">
+                                <rect key="frame" x="0.0" y="223.66666666666663" width="375" height="422"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="XWJ-W6-gno" secondAttribute="height" multiplier="1:1" constant="-47" id="DWR-i3-tsa"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="68B-o2-0YS" kind="embed" id="wI0-FH-bve"/>
+                                </connections>
+                            </containerView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
@@ -248,9 +248,21 @@
                                     <constraint firstAttribute="width" secondItem="gcR-RG-Gq3" secondAttribute="height" multiplier="375:25" id="vrD-Wg-hQo"/>
                                 </constraints>
                             </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="00:00:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pew-fS-sdj">
+                                <rect key="frame" x="25" y="395" width="87" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="25" id="X18-r3-mZ2"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="H18-ma-bZ0" customClass="ProgressSlider" customModule="BookPlayer" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="365" width="375" height="31"/>
+                                <rect key="frame" x="0.0" y="375" width="375" height="21"/>
                                 <color key="tintColor" red="0.20392156859999999" green="0.53333333329999999" blue="0.81960784310000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="ysd-UO-C4a"/>
+                                </constraints>
                                 <connections>
                                     <action selector="sliderDown:event:" destination="68B-o2-0YS" eventType="touchDown" id="Ixp-Ja-Gtu"/>
                                     <action selector="sliderUp:event:" destination="68B-o2-0YS" eventType="touchUpOutside" id="5zH-ZX-njh"/>
@@ -258,16 +270,10 @@
                                     <action selector="sliderValueChanged:event:" destination="68B-o2-0YS" eventType="valueChanged" id="IoN-f2-wvp"/>
                                 </connections>
                             </slider>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="00:00:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pew-fS-sdj">
-                                <rect key="frame" x="25" y="395" width="87" height="17"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2By-Fa-Kn1">
-                                <rect key="frame" x="263" y="395" width="87" height="17"/>
+                                <rect key="frame" x="263" y="395" width="87" height="25"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="17" id="Y6E-EF-Yub"/>
+                                    <constraint firstAttribute="height" constant="25" id="Y6E-EF-Yub"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                 <state key="normal" title="00:00:00">
@@ -278,10 +284,10 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LW8-1K-wDU">
-                                <rect key="frame" x="112" y="395" width="151" height="17"/>
+                                <rect key="frame" x="112" y="395" width="151" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="width" priority="250" constant="151" id="KKZ-pe-pby"/>
-                                    <constraint firstAttribute="height" constant="17" id="h0a-yl-Lzb"/>
+                                    <constraint firstAttribute="height" constant="25" id="h0a-yl-Lzb"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                 <state key="normal" title="Chapter 999 of 999">
@@ -298,7 +304,7 @@
                             <constraint firstAttribute="top" secondItem="vz5-r9-Aky" secondAttribute="top" constant="-25" id="1XY-T6-zwT"/>
                             <constraint firstItem="LW8-1K-wDU" firstAttribute="leading" secondItem="pew-fS-sdj" secondAttribute="trailing" id="4F8-1g-dXQ"/>
                             <constraint firstItem="pew-fS-sdj" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="4v0-4T-fQD"/>
-                            <constraint firstItem="H18-ma-bZ0" firstAttribute="top" secondItem="gcR-RG-Gq3" secondAttribute="bottom" constant="-10" id="7J6-pY-7OD"/>
+                            <constraint firstItem="H18-ma-bZ0" firstAttribute="top" secondItem="gcR-RG-Gq3" secondAttribute="bottom" id="7J6-pY-7OD"/>
                             <constraint firstItem="LW8-1K-wDU" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="FbH-td-CoD"/>
                             <constraint firstItem="2By-Fa-Kn1" firstAttribute="leading" secondItem="LW8-1K-wDU" secondAttribute="trailing" id="JUB-Ba-1Z3"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="width" secondItem="ssf-c8-jCZ" secondAttribute="width" id="P6V-BF-4mf"/>
@@ -306,7 +312,6 @@
                             <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="H18-ma-bZ0" secondAttribute="trailing" constant="2" id="ULW-oA-q4y"/>
                             <constraint firstItem="2By-Fa-Kn1" firstAttribute="top" secondItem="H18-ma-bZ0" secondAttribute="bottom" id="VBN-NU-1aI"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="top" secondItem="vz5-r9-Aky" secondAttribute="bottom" id="WqH-5Y-92m"/>
-                            <constraint firstItem="vz5-r9-Aky" firstAttribute="bottom" secondItem="ssf-c8-jCZ" secondAttribute="bottom" priority="750" constant="-72" id="XRd-yW-NqB"/>
                             <constraint firstItem="gcR-RG-Gq3" firstAttribute="centerX" secondItem="fdI-xo-0K2" secondAttribute="centerX" id="bq4-er-vcQ"/>
                             <constraint firstItem="fdI-xo-0K2" firstAttribute="trailing" secondItem="2By-Fa-Kn1" secondAttribute="trailing" constant="25" id="eMt-ww-NiK"/>
                             <constraint firstItem="2By-Fa-Kn1" firstAttribute="width" secondItem="pew-fS-sdj" secondAttribute="width" id="lOR-vA-oyE"/>

--- a/BookPlayer/Player/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Views/ArtworkControl.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+// swiftlint:disable type_body_length
 class ArtworkControl: UIView, UIGestureRecognizerDelegate {
     @IBOutlet var contentView: UIView!
 

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -90,7 +90,7 @@ class VoiceOverService {
     }
 }
 
-fileprivate enum TimeUnit: String {
+private enum TimeUnit: String {
     case minute
     case second
     case hour

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -67,9 +67,10 @@ class VoiceOverService {
     }
 
     public static func secondsToMinutes(_ interval: TimeInterval) -> String {
-        let hours = (interval / 3600.0).rounded(.towardZero)
-        let minutes = ((interval.truncatingRemainder(dividingBy: 3600)) / 60).rounded(.towardZero)
-        let seconds = ((interval.truncatingRemainder(dividingBy: 60)).truncatingRemainder(dividingBy: 60)).rounded()
+        let absInterval = abs(interval)
+        let hours = (absInterval / 3600.0).rounded(.towardZero)
+        let minutes = ((absInterval.truncatingRemainder(dividingBy: 3600)) / 60).rounded(.towardZero)
+        let seconds = ((absInterval.truncatingRemainder(dividingBy: 60)).truncatingRemainder(dividingBy: 60)).rounded()
 
         let hoursText = pluralization(amount: Int(hours), interval: .hour)
         let minutesText = pluralization(amount: Int(minutes), interval: .minute)


### PR DESCRIPTION
This PR replaces the labels for buttons for both the progress (i.e. the one that states the % or current chapter of the book) and the total duration of the book.

The button for the progress of the book will toggle between: % read vs current chapter (when available)
The button for the total duration of the book will toggle between: total duration vs remaining duration
