### PR TITLE
Playback Speed resolution Change

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -15,7 +15,7 @@ import MediaPlayer
 class PlayerManager: NSObject {
     static let shared = PlayerManager()
 
-    static let speedOptions: [Float] = [2.5, 2, 1.5, 1.25, 1, 0.75]
+    static let speedOptions: [Float] = [2.5, 2, 1.5, 1.25, 1.1, 1, 0.75]
 
     private var audioPlayer: AVAudioPlayer?
 


### PR DESCRIPTION
Add additional granularity (1.1) for playback speed.  Often audiobooks can be played at a slight increase in speed, but 1.25 can be too rapid for clarity.