### PR TITLE
Audio route change notification

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -138,7 +138,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Pause playback if route changes due to a disconnect
         switch reason {
         case .oldDeviceUnavailable:
-            PlayerManager.shared.pause()
+            DispatchQueue.main.async {
+                PlayerManager.shared.pause()
+            }
         default:
             break
         }


### PR DESCRIPTION
This notification comes from a background thread, when calling `PlayerManager.shared.pause()` it was making UI updates from a background thread and might be the cause of some current crashes