### PR TITLE
Use travis default script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: swift
 osx_image: xcode10
+xcode_project: BookPlayer.xcodeproj
+xcode_scheme: BookPlayer
+xcode_destination: platform=iOS Simulator,OS=11.3,name=iPhone 5s
 cache:
   directories:
   - Carthage
+  - $HOME/Library/Caches/Homebrew
 before_install:
   - brew update
   - brew outdated carthage || brew upgrade carthage
@@ -10,6 +14,4 @@ before_script:
   # bootstrap the dependencies for the project
   # you can remove if you don't have dependencies
   - carthage bootstrap --verbose --no-use-binaries --platform iOS --cache-builds
-script:
-  - swiftlint 
-  - xcodebuild -project BookPlayer.xcodeproj -scheme BookPlayer -destination 'platform=iOS Simulator,OS=11.3,name=iPhone 5s' test
+  - swiftlint


### PR DESCRIPTION
Checks have begun to fail due to exceeding the limits of the log file. This could be due to the many lines that compiling a file can generate, which are reduced using `xcpretty`. Travis already added `xcpretty` support out of the box