### PR TITLE
Fix autoplay

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -60,6 +60,8 @@ class PlayerManager: NSObject {
 
             self.update()
         }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(playerDidFinishPlaying(_:)), name: .AVPlayerItemDidPlayToEndTime, object: nil)
     }
 
     func load(_ book: Book, completion: @escaping (Bool) -> Void) {
@@ -493,17 +495,9 @@ extension PlayerManager {
                                             "fileURL": fileURL
         ])
     }
-}
 
-// MARK: - AVAudioPlayer Delegate
-
-extension PlayerManager: AVAudioPlayerDelegate {
-    // Leave the slider at max
-    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        guard flag else { return }
-
-        player.currentTime = player.duration
-
+    @objc
+    func playerDidFinishPlaying(_ notification: Notification) {
         if let book = self.currentBook,
             let library = book.library ?? book.playlist?.library {
             library.lastPlayedBook = nil
@@ -522,6 +516,8 @@ extension PlayerManager: AVAudioPlayerDelegate {
             NotificationCenter.default.post(name: .bookChange,
                                             object: nil,
                                             userInfo: userInfo)
+
+            self.play()
         })
     }
 }

--- a/Shared/Models/Playlist+CoreDataClass.swift
+++ b/Shared/Models/Playlist+CoreDataClass.swift
@@ -174,8 +174,11 @@ public class Playlist: LibraryItem {
         }
 
         for (index, book) in books.enumerated() {
-            guard index > indexFound,
-                !book.isFinished else { continue }
+            guard index > indexFound else { continue }
+
+            if book.isFinished {
+                book.currentTime = 0
+            }
 
             return book
         }


### PR DESCRIPTION
When AVAudioPlayer was changed for AVPlayer, I forgot to replace the delegate function that it brought with it (the callback when the book finished playing). 

Besides we made an alteration on how autoplay works, now the book that is next in line and is auto-played, it'll jump back to the beginning. This is to alleviate the users that have marked all the books in a playlist as completed, and can't listen to them again properly unless they mark it again as unfinished