### PR TITLE
Fix sorting

### DIFF
--- a/BookPlayer/Library/BaseListViewController.swift
+++ b/BookPlayer/Library/BaseListViewController.swift
@@ -259,40 +259,20 @@ class BaseListViewController: UIViewController {
         let alert = UIAlertController(title: "Sort Files by", message: nil, preferredStyle: .actionSheet)
 
         alert.addAction(UIAlertAction(title: "Title", style: .default, handler: { _ in
-            do {
-                try self.sort(by: .metadataTitle)
-                self.tableView.reloadData()
-            } catch {
-                self.displaySortFailureAlert()
-            }
+            self.sort(by: .metadataTitle)
+            self.tableView.reloadData()
         }))
 
         alert.addAction(UIAlertAction(title: "Original File Name", style: .default, handler: { _ in
-            do {
-                try self.sort(by: .fileName)
-                self.tableView.reloadData()
-            } catch {
-                self.displaySortFailureAlert()
-            }
+            self.sort(by: .fileName)
+            self.tableView.reloadData()
         }))
 
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         return alert
     }
 
-    func sort(by sortType: PlayListSortOrder) throws {
-        fatalError()
-    }
-
-    private func displaySortFailureAlert() {
-        let alert = UIAlertController(title: "Error",
-                                      message: "Sorting is unsupported. Please re-import files",
-                                      preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: "Ok", style: .cancel, handler: nil))
-
-        self.present(alert, animated: true, completion: nil)
-    }
+    func sort(by sortType: PlayListSortOrder) {}
 }
 
 // MARK: - TableView DataSource

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -357,8 +357,8 @@ class LibraryViewController: BaseListViewController, UIGestureRecognizerDelegate
     }
 
     // Sorting
-    override func sort(by sortType: PlayListSortOrder) throws {
-        try library.sort(by: sortType)
+    override func sort(by sortType: PlayListSortOrder) {
+        library.sort(by: sortType)
     }
 }
 

--- a/BookPlayer/Library/PlaylistViewController.swift
+++ b/BookPlayer/Library/PlaylistViewController.swift
@@ -102,8 +102,8 @@ class PlaylistViewController: BaseListViewController {
 
     // MARK: - Methods
 
-    override func sort(by sortType: PlayListSortOrder) throws {
-        try self.playlist.sort(by: sortType)
+    override func sort(by sortType: PlayListSortOrder) {
+        self.playlist.sort(by: sortType)
     }
 }
 

--- a/BookPlayer/Models/Library+CoreDataClass.swift
+++ b/BookPlayer/Models/Library+CoreDataClass.swift
@@ -81,9 +81,9 @@ public class Library: NSManagedObject {
 }
 
 extension Library: Sortable {
-    func sort(by sortType: PlayListSortOrder) throws {
+    func sort(by sortType: PlayListSortOrder) {
         guard let items = items else { return }
-        self.items = try BookSortService.sort(items, by: sortType)
+        self.items = BookSortService.sort(items, by: sortType)
         DataManager.saveContext()
     }
 }

--- a/BookPlayer/Models/Playlist+CoreDataClass.swift
+++ b/BookPlayer/Models/Playlist+CoreDataClass.swift
@@ -167,9 +167,9 @@ public class Playlist: LibraryItem {
 }
 
 extension Playlist: Sortable {
-    func sort(by sortType: PlayListSortOrder) throws {
+    func sort(by sortType: PlayListSortOrder) {
         guard let books = books else { return }
-        self.books = try BookSortService.sort(books, by: sortType)
+        self.books = BookSortService.sort(books, by: sortType)
         DataManager.saveContext()
     }
 }

--- a/BookPlayer/Services/BookSortService+SortError+PlayListSortOrder.swift
+++ b/BookPlayer/Services/BookSortService+SortError+PlayListSortOrder.swift
@@ -1,24 +1,23 @@
 import Foundation
 
 final class BookSortService {
-    public static func sort(_ books: NSOrderedSet, by type: PlayListSortOrder) throws -> NSOrderedSet {
+    public class func sort(_ books: NSOrderedSet, by type: PlayListSortOrder) -> NSOrderedSet {
         switch type {
-        case .metadataTitle:
-            let sortedBooks = try BookSortService.sortByTitle(books)
-            return sortedBooks
-        case .fileName:
-            return try BookSortService.sortByFileName(books)
+        case .metadataTitle, .fileName:
+            return self.sort(books, by: type.rawValue)
         }
     }
 
-    private static func sortByTitle(_ books: NSOrderedSet) throws -> NSOrderedSet {
-        let sortDescriptor = NSSortDescriptor(key: "title", ascending: true)
-        let sortedBooks = books.sortedArray(using: [sortDescriptor])
-        return NSOrderedSet(array: sortedBooks)
-    }
+    private class func sort(_ books: NSOrderedSet, by key: String, ascending: Bool = true) -> NSOrderedSet {
+        let sortDescriptor = NSSortDescriptor(key: key, ascending: ascending) { (field1, field2) -> ComparisonResult in
+            if let string1 = field1 as? String,
+                let string2 = field2 as? String {
+                return string1.localizedStandardCompare(string2)
+            }
 
-    private static func sortByFileName(_ books: NSOrderedSet) throws -> NSOrderedSet {
-        let sortDescriptor = NSSortDescriptor(key: "originalFileName", ascending: true)
+            return ascending ? .orderedAscending : .orderedDescending
+        }
+
         let sortedBooks = books.sortedArray(using: [sortDescriptor])
         return NSOrderedSet(array: sortedBooks)
     }
@@ -29,11 +28,11 @@ enum SortError: Error {
         invalidType
 }
 
-enum PlayListSortOrder {
-    case metadataTitle,
-        fileName
+enum PlayListSortOrder: String {
+    case metadataTitle = "title"
+    case fileName = "originalFileName"
 }
 
 protocol Sortable {
-    func sort(by sortType: PlayListSortOrder) throws
+    func sort(by sortType: PlayListSortOrder)
 }

--- a/BookPlayerTests/Services/BookSortServiceTest.swift
+++ b/BookPlayerTests/Services/BookSortServiceTest.swift
@@ -3,14 +3,19 @@ import XCTest
 
 class BookSortServiceTest: XCTestCase {
     let unorderedBookNames = [
+        "05 Book 1",
+        "01 Book 1",
+        "09 Book 10",
+        "09 Book 2"
+    ]
+
+    let orderedBookNames = [
         "01 Book 1",
         "05 Book 1",
-        "02 Book 1",
-        "03 Book 1",
-        "11 Book 1",
-        "09 Book 1",
-        "07 Book 1"
+        "09 Book 2",
+        "09 Book 10"
     ]
+
     var booksByFile: NSOrderedSet?
 
     override func setUp() {
@@ -20,13 +25,13 @@ class BookSortServiceTest: XCTestCase {
     override func tearDown() {}
 
     func testSortByFileName() {
-        // swiftlint:disable force_try
-        let sortedBooks = try! BookSortService.sort(booksByFile!, by: .fileName)
+        let sortedBooks = BookSortService.sort(booksByFile!, by: .fileName)
         let bookNames = sortedBooks.map { (book) -> String in
             guard let book = book as? Book else { return "" }
             return book.originalFileName!
         }
-        XCTAssert(bookNames == unorderedBookNames.sorted())
+
+        XCTAssert(bookNames == orderedBookNames)
         // swiftlint:enable force_try
     }
 }


### PR DESCRIPTION
Extracted from #289. I also removed the `throws` from the protocol since the `sort` implementation doesn't throw, so the failure alert never would have been called