### PR TITLE
New shortcut: `Resume last played book`

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		41544A1421BAF41400740AD2 /* ItemSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41544A1321BAF41400740AD2 /* ItemSelectionViewController.swift */; };
 		415758EA2226E18800DDB9B6 /* PlusBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415758E92226E18800DDB9B6 /* PlusBannerView.swift */; };
 		415B274421FAE47200F9D9B7 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415B274321FAE47200F9D9B7 /* LoadingView.swift */; };
+		415F0E6F244AAC5A00DD1D8B /* PlayMediaIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415F0E6E244AAC5A00DD1D8B /* PlayMediaIntentHandler.swift */; };
 		4160A09223F2DE130039166B /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 4160A09423F2DE130039166B /* Localizable.stringsdict */; };
 		4160A0A123F304530039166B /* LocalizableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4160A0A023F304530039166B /* LocalizableLabel.swift */; };
 		4163E313214AC43000072AA2 /* ImportOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4163E312214AC43000072AA2 /* ImportOperationTests.swift */; };
@@ -397,6 +398,7 @@
 		41544A1321BAF41400740AD2 /* ItemSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSelectionViewController.swift; sourceTree = "<group>"; };
 		415758E92226E18800DDB9B6 /* PlusBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusBannerView.swift; sourceTree = "<group>"; };
 		415B274321FAE47200F9D9B7 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		415F0E6E244AAC5A00DD1D8B /* PlayMediaIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayMediaIntentHandler.swift; sourceTree = "<group>"; };
 		4160A08E23F2DBD40039166B /* String+BookPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+BookPlayer.swift"; sourceTree = "<group>"; };
 		4160A09323F2DE130039166B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		4160A09523F2DE190039166B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 			children = (
 				41342D0024435D9900F0905B /* IntentHandler.swift */,
 				41342D0B24435EF800F0905B /* SleepTimerHandler.swift */,
+				415F0E6E244AAC5A00DD1D8B /* PlayMediaIntentHandler.swift */,
 				41342D0224435D9900F0905B /* Info.plist */,
 			);
 			path = BookPlayerIntents;
@@ -1668,6 +1671,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				41342D0C24435EF800F0905B /* SleepTimerHandler.swift in Sources */,
+				415F0E6F244AAC5A00DD1D8B /* PlayMediaIntentHandler.swift in Sources */,
 				41342D0A24435DAD00F0905B /* Intents.intentdefinition in Sources */,
 				41342D0124435D9900F0905B /* IntentHandler.swift in Sources */,
 			);

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -10,6 +10,7 @@ import AVFoundation
 import BookPlayerKit
 import CoreData
 import DirectoryWatcher
+import Intents
 import MediaPlayer
 import Sentry
 import SwiftyStoreKit
@@ -112,6 +113,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ActionParserService.process(userActivity)
 
         return true
+    }
+
+    func application(_ application: UIApplication, handle intent: INIntent, completionHandler: @escaping (INIntentResponse) -> Void) {
+        ActionParserService.process(intent)
+
+        let response = INPlayMediaIntentResponse(code: .success, userActivity: nil)
+        completionHandler(response)
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -222,6 +222,7 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).activity.playback</string>
+		<string>INPlayMediaIntent</string>
 		<string>SleepTimerIntent</string>
 	</array>
 	<key>UIApplicationShortcutItems</key>

--- a/BookPlayer/Intents.intentdefinition
+++ b/BookPlayer/Intents.intentdefinition
@@ -115,9 +115,9 @@
 	<key>INIntentDefinitionSystemVersion</key>
 	<string>19E287</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>11E146</string>
+	<string>11E503a</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>11.4</string>
+	<string>11.4.1</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -352,6 +352,234 @@
 			<string>Custom</string>
 			<key>INIntentVerb</key>
 			<string>Set</string>
