### PR TITLE
Same speed across books inside a playlist

### DIFF
--- a/BookPlayer/Models/BookPlayer.xcdatamodeld/Audiobook Player.xcdatamodel/contents
+++ b/BookPlayer/Models/BookPlayer.xcdatamodeld/Audiobook Player.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18A391" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ArtworkColors" representedClassName=".ArtworkColors" syncable="YES">
         <attribute name="backgroundHex" attributeType="String" syncable="YES"/>
         <attribute name="displayOnDark" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
@@ -33,6 +33,7 @@
         <attribute name="identifier" attributeType="String" syncable="YES"/>
         <attribute name="originalFileName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="percentCompleted" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="speed" attributeType="Float" defaultValueString="1" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="title" attributeType="String" syncable="YES"/>
         <relationship name="library" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Library" inverseName="items" inverseEntity="Library" syncable="YES"/>
     </entity>
@@ -45,7 +46,7 @@
         <element name="Book" positionX="-65" positionY="329" width="128" height="135"/>
         <element name="Chapter" positionX="162" positionY="99" width="128" height="120"/>
         <element name="Library" positionX="160" positionY="9" width="128" height="58"/>
-        <element name="LibraryItem" positionX="-63" positionY="-18" width="128" height="148"/>
+        <element name="LibraryItem" positionX="-63" positionY="-18" width="128" height="180"/>
         <element name="Playlist" positionX="16" positionY="207" width="128" height="73"/>
     </elements>
 </model>

--- a/BookPlayer/Models/LibraryItem+CoreDataProperties.swift
+++ b/BookPlayer/Models/LibraryItem+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension LibraryItem {
     @NSManaged public var identifier: String!
     @NSManaged public var title: String!
     @NSManaged public var percentCompleted: Double
+    @NSManaged public var speed: Float
     @NSManaged public var library: Library?
     @NSManaged public var originalFileName: String?
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -15,7 +15,7 @@ import MediaPlayer
 class PlayerManager: NSObject {
     static let shared = PlayerManager()
 
-    static let speedOptions: [Float] = [2.5, 2, 1.5, 1.25, 1, 0.75]
+    static let speedOptions: [Float] = [2.5, 2, 1.75, 1.5, 1.25, 1, 0.75]
 
     private var audioPlayer: AVAudioPlayer?
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -113,7 +113,7 @@ class PlayerManager: NSObject {
 
         // stop timer if the book is finished
         if Int(audioplayer.currentTime) == Int(audioplayer.duration) {
-            if self.timer != nil && self.timer.isValid {
+            if self.timer != nil, self.timer.isValid {
                 self.timer.invalidate()
             }
 
@@ -171,9 +171,13 @@ class PlayerManager: NSObject {
 
     var speed: Float {
         get {
+            guard let currentBook = self.currentBook else {
+                return 1.0
+            }
+
             let useGlobalSpeed = UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue)
             let globalSpeed = UserDefaults.standard.float(forKey: "global_speed")
-            let localSpeed = UserDefaults.standard.float(forKey: currentBook!.identifier + "_speed")
+            let localSpeed = currentBook.playlist?.speed ?? currentBook.speed
             let speed = useGlobalSpeed ? globalSpeed : localSpeed
 
             return speed > 0 ? speed : 1.0
@@ -184,7 +188,9 @@ class PlayerManager: NSObject {
                 return
             }
 
-            UserDefaults.standard.set(newValue, forKey: currentBook.identifier + "_speed")
+            currentBook.playlist?.speed = newValue
+            currentBook.speed = newValue
+            DataManager.saveContext()
 
             // set global speed
             if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue) {


### PR DESCRIPTION
Added a new property `speed` to `LibraryItem`. If a book is inside a playlist, the `PlayerManager` will prefer the playlist's speed over the book's speed configuration
