### PR TITLE
Fix crash when downloading

### DIFF
--- a/BookPlayer/Library/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemListViewController.swift
@@ -467,6 +467,13 @@ extension ItemListViewController {
 
 extension ItemListViewController: ItemListFeedback {
     func showLoadView(_ show: Bool, title: String? = nil, subtitle: String? = nil) {
+        guard self.isViewLoaded else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [unowned self] in
+                self.showLoadView(show, title: title, subtitle: subtitle)
+            }
+            return
+        }
+
         if let title = title {
             self.loadingView.titleLabel.text = title
         }

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -75,8 +75,8 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
                 self.showAlert("network_error_title".localized, message: error.localizedDescription)
             }
 
-            if let response = response.response, response.statusCode != 200 {
-                self.showAlert("network_error_title".localized, message: nil)
+            if let response = response.response, response.statusCode >= 300 {
+                self.showAlert("network_error_title".localized, message: "Code \(response.statusCode)")
             }
         }
     }


### PR DESCRIPTION
# 🔨 PR Type

- [X] Bugfix

# 📝 Summary of Changes

- Fix crash when app is launched by the url-scheme to download a book, the `view` property hasn't loaded yet when it tried to show the loading banner