+		</dict>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>system</string>
+			<key>INIntentClassName</key>
+			<string>INPlayMediaIntent</string>
+			<key>INIntentClassPrefix</key>
+			<string>IN</string>
+			<key>INIntentCustomizable</key>
+			<true/>
+			<key>INIntentDescription</key>
+			<string>A request to play the most recent book.</string>
+			<key>INIntentDescriptionID</key>
+			<string>LdrEPN</string>
+			<key>INIntentDomain</key>
+			<string>Media</string>
+			<key>INIntentInput</key>
+			<string>mediaItems</string>
+			<key>INIntentKeyParameter</key>
+			<string>mediaItems</string>
+			<key>INIntentLastParameterTag</key>
+			<integer>17</integer>
+			<key>INIntentName</key>
+			<string>PlayMedia</string>
+			<key>INIntentParameterCombinations</key>
+			<dict>
+				<key></key>
+				<dict>
+					<key>INIntentParameterCombinationIsPrimary</key>
+					<true/>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Resume last played book</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>5EnoUf</string>
+				</dict>
+			</dict>
+			<key>INIntentParameters</key>
+			<array>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Items</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>cfJexL</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>1</integer>
+					<key>INIntentParameterName</key>
+					<string>mediaItems</string>
+					<key>INIntentParameterObjectType</key>
+					<string>MediaItem</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>System</string>
+					<key>INIntentParameterSupportsMultipleValues</key>
+					<true/>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>1</integer>
+					<key>INIntentParameterType</key>
+					<string>Object</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Container</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>xdnqvn</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>2</integer>
+					<key>INIntentParameterName</key>
+					<string>mediaContainer</string>
+					<key>INIntentParameterObjectType</key>
+					<string>MediaItem</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>System</string>
+					<key>INIntentParameterTag</key>
+					<integer>2</integer>
+					<key>INIntentParameterType</key>
+					<string>Object</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Shuffled</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>WktFNa</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>3</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataFalseDisplayName</key>
+						<string>not shuffled</string>
+						<key>INIntentParameterMetadataFalseDisplayNameID</key>
+						<string>mCAocc</string>
+						<key>INIntentParameterMetadataTrueDisplayName</key>
+						<string>shuffled</string>
+						<key>INIntentParameterMetadataTrueDisplayNameID</key>
+						<string>QqdHiR</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>playShuffled</string>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>3</integer>
+					<key>INIntentParameterType</key>
+					<string>Boolean</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Repeat Mode</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>ErAaNp</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>4</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>PlaybackRepeatMode</string>
+					<key>INIntentParameterEnumTypeNamespace</key>
+					<string>System</string>
+					<key>INIntentParameterName</key>
+					<string>playbackRepeatMode</string>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Resume</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>rvNMpm</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>5</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataFalseDisplayName</key>
+						<string>don't resume</string>
+						<key>INIntentParameterMetadataFalseDisplayNameID</key>
+						<string>Pk1Fkx</string>
+						<key>INIntentParameterMetadataTrueDisplayName</key>
+						<string>resume</string>
+						<key>INIntentParameterMetadataTrueDisplayNameID</key>
+						<string>No0K9w</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>resumePlayback</string>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>5</integer>
+					<key>INIntentParameterType</key>
+					<string>Boolean</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Queue Location</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>cV2HLF</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>6</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>PlaybackQueueLocation</string>
+					<key>INIntentParameterEnumTypeNamespace</key>
+					<string>System</string>
+					<key>INIntentParameterName</key>
+					<string>playbackQueueLocation</string>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>6</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Playback Speed</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>RvX3Zd</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>7</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataMaximumValue</key>
+						<real>1</real>
+						<key>INIntentParameterMetadataSupportsNegativeNumbers</key>
+						<string>YES</string>
+						<key>INIntentParameterMetadataType</key>
+						<string>Field</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>playbackSpeed</string>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>7</integer>
+					<key>INIntentParameterType</key>
+					<string>Decimal</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterDisplayName</key>
+					<string>Media Search</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>1uT6VF</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>8</integer>
+					<key>INIntentParameterName</key>
+					<string>mediaSearch</string>
+					<key>INIntentParameterObjectType</key>
+					<string>MediaSearch</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>System</string>
+					<key>INIntentParameterTag</key>
+					<integer>8</integer>
+					<key>INIntentParameterType</key>
+					<string>Object</string>
+				</dict>
+			</array>
+			<key>INIntentTitle</key>
+			<string>Resume last played book</string>
+			<key>INIntentTitleID</key>
+			<string>G3J6fP</string>
+			<key>INIntentType</key>
+			<string>System</string>
 		</dict>
 	</array>
 	<key>INTypes</key>

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -8,6 +8,7 @@
 
 import BookPlayerKit
 import Foundation
