### PR TITLE
Fix misaligned tick mark on the completed playlist

### DIFF
--- a/BookPlayer/Base.lproj/Main.storyboard
+++ b/BookPlayer/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1tN-zP-ONE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1tN-zP-ONE">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/BookPlayer/Library/Views/BookCellView.swift
+++ b/BookPlayer/Library/Views/BookCellView.swift
@@ -26,7 +26,6 @@ class BookCellView: UITableViewCell {
     @IBOutlet private weak var artworkView: BPArtworkView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var subtitleLabel: UILabel!
-    @IBOutlet private weak var progressTrailing: NSLayoutConstraint!
     @IBOutlet private weak var progressView: ItemProgress!
     @IBOutlet weak var selectionView: CheckboxSelectionView!
     @IBOutlet private weak var artworkButton: UIButton!
@@ -82,22 +81,10 @@ class BookCellView: UITableViewCell {
     var type: BookCellType = .book {
         didSet {
             switch self.type {
-            case .file:
-                self.accessoryType = .none
-
-                self.progressTrailing.constant = 11.0
             case .playlist:
                 self.accessoryType = .disclosureIndicator
-
-                if #available(iOS 13.0, *) {
-                    self.progressTrailing.constant = 2.5
-                } else {
-                    self.progressTrailing.constant = -5.0
-                }
             default:
                 self.accessoryType = .none
-
-                self.progressTrailing.constant = 29.0 // Disclosure indicator offset
             }
         }
     }

--- a/BookPlayer/Library/Views/BookCellView.xib
+++ b/BookPlayer/Library/Views/BookCellView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,20 +32,20 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="middleTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RWS-bw-cRW">
-                        <rect key="frame" x="82" y="18" width="242" height="18"/>
+                        <rect key="frame" x="82" y="18" width="228" height="18"/>
                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                         <color key="textColor" red="0.12156862745098039" green="0.14117647058823529" blue="0.14509803921568626" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                         <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7zZ-yo-0dC">
-                        <rect key="frame" x="82" y="39" width="242" height="16"/>
+                        <rect key="frame" x="82" y="39" width="228" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <color key="textColor" red="0.5607843137254902" green="0.55686274509803924" blue="0.58039215686274503" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nkg-F5-bH6" customClass="ItemProgress" customModule="BookPlayer" customModuleProvider="target">
-                        <rect key="frame" x="340" y="28.5" width="19" height="19"/>
+                        <rect key="frame" x="326" y="28.5" width="19" height="19"/>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="19" id="0cI-q3-r00"/>
@@ -67,7 +67,6 @@
                     <constraint firstItem="fxJ-mz-qEf" firstAttribute="centerY" secondItem="cUU-yJ-MnU" secondAttribute="centerY" constant="1" id="FUs-kn-r02"/>
                     <constraint firstItem="RWS-bw-cRW" firstAttribute="centerY" secondItem="cUU-yJ-MnU" secondAttribute="centerY" constant="-11" id="ICT-n3-FfX"/>
                     <constraint firstItem="weP-Z4-F5J" firstAttribute="centerY" secondItem="3kC-6m-IJf" secondAttribute="centerY" id="JnB-S2-bVa"/>
-                    <constraint firstAttribute="trailing" secondItem="Nkg-F5-bH6" secondAttribute="trailing" constant="16" id="Su9-Ah-617"/>
                     <constraint firstItem="Nkg-F5-bH6" firstAttribute="centerY" secondItem="cUU-yJ-MnU" secondAttribute="centerY" id="aWv-8h-fY6"/>
                     <constraint firstItem="7zZ-yo-0dC" firstAttribute="top" secondItem="RWS-bw-cRW" secondAttribute="bottom" constant="3" id="bkb-Am-hVm"/>
                     <constraint firstItem="RWS-bw-cRW" firstAttribute="leading" secondItem="fxJ-mz-qEf" secondAttribute="trailing" constant="83" id="fGe-xc-DNI"/>
@@ -80,12 +79,14 @@
                     <constraint firstItem="7zZ-yo-0dC" firstAttribute="width" secondItem="RWS-bw-cRW" secondAttribute="width" id="zcg-Iy-KZv"/>
                 </constraints>
             </tableViewCellContentView>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="Nkg-F5-bH6" secondAttribute="trailing" constant="30" id="fsI-i7-zEg"/>
+            </constraints>
             <connections>
                 <outlet property="artworkButton" destination="weP-Z4-F5J" id="IdS-tc-798"/>
                 <outlet property="artworkHeight" destination="LD8-Eg-YNe" id="utQ-dF-ve5"/>
                 <outlet property="artworkView" destination="3kC-6m-IJf" id="AgR-ku-gzP"/>
                 <outlet property="artworkWidth" destination="zo4-rD-Ned" id="V2J-c2-uiC"/>
-                <outlet property="progressTrailing" destination="Su9-Ah-617" id="Osb-qI-hpx"/>
                 <outlet property="progressView" destination="Nkg-F5-bH6" id="HiU-IX-RA1"/>
                 <outlet property="selectionView" destination="fxJ-mz-qEf" id="7Jl-Fj-1DG"/>
                 <outlet property="subtitleLabel" destination="7zZ-yo-0dC" id="usK-11-1gM"/>


### PR DESCRIPTION
# 🔨 PR Type

_Please check the type of change your PR introduces._

- [x] Bugfix

_Provide a more descriptive summary of the changes in this PR here._

# 📝 Summary of Changes

Updating the constraint of the progress view to the table view cell instead of the actual content view which was pushing out everything. 

Removed the progress trailing constraint

This solution fixes even the small misalignment which was there earlier between a playlist / File and Book due to the disclosure icon during a non edit state.

## 🔨 Scenarios Tested / How To Test

- Tested 5s/6s - OS 12.4
- Tested 6s/7s/8/ - OS 13

Closes #479 