### PR TITLE
Siri shortcut for last played book

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		418B6D051D2707F800F974FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 418B6D041D2707F800F974FB /* Assets.xcassets */; };
 		418B6D081D2707F800F974FB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 418B6D061D2707F800F974FB /* LaunchScreen.storyboard */; };
 		418B6D5D1D2CB76900F974FB /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418B6D5C1D2CB76900F974FB /* PlayerViewController.swift */; };
+		4197240021874D5F00AB1190 /* UserActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419723FF21874D5F00AB1190 /* UserActivityManager.swift */; };
 		41A6A87520DEECC400B2C621 /* PlaylistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A6A87420DEECC400B2C621 /* PlaylistTests.swift */; };
 		41B2AC8E1D43CCE8005382A9 /* ChaptersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B2AC8D1D43CCE8005382A9 /* ChaptersViewController.swift */; };
 		41C3CF7E20AEA5E5007C3EF4 /* DataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */; };
@@ -50,10 +51,10 @@
 		41D4F2EB2101A278009F1B1E /* DirectoryWatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D4F2EA2101A278009F1B1E /* DirectoryWatcher.framework */; };
 		41D4F2EF21053944009F1B1E /* IndexPath+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D4F2EE21053944009F1B1E /* IndexPath+BookPlayer.swift */; };
 		41E34E502138EA8200A3997C /* ImportOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E34E4F2138EA8200A3997C /* ImportOperation.swift */; };
+		5CBB29552163E57300E3A9FF /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
 		69225C4F2159C2650004739E /* BookSortService+SortError+PlayListSortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69225C4E2159C2650004739E /* BookSortService+SortError+PlayListSortOrder.swift */; };
-		5CBB29552163E57300E3A9FF /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */; };
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
 		69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */; };
 		C30B085F209654E3003F325B /* UIColor+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */; };
@@ -160,6 +161,7 @@
 		418B6D141D2707F800F974FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		418B6D5C1D2CB76900F974FB /* PlayerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
 		419196341D47CC4E007A3AF3 /* BookPlayer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BookPlayer.entitlements; sourceTree = "<group>"; };
+		419723FF21874D5F00AB1190 /* UserActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActivityManager.swift; sourceTree = "<group>"; };
 		41A6A87420DEECC400B2C621 /* PlaylistTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTests.swift; sourceTree = "<group>"; };
 		41AB1C121D30298800AC1AA0 /* MBProgressHUD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MBProgressHUD.framework; path = Carthage/Build/iOS/MBProgressHUD.framework; sourceTree = "<group>"; };
 		41B2AC8D1D43CCE8005382A9 /* ChaptersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChaptersViewController.swift; sourceTree = "<group>"; };
@@ -168,10 +170,10 @@
 		41D4F2EA2101A278009F1B1E /* DirectoryWatcher.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DirectoryWatcher.framework; path = Carthage/Build/iOS/DirectoryWatcher.framework; sourceTree = "<group>"; };
 		41D4F2EE21053944009F1B1E /* IndexPath+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IndexPath+BookPlayer.swift"; sourceTree = "<group>"; };
 		41E34E4F2138EA8200A3997C /* ImportOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportOperation.swift; sourceTree = "<group>"; };
+		5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
 		69225C4E2159C2650004739E /* BookSortService+SortError+PlayListSortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookSortService+SortError+PlayListSortOrder.swift"; sourceTree = "<group>"; };
-		5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		69343D322133844D000C425E /* VoiceOverService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverService.swift; sourceTree = "<group>"; };
 		69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverServiceTest.swift; sourceTree = "<group>"; };
 		C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BookPlayer.swift"; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 			children = (
 				69343D322133844D000C425E /* VoiceOverService.swift */,
 				69225C4E2159C2650004739E /* BookSortService+SortError+PlayListSortOrder.swift */,