+import Intents
 
 class ActionParserService {
     public class func process(_ url: URL) {
@@ -18,6 +19,12 @@ class ActionParserService {
 
     public class func process(_ activity: NSUserActivity) {
         guard let action = CommandParser.parse(activity) else { return }
+
+        self.handleAction(action)
+    }
+
+    public class func process(_ intent: INIntent) {
+        guard let action = CommandParser.parse(intent) else { return }
 
         self.handleAction(action)
     }

--- a/BookPlayer/Services/UserActivityManager.swift
+++ b/BookPlayer/Services/UserActivityManager.swift
@@ -17,6 +17,9 @@ class UserActivityManager {
     var playbackRecord: PlaybackRecord?
 
     private init() {
+        let intent = INPlayMediaIntent()
+        let interaction = INInteraction(intent: intent, response: nil)
+        interaction.donate(completion: nil)
         let activity = NSUserActivity(activityType: Constants.UserActivityPlayback)
         activity.title = "siri_activity_title".localized
         activity.isEligibleForPrediction = true

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -206,7 +206,10 @@ class SettingsViewController: UITableViewController, MFMailComposeViewController
     }
 
     func showLastPlayedShortcut() {
-        let shortcut = INShortcut(userActivity: UserActivityManager.shared.currentActivity)
+        let intent = INPlayMediaIntent()
+
+        guard let shortcut = INShortcut(intent: intent) else { return }
+
         let vc = INUIAddVoiceShortcutViewController(shortcut: shortcut)
         vc.delegate = self
 

--- a/BookPlayerIntents/Info.plist
+++ b/BookPlayerIntents/Info.plist
@@ -30,6 +30,7 @@
 			<array/>
 			<key>IntentsSupported</key>
 			<array>
+				<string>INPlayMediaIntent</string>
 				<string>SleepTimerIntent</string>
 			</array>
 		</dict>

--- a/BookPlayerIntents/IntentHandler.swift
+++ b/BookPlayerIntents/IntentHandler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Tortuga Power. All rights reserved.
 //
 
+import BookPlayerKit
 import Intents
 
 class IntentHandler: INExtension {
@@ -13,6 +14,10 @@ class IntentHandler: INExtension {
         // This is the default implementation.  If you want different objects to handle different intents,
         // you can override this and return the handler you want for that particular intent.
 
-        return SleepTimerHandler()
+        if intent is SleepTimerIntent {
+            return SleepTimerHandler()
+        }
+
+        return PlayMediaIntentHandler()
     }
 }

--- a/BookPlayerIntents/PlayMediaIntentHandler.swift
+++ b/BookPlayerIntents/PlayMediaIntentHandler.swift
@@ -1,0 +1,17 @@
+//
+//  PlayMediaIntentHandler.swift
+//  BookPlayerIntents
+//
+//  Created by Gianni Carlo on 4/17/20.
+//  Copyright © 2020 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Intents
+
+class PlayMediaIntentHandler: INExtension, INPlayMediaIntentHandling {
+    func handle(intent: INPlayMediaIntent, completion: @escaping (INPlayMediaIntentResponse) -> Void) {
+        let response = INPlayMediaIntentResponse(code: .handleInApp, userActivity: nil)
+        completion(response)
+    }
+}

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -7,10 +7,19 @@
 //
 
 import Foundation
+import Intents
 
 public class CommandParser {
     public class func parse(_ activity: NSUserActivity) -> Action? {
-        if let sleepIntent = activity.interaction?.intent as? SleepTimerIntent {
+        if let intent = activity.interaction?.intent {
+            return self.parse(intent)
+        }
+
+        return Action(command: .play)
+    }
+
+    public class func parse(_ intent: INIntent) -> Action? {
+        if let sleepIntent = intent as? SleepTimerIntent {
             var queryItem: URLQueryItem
 
             if let seconds = sleepIntent.seconds {


### PR DESCRIPTION
This new shortcut should be used instead of `Continue last played book` if you need for the shortcut to run in the background without the need to unlock your device.

I'm not sure if we should erase the previous shortcut, or just leave it be, and have both as an option 🤔