### PR TITLE
ISSUE-477 : Disabling the edit button on empty view

### DIFF
--- a/BookPlayer/Library/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemListViewController.swift
@@ -169,6 +169,7 @@ class ItemListViewController: UIViewController, ItemList, ItemListAlerts, ItemLi
 
     func toggleEmptyStateView() {
         self.emptyStatePlaceholder.isHidden = !self.items.isEmpty
+        self.editButtonItem.isEnabled = !self.items.isEmpty
     }
 
     func presentImportFilesAlert() {


### PR DESCRIPTION
Proposed changes

Disabling the edit button on empty view  across library  and the playlist 

Types of changes

- [x]  Bug fix

Checklist

- [x]  I have read the CONTRIBUTING doc
- [x] Linter check and compiled locally before pushing 
- [x] Tested various sorting scenarios across both library view and the playlist view