+				419723FF21874D5F00AB1190 /* UserActivityManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -582,13 +585,16 @@
 					};
 					418B6CF71D2707F800F974FB = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = FV9NULGJG4;
+						DevelopmentTeam = S7TJSJXWUZ;
 						LastSwiftMigration = 0900;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
 							};
 							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+							com.apple.Siri = {
 								enabled = 1;
 							};
 							com.apple.iCloud = {
@@ -741,6 +747,7 @@
 				C30EEEBF2079645C00A4ED33 /* PlayerContainerViewController.swift in Sources */,
 				C318D3AD208CF624000666F8 /* PlayerJumpIcon.swift in Sources */,
 				C37A6875209F13120063AEAC /* CreditsViewController.swift in Sources */,
+				4197240021874D5F00AB1190 /* UserActivityManager.swift in Sources */,
 				41D4F2EF21053944009F1B1E /* IndexPath+BookPlayer.swift in Sources */,
 				418B6D5D1D2CB76900F974FB /* PlayerViewController.swift in Sources */,
 				69343D332133844D000C425E /* VoiceOverService.swift in Sources */,

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         if let activityDictionary = launchOptions?[.userActivityDictionary] as? [UIApplicationLaunchOptionsKey: Any],
             let activityType = activityDictionary[.userActivityType] as? String,
-            activityType == Constants.Activities.playback.rawValue {
+            activityType == Constants.UserActivityPlayback {
             defaults.set(true, forKey: activityType)
         }
 

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -53,6 +53,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // register document's folder listener
         self.setupDocumentListener()
 
+        if let activityDictionary = launchOptions?[.userActivityDictionary] as? [UIApplicationLaunchOptionsKey: Any],
+            let activityType = activityDictionary[.userActivityType] as? String,
+            activityType == Constants.Activities.playback.rawValue {
+            defaults.set(true, forKey: activityType)
+        }
+
         return true
     }
 
@@ -61,6 +67,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // like when receiving files through AirDrop
         DataManager.processFile(at: url)
 
+        return true
+    }
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        PlayerManager.shared.play()
         return true
     }
 

--- a/BookPlayer/BookPlayer.entitlements
+++ b/BookPlayer/BookPlayer.entitlements
@@ -10,6 +10,8 @@
 	<array>
 		<string>CloudDocuments</string>
 	</array>
+	<key>com.apple.developer.siri</key>
+	<true/>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
 		<string>iCloud.$(CFBundleIdentifier)</string>

--- a/BookPlayer/BookPlayer.entitlements
+++ b/BookPlayer/BookPlayer.entitlements
@@ -20,7 +20,7 @@
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.tortugapower.bookplayer.files</string>
+		<string>group.$(CFBundleIdentifier).files</string>
 	</array>
 </dict>
 </plist>

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -37,7 +37,5 @@ enum Constants {
         case boosted = 2.0
     }
 
-    enum Activities: String {
-        case playback = "com.tortugapower.audiobookplayer.activity.playback"
-    }
+    static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
 }

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -36,4 +36,8 @@ enum Constants {
         case normal = 1.0
         case boosted = 2.0
     }
+
+    enum Activities: String {
+        case playback = "com.tortugapower.audiobookplayer.activity.playback"
+    }
 }

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -38,4 +38,5 @@ enum Constants {
     }
 
     static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
+    static let ApplicationGroupIdentifier = "group." + Bundle.main.bundleIdentifier! + ".files"
 }

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>NSUserActivityTypes</key>
 	<array>
-		<string>com.tortugapower.audiobookplayer.activity.playback</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).activity.playback</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>com.tortugapower.audiobookplayer.activity.playback</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/BookPlayer/Library/FileManagement/DataManager.swift
+++ b/BookPlayer/Library/FileManagement/DataManager.swift
@@ -41,7 +41,7 @@ class DataManager {
     }
 
     private static var storeUrl: URL {
-        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.tortugapower.bookplayer.files")!.appendingPathComponent("BookPlayer.sqlite")
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)!.appendingPathComponent("BookPlayer.sqlite")
     }
 
     // MARK: - Operations

