### PR TITLE
Completed state & selected book on artwork tap

### DIFF
--- a/BookPlayer/Library/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemListViewController.swift
@@ -321,7 +321,10 @@ class ItemListViewController: UIViewController, ItemList, ItemListAlerts, ItemLi
         }
 
         let item = self.items[index]
-        let progress = userInfo["progress"] as? Double ?? item.progress
+
+        let progress = item is Playlist
+            ? item.progress
+            : userInfo["progress"] as? Double ?? item.progress
 
         cell.progress = item.isFinished ? 1.0 : progress
     }

--- a/BookPlayer/Library/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemListViewController.swift
@@ -393,7 +393,16 @@ extension ItemListViewController: UITableViewDataSource {
                 }
                 return
             }
-            guard let book = item.getBookToPlay() else { return }
+            guard var book = item.getBookToPlay() else { return }
+
+            // if current playing book belongs to this playlist, override next book
+            if item is Playlist,
+                let bookPlaying = PlayerManager.shared.currentBook,
+                let currentPlaylist = bookPlaying.playlist,
+                currentPlaylist == item,
+                bookPlaying != book {
+                book = bookPlaying
+            }
 
             self?.setupPlayer(book: book)
         }

--- a/BookPlayer/Models/Book+CoreDataClass.swift
+++ b/BookPlayer/Models/Book+CoreDataClass.swift
@@ -26,7 +26,7 @@ public class Book: LibraryItem {
         return self.title
     }
 
