### PR TITLE
Custom action for VoiceOver in Library

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "voiceover_book_chapter" = "%@ by %@, chapter %@";
 "voiceover_rewind_time" = "Rewind %@";
 "voiceover_forward_time" = "Fast Forward %@";
+"voiceover_continue_playback_title" = "Continue Playback";
 "watchapp_last_played_title" = "Last Played";
 "watchapp_refresh_data_title" = "Refresh data";
 "carplay_recent_title" = "Recent";

--- a/BookPlayer/Library/Views/BookCellView.swift
+++ b/BookPlayer/Library/Views/BookCellView.swift
@@ -108,6 +108,8 @@ class BookCellView: UITableViewCell {
     private func setup() {
         self.accessoryType = .none
         self.selectionStyle = .none
+        let resumeAction = UIAccessibilityCustomAction(name: "voiceover_continue_playback_title".localized, target: self, selector: #selector(self.artworkButtonTapped(_:)))
+        accessibilityCustomActions = [resumeAction]
     }
 
     override func addSubview(_ view: UIView) {

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "voiceover_book_chapter" = "%@ by %@, chapter %@";
 "voiceover_rewind_time" = "Rewind %@";
 "voiceover_forward_time" = "Fast Forward %@";
+"voiceover_continue_playback_title" = "Continue Playback";
 "watchapp_last_played_title" = "Last Played";
 "watchapp_refresh_data_title" = "Refresh data";
 "carplay_recent_title" = "Recent";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "voiceover_book_chapter" = "%@ por %@ , capítulo %@";
 "voiceover_rewind_time" = "Retroceder %@";
 "voiceover_forward_time" = "Avanzar %@";
+"voiceover_continue_playback_title" = "Continuar Reproducción";
 "watchapp_last_played_title" = "Última Reproducción";
 "watchapp_refresh_data_title" = "Actualizar data";
 "carplay_recent_title" = "Recientes";


### PR DESCRIPTION
There's no easy way to resume playback on a playlist for VoiceOver users, default action takes them to the detail screen. Now they can swipe down to access the custom action to resume playback (equivalent to tapping the artwork)