--- a/BookPlayer/Library/FileManagement/ImportOperation.swift
+++ b/BookPlayer/Library/FileManagement/ImportOperation.swift
@@ -75,35 +75,37 @@ class ImportOperation: Operation {
 
             inputStream.open()
 
-            let digest = Digest(algorithm: .md5)
+            autoreleasepool {
+                let digest = Digest(algorithm: .md5)
 
-            while inputStream.hasBytesAvailable {
-                var inputBuffer = [UInt8](repeating: 0, count: 1024)
-                inputStream.read(&inputBuffer, maxLength: inputBuffer.count)
-                _ = digest.update(byteArray: inputBuffer)
-            }
-
-            inputStream.close()
-
-            let finalDigest = digest.final()
-
-            let hash = hexString(fromArray: finalDigest)
-            let ext = file.originalUrl.pathExtension
-            let filename = hash + ".\(ext)"
-            let destinationURL = file.destinationFolder.appendingPathComponent(filename)
-
-            do {
-                if !FileManager.default.fileExists(atPath: destinationURL.path) {
-                    try FileManager.default.moveItem(at: file.originalUrl, to: destinationURL)
-                    try (destinationURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
-                } else {
-                    try FileManager.default.removeItem(at: file.originalUrl)
+                while inputStream.hasBytesAvailable {
+                    var inputBuffer = [UInt8](repeating: 0, count: 1024)
+                    inputStream.read(&inputBuffer, maxLength: inputBuffer.count)
+                    _ = digest.update(byteArray: inputBuffer)
                 }
-            } catch {
-                fatalError("Fail to move file from \(file.originalUrl) to \(destinationURL)")
-            }
 
-            file.processedUrl = destinationURL
+                inputStream.close()
+
+                let finalDigest = digest.final()
+
+                let hash = hexString(fromArray: finalDigest)
+                let ext = file.originalUrl.pathExtension
+                let filename = hash + ".\(ext)"
+                let destinationURL = file.destinationFolder.appendingPathComponent(filename)
+
+                do {
+                    if !FileManager.default.fileExists(atPath: destinationURL.path) {
+                        try FileManager.default.moveItem(at: file.originalUrl, to: destinationURL)
+                        try (destinationURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
+                    } else {
+                        try FileManager.default.removeItem(at: file.originalUrl)
+                    }
+                } catch {
+                    fatalError("Fail to move file from \(file.originalUrl) to \(destinationURL)")
+                }
+
+                file.processedUrl = destinationURL
+            }
         }
     }
 }

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -25,13 +25,13 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
         // register for appDelegate openUrl notifications
         NotificationCenter.default.addObserver(self, selector: #selector(self.reloadData), name: .reloadData, object: nil)
 
-        self.loadLibrary()
-
         // handle CoreData migration into shared app groups
         if !UserDefaults.standard.bool(forKey: Constants.UserDefaults.appGroupsMigration.rawValue) {
             self.migrateCoreDataStack()
             UserDefaults.standard.set(true, forKey: Constants.UserDefaults.appGroupsMigration.rawValue)
         }
+
+        self.loadLibrary()
 
         self.loadLastBook()
     }

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -78,8 +78,8 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
             guard loaded else { return }
 
             NotificationCenter.default.post(name: .playerDismissed, object: nil, userInfo: nil)
-            if UserDefaults.standard.bool(forKey: Constants.Activities.playback.rawValue) {
-                UserDefaults.standard.removeObject(forKey: Constants.Activities.playback.rawValue)
+            if UserDefaults.standard.bool(forKey: Constants.UserActivityPlayback) {
+                UserDefaults.standard.removeObject(forKey: Constants.UserActivityPlayback)
                 PlayerManager.shared.play()
             }
         }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -81,10 +81,6 @@ class PlayerManager: NSObject {
 
                     NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["book": book])
 
-                    if #available(iOS 11.0, *) {
-                        MPNowPlayingInfoCenter.default().playbackState = self.isPlaying ? MPNowPlayingPlaybackState.playing : MPNowPlayingPlaybackState.paused
-                    }
-
                     completion(true)
                 }
             )

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -79,6 +79,8 @@ class PlayerManager: NSObject {
                     // Set speed for player
                     audioplayer.rate = self.speed
 
+                    UserActivityManager.shared.resumePlaybackActivity()
+
                     NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["book": book])
 
                     completion(true)