-    var progress: Double {
+    override var progress: Double {
         return self.currentTime / self.duration
     }
 
@@ -38,10 +38,9 @@ public class Book: LibraryItem {
         return !(self.chapters?.array.isEmpty ?? true)
     }
 
-    // TODO: This is a makeshift version of a proper completion property.
-    // See https://github.com/TortugaPower/BookPlayer/issues/201
-    override var isCompleted: Bool {
-        return Int(round(self.currentTime)) == Int(round(self.duration))
+    func markAsFinished(_ flag: Bool) {
+        self.isFinished = flag
+        self.playlist?.updateCompletionState()
     }
 
     func setChapters(from asset: AVAsset, context: NSManagedObjectContext) {
@@ -81,6 +80,7 @@ public class Book: LibraryItem {
         self.author = authorFromMeta ?? "Unknown Author"
         self.duration = CMTimeGetSeconds(asset.duration)
         self.originalFileName = bookUrl.originalUrl.lastPathComponent
+        self.isFinished = false
 
         var colors: ArtworkColors!
         if let data = AVMetadataItem.metadataItems(from: asset.metadata, withKey: AVMetadataKey.commonKeyArtwork, keySpace: AVMetadataKeySpace.common).first?.value?.copy(with: nil) as? NSData {

--- a/BookPlayer/Models/BookPlayer.xcdatamodeld/Audiobook Player.xcdatamodel/contents
+++ b/BookPlayer/Models/BookPlayer.xcdatamodeld/Audiobook Player.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18D109" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ArtworkColors" representedClassName=".ArtworkColors" syncable="YES">
         <attribute name="backgroundHex" attributeType="String" syncable="YES"/>
         <attribute name="displayOnDark" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
@@ -31,6 +31,7 @@
         <attribute name="currentTime" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="identifier" attributeType="String" syncable="YES"/>
+        <attribute name="isFinished" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="originalFileName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="percentCompleted" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="speed" attributeType="Float" defaultValueString="1" usesScalarValueType="YES" syncable="YES"/>
@@ -43,10 +44,10 @@
     </entity>
     <elements>
         <element name="ArtworkColors" positionX="-261" positionY="330" width="128" height="135"/>
-        <element name="Book" positionX="-65" positionY="329" width="128" height="135"/>
+        <element name="Book" positionX="-65" positionY="329" width="128" height="133"/>
         <element name="Chapter" positionX="162" positionY="99" width="128" height="120"/>
         <element name="Library" positionX="160" positionY="9" width="128" height="58"/>
-        <element name="LibraryItem" positionX="-63" positionY="-18" width="128" height="180"/>
+        <element name="LibraryItem" positionX="-63" positionY="-18" width="128" height="193"/>
         <element name="Playlist" positionX="16" positionY="207" width="128" height="73"/>
     </elements>
 </model>

--- a/BookPlayer/Models/LibraryItem+CoreDataClass.swift
+++ b/BookPlayer/Models/LibraryItem+CoreDataClass.swift
@@ -27,11 +27,11 @@ public class LibraryItem: NSManagedObject {
 
     var cachedArtwork: UIImage?
 
-    var isCompleted: Bool {
-        return false
-    }
-
     func getBookToPlay() -> Book? {
         return nil
+    }
+
+    var progress: Double {
+        return 1.0
     }
 }

--- a/BookPlayer/Models/LibraryItem+CoreDataProperties.swift
+++ b/BookPlayer/Models/LibraryItem+CoreDataProperties.swift
@@ -24,4 +24,5 @@ extension LibraryItem {
     @NSManaged public var speed: Float
     @NSManaged public var library: Library?
     @NSManaged public var originalFileName: String?
+    @NSManaged public var isFinished: Bool
 }

--- a/BookPlayer/Models/Playlist+CoreDataClass.swift
+++ b/BookPlayer/Models/Playlist+CoreDataClass.swift
@@ -24,10 +24,6 @@ public class Playlist: LibraryItem {
         return book.artwork
     }
 
-    override var isCompleted: Bool {
-        return round(self.totalProgress()) >= round(self.totalDuration())
-    }
-
     // MARK: - Init
 
     convenience init(title: String, books: [Book], context: NSManagedObjectContext) {
@@ -61,7 +57,7 @@ public class Playlist: LibraryItem {
         return totalDuration
     }
 
-    func totalProgress() -> Double {
+    override var progress: Double {
         guard let books = self.books?.array as? [Book] else {
             return 0.0
         }
@@ -79,6 +75,12 @@ public class Playlist: LibraryItem {
         }
 
         return totalProgress / totalDuration
+    }
+
+    func updateCompletionState() {
+        guard let books = self.books?.array as? [Book] else { return }
+        print(!books.contains(where: { !$0.isFinished }))
+        self.isFinished = !books.contains(where: { !$0.isFinished })
     }
 
     func hasBooks() -> Bool {
@@ -133,7 +135,7 @@ public class Playlist: LibraryItem {
         guard let books = self.books else { return nil }
 
         for item in books {
-            guard let book = item as? Book, !book.isCompleted else { continue }
+            guard let book = item as? Book, !book.isFinished else { continue }
 
             return book
         }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -119,7 +119,7 @@ class PlayerManager: NSObject {
 
             // Once book a book is finished, ask for a review
             UserDefaults.standard.set(true, forKey: "ask_review")
-            NotificationCenter.default.post(name: .bookEnd, object: nil)
+            self.markAsCompleted(true)
         }
 
         if let currentChapter = book.currentChapter,
@@ -406,6 +406,19 @@ extension PlayerManager {
                                             object: nil,
                                             userInfo: userInfo)
         }
+    }
+
+    func markAsCompleted(_ flag: Bool) {
+        guard let book = self.currentBook else { return }
+
+        book.markAsFinished(flag)
+        DataManager.saveContext()
+
+        NotificationCenter.default.post(name: .bookEnd,
+                                        object: nil,
+                                        userInfo: [
+                                            "fileURL": book.fileURL
+        ])
     }
 }
 

--- a/BookPlayer/Player/PlayerViewController.swift
+++ b/BookPlayer/Player/PlayerViewController.swift
@@ -19,7 +19,7 @@ class PlayerViewController: UIViewController, UIGestureRecognizerDelegate {
     @IBOutlet private weak var speedButton: UIBarButtonItem!
     @IBOutlet private weak var sleepButton: UIBarButtonItem!
     @IBOutlet private var sleepLabel: UIBarButtonItem!
-    @IBOutlet private weak var chaptersButton: UIBarButtonItem!
+    @IBOutlet private var chaptersButton: UIBarButtonItem!
     @IBOutlet private weak var moreButton: UIBarButtonItem!
     @IBOutlet private weak var backgroundImage: UIImageView!
 

--- a/BookPlayer/Player/PlayerViewController.swift
+++ b/BookPlayer/Player/PlayerViewController.swift
@@ -254,12 +254,11 @@ class PlayerViewController: UIViewController, UIGestureRecognizerDelegate {
             PlayerManager.shared.jumpTo(0.0)
         }))
 
-        actionSheet.addAction(UIAlertAction(title: "Mark as Finished", style: .default, handler: { _ in
-            PlayerManager.shared.pause()
-            // Player resets back to 0.0 if currentTime is set to player's duration
-            PlayerManager.shared.jumpTo(0.1, fromEnd: true)
+        let markTitle = self.currentBook.isFinished ? "Mark as Unfinished" : "Mark as Finished"
 
-            self.requestReview()
+        actionSheet.addAction(UIAlertAction(title: markTitle, style: .default, handler: { _ in
+            PlayerManager.shared.pause()
+            PlayerManager.shared.markAsCompleted(!self.currentBook.isFinished)
         }))
 
         actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/BookPlayerTests/PlaylistTests.swift
+++ b/BookPlayerTests/PlaylistTests.swift
@@ -52,21 +52,21 @@ class PlaylistTests: XCTestCase {
 
         let playlist = generatePlaylist(title: "playlist", books: [book1, book2])
 
-        let emptyProgress = playlist.totalProgress()
+        let emptyProgress = playlist.progress
 
         XCTAssert(emptyProgress == 0.0)
 
         book1.currentTime = 50
         book2.currentTime = 50
 
-        let halfProgress = playlist.totalProgress()
+        let halfProgress = playlist.progress
 
         XCTAssert(halfProgress == 0.5)
 
         book1.currentTime = 100
         book2.currentTime = 100
 
-        let completedProgress = playlist.totalProgress()
+        let completedProgress = playlist.progress
 
         XCTAssert(completedProgress == 1.0)
     }


### PR DESCRIPTION
- New `isFinished` boolean property for `LibraryItem`
  - This state is no longer tied to the progress of the book, so a book that is halfway through could be marked as finished and retain the current position that the user left it in.
- When tapping the artwork of a playlist, and the player has loaded a book of such playlist, it will open the player's book. This will prevent an 'earlier' book being loaded