### PR TITLE
Migrate CoreData stack + Autoplay fix

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -585,6 +585,9 @@
 						DevelopmentTeam = FV9NULGJG4;
 						LastSwiftMigration = 0900;
 						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
 							com.apple.BackgroundModes = {
 								enabled = 1;
 							};

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -29,12 +29,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch.rawValue)
         }
 
-        // Migrate file security to make autoplay on background work
-        if !defaults.bool(forKey: Constants.UserDefaults.fileProtectionMigration.rawValue) {
-            DataManager.makeFilesPublic()
-            defaults.set(true, forKey: Constants.UserDefaults.fileProtectionMigration.rawValue)
-        }
-
         // Appearance
         UINavigationBar.appearance().titleTextAttributes = [
             NSAttributedStringKey.foregroundColor: UIColor.init(hex: "#37454E")

--- a/BookPlayer/BookPlayer.entitlements
+++ b/BookPlayer/BookPlayer.entitlements
@@ -16,5 +16,9 @@
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.tortugapower.bookplayer.files</string>
+	</array>
 </dict>
 </plist>

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -8,7 +8,7 @@ enum Constants {
     enum UserDefaults: String {
         // Application information
         case completedFirstLaunch = "userSettingsCompletedFirstLaunch"
-        case fileProtectionMigration = "userSettingsFileProtectionMigration"
+        case appGroupsMigration = "userSettingsAppGroupsMigration"
         case lastPauseTime = "userSettingsLastPauseTime"
         case lastPlayedBook = "userSettingsLastPlayedBook"
 

--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -251,6 +251,7 @@ class BaseListViewController: UIViewController {
         guard
             let userInfo = notification.userInfo,
             let book = userInfo["book"] as? Book,
+            !book.isFault,
             let index = self.library.itemIndex(with: book.fileURL),
             let bookCell = self.tableView.cellForRow(at: IndexPath(row: index, section: .library)) as? BookCellView
         else {

--- a/BookPlayer/Library/FileManagement/DataManager.swift
+++ b/BookPlayer/Library/FileManagement/DataManager.swift
@@ -331,7 +331,7 @@ class DataManager {
         self.saveContext()
     }
 
-    internal class func delete(_ item: NSManagedObject) {
+    class func delete(_ item: NSManagedObject) {
         self.persistentContainer.viewContext.delete(item)
         self.saveContext()
     }

--- a/BookPlayer/Library/FileManagement/DataManager.swift
+++ b/BookPlayer/Library/FileManagement/DataManager.swift
@@ -138,7 +138,7 @@ class DataManager {
      Remove file protection for one file
      */
     class func makeFilePublic(_ file: NSURL) {
-        try? file.setResourceValue(URLFileProtection.completeUntilFirstUserAuthentication, forKey: .fileProtectionKey)
+        try? file.setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
     }
 
     /**

--- a/BookPlayer/Library/FileManagement/DataManager.swift
+++ b/BookPlayer/Library/FileManagement/DataManager.swift
@@ -40,6 +40,10 @@ class DataManager {
         return processedFolderURL
     }
 
+    private static var storeUrl: URL {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.tortugapower.bookplayer.files")!.appendingPathComponent("BookPlayer.sqlite")
+    }
+
     // MARK: - Operations
     class func start(_ operation: Operation) {
         self.queue.addOperation(operation)
@@ -60,9 +64,38 @@ class DataManager {
     }
 
     // MARK: - Core Data stack
+    class func migrateStack() throws {
+        let name = "BookPlayer"
+        let container = NSPersistentContainer(name: name)
+        let psc = container.persistentStoreCoordinator
+
+        let oldStoreUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last!
+            .appendingPathComponent("\(name).sqlite")
+
+        let options = [
+            NSMigratePersistentStoresAutomaticallyOption: true,
+            NSInferMappingModelAutomaticallyOption: true
+        ]
+
+        guard let oldStore = try? psc.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: oldStoreUrl, options: options) else {
+            // couldn't load old store
+            return
+        }
+
+        try psc.migratePersistentStore(oldStore, to: self.storeUrl, options: nil, withType: NSSQLiteStoreType)
+    }
 
     private static var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "BookPlayer")
+        let name = "BookPlayer"
+
+        let container = NSPersistentContainer(name: name)
+
+        let description = NSPersistentStoreDescription()
+        description.shouldInferMappingModelAutomatically = true
+        description.shouldMigrateStoreAutomatically = true
+        description.url = storeUrl
+
+        container.persistentStoreDescriptions = [description]
 
         container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {

--- a/BookPlayer/Library/FileManagement/ImportOperation.swift
+++ b/BookPlayer/Library/FileManagement/ImportOperation.swift
@@ -95,6 +95,7 @@ class ImportOperation: Operation {
             do {
                 if !FileManager.default.fileExists(atPath: destinationURL.path) {
                     try FileManager.default.moveItem(at: file.originalUrl, to: destinationURL)
+                    try (destinationURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
                 } else {
                     try FileManager.default.removeItem(at: file.originalUrl)
                 }

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -174,11 +174,11 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
                 PlayerManager.shared.stop()
             }
 
+            try? FileManager.default.removeItem(at: book.fileURL)
+
             self.library.removeFromItems(book)
 
-            DataManager.saveContext()
-
-            try? FileManager.default.removeItem(at: book.fileURL)
+            DataManager.delete(book)
 
             self.deleteRows(at: [indexPath])
         }))
@@ -193,7 +193,7 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
         guard playlist.hasBooks() else {
             library.removeFromItems(playlist)
 
-            DataManager.saveContext()
+            DataManager.delete(playlist)
 
             deleteRows(at: [indexPath])
             return
@@ -211,7 +211,7 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
             }
 
             self.library.removeFromItems(playlist)
-            DataManager.saveContext()
+            DataManager.delete(playlist)
 
             self.tableView.beginUpdates()
             self.tableView.reloadSections(IndexSet(integer: Section.library.rawValue), with: .none)
@@ -220,14 +220,17 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
         }))
 
         sheet.addAction(UIAlertAction(title: "Delete both playlist and books", style: .destructive, handler: { _ in
-            self.library.removeFromItems(playlist)
-
-            DataManager.saveContext()
-
             // swiftlint:disable force_cast
             for book in playlist.books?.array as! [Book] {
+                if book == PlayerManager.shared.currentBook {
+                    PlayerManager.shared.stop()
+                }
                 try? FileManager.default.removeItem(at: book.fileURL)
             }
+
+            self.library.removeFromItems(playlist)
+
+            DataManager.delete(playlist)
 
             self.deleteRows(at: [indexPath])
         }))

--- a/BookPlayer/Library/PlaylistViewController.swift
+++ b/BookPlayer/Library/PlaylistViewController.swift
@@ -84,6 +84,7 @@ class PlaylistViewController: BaseListViewController {
         guard
             let userInfo = notification.userInfo,
             let book = userInfo["book"] as? Book,
+            !book.isFault,
             let index = self.playlist.itemIndex(with: book.fileURL),
             let bookCell = self.tableView.cellForRow(at: IndexPath(row: index, section: .library)) as? BookCellView
         else {
@@ -198,11 +199,11 @@ extension PlaylistViewController {
                     PlayerManager.shared.stop()
                 }
 
+                try? FileManager.default.removeItem(at: book.fileURL)
+
                 self.playlist.removeFromBooks(book)
 
-                DataManager.saveContext()
-
-                try? FileManager.default.removeItem(at: book.fileURL)
+                DataManager.delete(book)
 
                 self.deleteRows(at: [indexPath])
 

--- a/BookPlayer/Player/Containers/PlayerControlsViewController.swift
+++ b/BookPlayer/Player/Containers/PlayerControlsViewController.swift
@@ -18,7 +18,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
 
     var book: Book? {
         didSet {
-            guard let book = self.book else {
+            guard let book = self.book, !book.isFault else {
                 return
             }
 
@@ -39,7 +39,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
     }
 
     private var currentTimeInContext: TimeInterval {
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             return 0.0
         }
 
@@ -54,7 +54,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
     }
 
     private var maxTimeInContext: TimeInterval {
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             return 0.0
         }
 
@@ -76,7 +76,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
     }
 
     private var durationTimeInContext: TimeInterval {
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             return 0.0
         }
 
@@ -168,7 +168,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
     // MARK: - Helpers
 
     private func setProgress() {
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             self.progressButton.setTitle("", for: .normal)
 
             return
@@ -262,7 +262,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
             self.artworkControl.setAnchorPoint(anchorPoint: CGPoint(x: 0.5, y: 0.5))
         })
 
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             return
         }
 
@@ -283,7 +283,7 @@ class PlayerControlsViewController: PlayerContainerViewController, UIGestureReco
 
         self.transformArtworkView(CGFloat(sender.value))
 
-        guard let book = self.book else {
+        guard let book = self.book, !book.isFault else {
             return
         }
 


### PR DESCRIPTION
In preparation for future features, this PR enables App Groups and migrates the existing CoreData stack. If for some reason the migration fails, the fallback is to load into the library all of the existing files in the `Processed` folder.

I'm also slipping in the fix for #265 since the last time I fixed it, I only changed the files permissions of the existing files and forgot to put that condition when importing new files 😅