@@ -274,6 +276,8 @@ class PlayerManager: NSObject {
             return
         }
 
+        UserActivityManager.shared.resumePlaybackActivity()
+
         UserDefaults.standard.set(currentBook.identifier, forKey: Constants.UserDefaults.lastPlayedBook.rawValue)
 
         do {
@@ -338,6 +342,8 @@ class PlayerManager: NSObject {
             return
         }
 
+        UserActivityManager.shared.stopPlaybackActivity()
+
         UserDefaults.standard.set(currentBook.identifier, forKey: Constants.UserDefaults.lastPlayedBook.rawValue)
 
         // Invalidate timer if needed
@@ -383,6 +389,8 @@ class PlayerManager: NSObject {
 
     func stop() {
         self.audioPlayer?.stop()
+
+        UserActivityManager.shared.stopPlaybackActivity()
 
         var userInfo: [AnyHashable: Any]?
 

--- a/BookPlayer/Services/UserActivityManager.swift
+++ b/BookPlayer/Services/UserActivityManager.swift
@@ -16,11 +16,11 @@ class UserActivityManager {
     var currentActivity: NSUserActivity?
 
     private func createPlaybackActivity() -> NSUserActivity {
-        let activity = NSUserActivity(activityType: Constants.Activities.playback.rawValue)
+        let activity = NSUserActivity(activityType: Constants.UserActivityPlayback)
         activity.title = "Continue last played book"
         if #available(iOS 12.0, *) {
             activity.isEligibleForPrediction = true
-            activity.persistentIdentifier = NSUserActivityPersistentIdentifier(Constants.Activities.playback.rawValue)
+            activity.persistentIdentifier = NSUserActivityPersistentIdentifier(Constants.UserActivityPlayback)
             activity.suggestedInvocationPhrase = "Continue my book"
         }
         activity.isEligibleForSearch = true

--- a/BookPlayer/Services/UserActivityManager.swift
+++ b/BookPlayer/Services/UserActivityManager.swift
@@ -1,0 +1,39 @@
+//
+//  UserActivityManager.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 10/29/18.
+//  Copyright © 2018 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import Intents
+
+class UserActivityManager {
+    static let shared = UserActivityManager()
+    private init() {}
+
+    var currentActivity: NSUserActivity?
+
+    private func createPlaybackActivity() -> NSUserActivity {
+        let activity = NSUserActivity(activityType: Constants.Activities.playback.rawValue)
+        activity.title = "Continue last played book"
+        if #available(iOS 12.0, *) {
+            activity.isEligibleForPrediction = true
+            activity.persistentIdentifier = NSUserActivityPersistentIdentifier(Constants.Activities.playback.rawValue)
+            activity.suggestedInvocationPhrase = "Continue my book"
+        }
+        activity.isEligibleForSearch = true
+
+        return activity
+    }
+
+    func resumePlaybackActivity() {
+        self.currentActivity = self.currentActivity ?? self.createPlaybackActivity()
+        self.currentActivity?.becomeCurrent()
+    }
+
+    func stopPlaybackActivity() {
+        self.currentActivity?.resignCurrent()
+    }
+}


### PR DESCRIPTION
I'm adding the last played book shortcut using `NSUserActivity`

`UserActivityManager` holds one playback activity to resume or stop in tandem with the playback (supposedly this will help with siri suggestions too)

I wasn't sure about the `loadLastBook`. Since the app could be closed when the shortcut is triggered, the library needs to be loaded, that's why `DataManager.getLibrary()` was moved to `RootViewController` and why `loadLastBook` exists on `RootViewController. 
I wasn't sure about using the Notification center, since a notification could arrived when the `LibraryViewController` hasn't loaded yet, so the observers aren't set yet.

I'd like feedback on this last part, I'm still not convinced if the way I'm doing it is the best way