### PR TITLE
"Always On" mode for when device is plugged in

### DIFF
--- a/BookPlayer/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Base.lproj/Settings.storyboard
@@ -189,6 +189,35 @@
                                             <outlet property="customLabel" destination="iys-Y1-zT4" id="p3L-zw-Nfh"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="AuQ-P2-doo" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="587" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AuQ-P2-doo" id="3Hy-3P-G22">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="NMd-BM-Aab">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Only when connected to power" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUk-YK-XeG">
+                                                    <rect key="frame" x="16" y="11.5" width="286" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="NMd-BM-Aab" secondAttribute="trailing" constant="16" id="7Vw-TE-lbA"/>
+                                                <constraint firstItem="ZUk-YK-XeG" firstAttribute="centerY" secondItem="3Hy-3P-G22" secondAttribute="centerY" id="Jr3-gH-rUD"/>
+                                                <constraint firstItem="NMd-BM-Aab" firstAttribute="leading" secondItem="ZUk-YK-XeG" secondAttribute="trailing" constant="8" id="ZUV-GF-mSC"/>
+                                                <constraint firstItem="NMd-BM-Aab" firstAttribute="centerY" secondItem="3Hy-3P-G22" secondAttribute="centerY" id="btB-Ax-J4h"/>
+                                                <constraint firstItem="ZUk-YK-XeG" firstAttribute="leading" secondItem="3Hy-3P-G22" secondAttribute="leading" constant="16" id="k0b-dr-0mp"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="customLabel" destination="ZUk-YK-XeG" id="1dg-Wi-glH"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Siri Shortcut" footerTitle="Use Siri to continue the last played book." id="V2g-SX-Hc4">
@@ -335,6 +364,8 @@
                     <size key="freeformSize" width="375" height="775"/>
                     <connections>
                         <outlet property="appIconLabel" destination="MdO-Yx-eBK" id="dXu-fc-mwk"/>
+                        <outlet property="autolockDisabledOnlyWhenPoweredLabel" destination="ZUk-YK-XeG" id="2hI-Ie-TKo"/>
+                        <outlet property="autolockDisabledOnlyWhenPoweredSwitch" destination="NMd-BM-Aab" id="FuE-ky-W4F"/>
                         <outlet property="autoplayLibrarySwitch" destination="U00-rk-lxZ" id="HCv-jo-TbM"/>
                         <outlet property="disableAutolockSwitch" destination="BlM-8p-0Ka" id="Fbl-zc-kUw"/>
                         <outlet property="themeLabel" destination="CVc-ad-1rf" id="I40-1O-6rO"/>

--- a/BookPlayer/Constants.swift
+++ b/BookPlayer/Constants.swift
@@ -25,6 +25,7 @@ enum Constants {
         case globalSpeedEnabled = "userSettingsGlobalSpeed"
         case autoplayEnabled = "userSettingsAutoplay"
         case autolockDisabled = "userSettingsDisableAutolock"
+        case autolockDisabledOnlyWhenPowered = "userSettingsAutolockOnlyWhenPowered"
 
         case rewindInterval = "userSettingsRewindInterval"
         case forwardInterval = "userSettingsForwardInterval"

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -16,6 +16,8 @@ import UIKit
 class SettingsViewController: UITableViewController, MFMailComposeViewControllerDelegate {
     @IBOutlet weak var autoplayLibrarySwitch: UISwitch!
     @IBOutlet weak var disableAutolockSwitch: UISwitch!
+    @IBOutlet weak var autolockDisabledOnlyWhenPoweredSwitch: UISwitch!
+    @IBOutlet weak var autolockDisabledOnlyWhenPoweredLabel: UILabel!
     @IBOutlet weak var themeLabel: UILabel!
     @IBOutlet weak var appIconLabel: UILabel!
 
@@ -56,10 +58,14 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 
         self.autoplayLibrarySwitch.addTarget(self, action: #selector(self.autoplayToggleDidChange), for: .valueChanged)
         self.disableAutolockSwitch.addTarget(self, action: #selector(self.disableAutolockDidChange), for: .valueChanged)
+        self.autolockDisabledOnlyWhenPoweredSwitch.addTarget(self, action: #selector(self.autolockOnlyWhenPoweredDidChange), for: .valueChanged)
 
         // Set initial switch positions
         self.autoplayLibrarySwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled.rawValue), animated: false)
         self.disableAutolockSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue), animated: false)
+        self.autolockDisabledOnlyWhenPoweredSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue), animated: false)
+        self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue)
+        self.autolockDisabledOnlyWhenPoweredLabel.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue)
 
         guard
             let version = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String,
@@ -82,6 +88,12 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
 
     @objc func disableAutolockDidChange() {
         UserDefaults.standard.set(self.disableAutolockSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabled.rawValue)
+        self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = self.disableAutolockSwitch.isOn
+        self.autolockDisabledOnlyWhenPoweredLabel.isEnabled = self.disableAutolockSwitch.isOn
+    }
+
+    @objc func autolockOnlyWhenPoweredDidChange() {
+        UserDefaults.standard.set(self.autolockDisabledOnlyWhenPoweredSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue)
     }
 
     @IBAction func done(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
This PR adds a setting to allow disabling autolock when the device is plugged in to power.

I added this as a switch in the Settings view. If the "Disable Autolock" switch is off, then this setting will be inaccessible. (i.e. the user will need to enable "Disable Autolock" and then further enable "Only When Plugged In")

I also added a listener to battery state updates in the `PlayerViewController` so that the idle timer is enabled/disabled dynamically as the device battery state changes.

Please let me know if you'd prefer a different wording of the setting. This is my first iOS/Swift PR, so I'm also super open to other code/style suggestions. 😄 

#### Screenshots

<img src="https://user-images.githubusercontent.com/706257/56617454-8b454680-65e5-11e9-90a6-19b3f8fd1bc2.png" width="250"/>

<img src="https://user-images.githubusercontent.com/706257/56617455-8bdddd00-65e5-11e9-9ba0-29b58843efee.png" width="250"/>

