### PR TITLE
Fix sleep timer label not showing

### DIFF
--- a/Shared/Extensions/Notification+BookPlayerKit.swift
+++ b/Shared/Extensions/Notification+BookPlayerKit.swift
@@ -20,4 +20,7 @@ extension Notification.Name {
     public static let bookPlaying = Notification.Name("com.tortugapower.audiobookplayer.book.playback")
     public static let contextUpdate = Notification.Name("com.tortugapower.audiobookplayer.watch.sync")
     public static let messageReceived = Notification.Name("com.tortugapower.audiobookplayer.watch.message")
+    public static let timerStart = Notification.Name("com.tortugapower.audiobookplayer.sleeptimer.start")
+    public static let timerProgress = Notification.Name("com.tortugapower.audiobookplayer.sleeptimer.progress")
+    public static let timerEnd = Notification.Name("com.tortugapower.audiobookplayer.sleeptimer.end")
 }


### PR DESCRIPTION
This refactors the singleton to stop using completion blocks (which were lost to the dismissed instance of the PlayerViewController, and we opt for three new events which basically do the same