### PR TITLE
ISSUE-387 : Dismissing the player vc if there during background import

### DIFF
--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -232,8 +232,12 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
         let loadingTitle = "import_preparing_title".localized
         UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: self.loadingView.titleLabel)
 
-        self.showLoadView(true, title: loadingTitle)
+        if let vc = self.navigationController?.visibleViewController as? PlayerViewController {
+            vc.dismissPlayer()
+        }
 
+        self.showLoadView(true, title: loadingTitle)
+        
         if let vc = self.navigationController?.visibleViewController as? PlaylistViewController {
             vc.showLoadView(true, title: loadingTitle)
         }


### PR DESCRIPTION
Proposed changes

If the player is open and files are imported via AirDrop or sharing from an external app, the import progress isn't shown. Dismissing the player / presenting the Library would change that.


Types of changes

- [x]  Bugfix (non-breaking change which fixes an issue)

Checklist

- [x]  I have read the CONTRIBUTING doc
