### PR TITLE
More bug fixes

### DIFF
--- a/BookPlayer/Library/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemListViewController.swift
@@ -195,11 +195,12 @@ class ItemListViewController: UIViewController, ItemList, ItemListAlerts, ItemLi
         }
     }
 
-    func setupPlayer(book: Book) {
+    func setupPlayer(book: Book, _ override: Bool = false) {
         // Make sure player is for a different book
         guard
             let currentBook = PlayerManager.shared.currentBook,
-            currentBook == book
+            currentBook == book,
+            !override
         else {
             // Handle loading new player
             self.loadPlayer(book: book)
@@ -492,7 +493,7 @@ extension ItemListViewController: UITableViewDataSource {
 
             guard let book = self?.getNextBook(item) else { return }
 
-            self?.setupPlayer(book: book)
+            self?.setupPlayer(book: book, true)
         }
 
         if let book = item as? Book {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -106,7 +106,9 @@ class PlayerManager: NSObject {
                 MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
 
                 if book.currentTime > 0.0 {
-                    self.jumpTo(book.currentTime)
+                    // if book is truly finished, start book again to avoid autoplaying next one
+                    let time = book.currentTime == book.duration ? 0 : book.currentTime
+                    self.jumpTo(time)
                 }
 
                 NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["book": book])

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -16,7 +16,7 @@ import MediaPlayer
 class PlayerManager: NSObject {
     static let shared = PlayerManager()
 
-    static let speedOptions: [Float] = [2.5, 2, 1.75, 1.5, 1.25, 1, 0.75]
+    static let speedOptions: [Float] = [3, 2.5, 2, 1.75, 1.5, 1.25, 1, 0.9, 0.75, 0.5]
 
     private var audioPlayer = AVPlayer()
 

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -90,7 +90,6 @@ class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableContentDe
 
         guard let playlist = items[indexPath[IndexGuide.library.content]] as? Playlist,
             let count = playlist.books?.count else {
-            print(items[indexPath[IndexGuide.library.content]])
             return 0
         }
 

--- a/Shared/Models/Playlist+CoreDataClass.swift
+++ b/Shared/Models/Playlist+CoreDataClass.swift
@@ -100,7 +100,7 @@ public class Playlist: LibraryItem {
 
     public func updateCompletionState() {
         guard let books = self.books?.array as? [Book] else { return }
-        print(!books.contains(where: { !$0.isFinished }))
+
         self.isFinished = !books.contains(where: { !$0.isFinished })
     }
 


### PR DESCRIPTION
This PR fixes:
- Unable to pick a completed book from inside a playlist (it skipped to the next one)
- Sleep timer end-of-chapter option won't stop when the book finishes
- Tapping mini artwork won't start playback in case the book is already loaded

It also includes three new speed options (3x, 0.9x, 0.5x)