### PR TITLE
Fixing issue with book not starting from the right time

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let activityDictionary = launchOptions?[.userActivityDictionary] as? [UIApplication.LaunchOptionsKey: Any],
             let activityType = activityDictionary[.userActivityType] as? String,
             activityType == Constants.UserActivityPlayback {
-            defaults.set(true, forKey: activityType)
+            self.playLastBook()
         }
 
         // Create a Sentry client and start crash handler
@@ -119,7 +119,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        PlayerManager.shared.play()
+        self.playLastBook()
         return true
     }
 
@@ -365,7 +365,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate {
     func playLastBook() {
-        if PlayerManager.shared.isLoaded {
+        if PlayerManager.shared.hasLoadedBook {
             PlayerManager.shared.play()
         } else {
             UserDefaults.standard.set(true, forKey: Constants.UserActivityPlayback)

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -373,7 +373,7 @@ extension AppDelegate {
     }
 
     func showPlayer() {
-        if PlayerManager.shared.isLoaded {
+        if PlayerManager.shared.hasLoadedBook {
             guard let rootVC = UIApplication.shared.keyWindow?.rootViewController! as? RootViewController,
                 let appNav = rootVC.children.first as? AppNavigationController,
                 let libraryVC = appNav.children.first as? LibraryViewController,

--- a/BookPlayer/Library/RootViewController.swift
+++ b/BookPlayer/Library/RootViewController.swift
@@ -79,7 +79,7 @@ class RootViewController: UIViewController, UIGestureRecognizerDelegate {
     // MARK: -
 
     @objc private func presentMiniPlayer() {
-        guard PlayerManager.shared.isLoaded else { return }
+        guard PlayerManager.shared.hasLoadedBook else { return }
 
         self.animateView(self.miniPlayerContainer, show: true)
     }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -30,6 +30,8 @@ class PlayerManager: NSObject {
 
     var outputPort: AVAudioSessionPortDescription?
 
+    private(set) var hasLoadedBook = false
+
     func load(_ book: Book, completion: @escaping (Bool) -> Void) {
         if self.currentBook != nil {
             self.stop()
@@ -85,6 +87,7 @@ class PlayerManager: NSObject {
                 NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["book": book])
 
                 completion(true)
+                self.hasLoadedBook = true
             })
         }
     }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -86,8 +86,8 @@ class PlayerManager: NSObject {
 
                 NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["book": book])
 
-                completion(true)
                 self.hasLoadedBook = true
+                completion(true)
             })
         }
     }
@@ -150,10 +150,6 @@ class PlayerManager: NSObject {
     }
 
     // MARK: - Player states
-
-    var isLoaded: Bool {
-        return self.audioPlayer != nil
-    }
 
     var isPlaying: Bool {
         return self.audioPlayer?.isPlaying ?? false

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -431,6 +431,7 @@ extension PlayerManager {
         }
 
         self.currentBook = nil
+        self.hasLoadedBook = false
 
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .bookStopped,

--- a/BookPlayer/Player/PlayerViewController.swift
+++ b/BookPlayer/Player/PlayerViewController.swift
@@ -362,7 +362,7 @@ extension PlayerViewController {
     }
 
     @IBAction func showMore() {
-        guard PlayerManager.shared.isLoaded else {
+        guard PlayerManager.shared.hasLoadedBook else {
             return
         }
 


### PR DESCRIPTION
When using the Siri intent AND the app is not in the background when the app starts it plays from the beginning of the previous book but not form where you played last.

This creates a better flag to check if the book should start playing or if it should postpone.

To reproduce: 

* Open the app
* Start a book and go to the middle of the file.
* Stop
* Background
* Hard quit
* Invoke the siri shortcut
* Book should start from the beginning.

The key to this change seems to be having a separate flag that indicates if the book was loaded, not if the audio player was created.