### PR TITLE
Sort files before creating the import operation

### DIFF
--- a/BookPlayer/Library/FileManagement/ImportManager.swift
+++ b/BookPlayer/Library/FileManagement/ImportManager.swift
@@ -37,6 +37,8 @@ class ImportManager {
     @objc private func createOperation() {
         guard !self.files.isEmpty else { return }
 
+        self.files.sort(by: { $0.originalUrl.path < $1.originalUrl.path })
+
         let operation = ImportOperation(files: self.files)
 
         self.files = []


### PR DESCRIPTION
Small PR, when importing via iTunes, the `DirectoryWatcher` library sometimes report new files out of order. With this line we'll make sure to always have the books imported ordered alphabetically