### PR TITLE
added url extension and sorting of files in DataManager+CoreData

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -212,6 +212,9 @@
 		41F1A216254B0AA40043FCF3 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A215254B0AA40043FCF3 /* Kingfisher */; };
 		41F1A21F254B0B0B0043FCF3 /* SwiftyStoreKit in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A21E254B0B0B0043FCF3 /* SwiftyStoreKit */; };
 		41F1A228254B0C6C0043FCF3 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A227254B0C6C0043FCF3 /* ZipArchive */; };
+		5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
+		5126F122258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
+		5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
@@ -581,6 +584,7 @@
 		41EE378B21C0028800A55F51 /* ItemListActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListActions.swift; sourceTree = "<group>"; };
 		41F516952272CC5300F36C3E /* WatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityService.swift; sourceTree = "<group>"; };
 		41F898AE2402080C00F58B8A /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZipArchive.framework; path = Carthage/Build/iOS/ZipArchive.framework; sourceTree = "<group>"; };
+		5126F120258E9F18009965DC /* URL+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+BookPlayer.swift"; sourceTree = "<group>"; };
 		5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
@@ -880,6 +884,7 @@
 		41A1B106226E9DCA00EA0400 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				5126F120258E9F18009965DC /* URL+BookPlayer.swift */,
 				4160A08E23F2DBD40039166B /* String+BookPlayer.swift */,
 				C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */,
 				C30CD2A0209791FA00258B09 /* UIColor+Sweetercolor.swift */,
@@ -1727,6 +1732,7 @@
 				4140EA82227289DB0009F794 /* FileItem.swift in Sources */,
 				4140EA6C2272898F0009F794 /* DataManager.swift in Sources */,
 				4140EA71227289A20009F794 /* UIColor+BookPlayer.swift in Sources */,
+				5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				419BD5992443FD04001E50A0 /* Intents.intentdefinition in Sources */,
 				4140EA80227289D50009F794 /* Playlist+CoreDataClass.swift in Sources */,
 				4140EA78227289BC0009F794 /* PlaybackRecord+CoreDataClass.swift in Sources */,
@@ -1821,6 +1827,7 @@
 				C33E843C20C6E179004A0489 /* ItemProgress.swift in Sources */,
 				411373912552371D00295022 /* TelemetryProtocol.swift in Sources */,
 				41A1B12E226FC7E500EA0400 /* ImportOperation.swift in Sources */,
+				5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				410D0FED1EDCF4B000A52EB9 /* SettingsViewController.swift in Sources */,
 				4193E202243A91AE004D6A82 /* ActionParserService.swift in Sources */,
 				41B2A5DE21CAF20E00917584 /* ThemesViewController.swift in Sources */,
@@ -1871,6 +1878,7 @@
 				41A1B123226F88C500EA0400 /* Book+CoreDataClass.swift in Sources */,
 				41A1B105226E9DBD00EA0400 /* UIColor+Sweetercolor.swift in Sources */,
 				41A1B10C226E9E9700EA0400 /* DeleteMode.swift in Sources */,
+				5126F122258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				41A1B101226E9D4500EA0400 /* FileItem.swift in Sources */,
 				41A1B121226F88C500EA0400 /* PlaybackRecord+CoreDataClass.swift in Sources */,
 				41A1B104226E9DBA00EA0400 /* UIColor+BookPlayer.swift in Sources */,

--- a/BookPlayer/Library/DataManagement/DataManager+CoreData.swift
+++ b/BookPlayer/Library/DataManagement/DataManager+CoreData.swift
@@ -27,7 +27,7 @@ extension DataManager {
     class func insertBooks(from files: [FileItem], into playlist: Playlist?, or library: Library, completion: @escaping () -> Void) {
         let context = self.persistentContainer.viewContext
 
-        for file in files {
+        for file in files.sorted(by: {$0.originalUrl.fileName < $1.originalUrl.fileName}) {
             // TODO: do something about unprocessed URLs
             guard let url = file.processedUrl else { continue }
 

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -1,0 +1,26 @@
+import Foundation
+public extension URL {
+    /// Isolates and returns the parent directory of a `URL`
+    var parentDirectory: URL {
+        get {
+            let parent = self.deletingLastPathComponent()
+            return parent
+        }
+        set {
+            let newParentDirectory = newValue
+            let fileNameFromBefore = self.lastPathComponent
+            let fileNameInNewDirectory = newParentDirectory
+                .appendingPathComponent(fileNameFromBefore)
+            // Replace the URL with the new one:
+            self = fileNameInNewDirectory
+        }
+    }
+    
+    /// Isolates and returns a filename string from a `URL`
+    var fileName: String {
+        get {
+            let filename = self.deletingPathExtension().lastPathComponent
+            return filename
+        }
+    }
+}


### PR DESCRIPTION
- ☝️ Provide a short but descriptive title for this PR.
- 🏷 Remember to label your pull request appropriately and select appropriate code reviewers.

# 🔨 PR Type

_Please check the type of change your PR introduces._

Closes #508 

_Provide a more descriptive summary of the changes in this PR here._

A very simple fix, files should now be sorted in ascending order by filename before further processing.

Changes proposed in this pull request:

- Bug fix for #508.
- Added small convenience extension to URL that allows for easy isolation of the `fileName` string
- Changed one line of `DataManager+CoreData` to sort files by the fileName of the `originalUrl` before processing any further.

# ⚠️ Items of Note

I haven't actually tested this yet, because I'm not familiar with how your test module mocks up example files, but it's very unlikely the change will have broken anything. At worst, it just won't fix the problem it's meant to fix because it goes deeper than it appears to.

# 🧐🗒 Reviewer Notes

## 💁 Example

_Add an example of using the changes you've implemented (eg, a screenshot or screen recording)._

## 🔨 Scenarios Tested / How To Test

Simply mock up a bunch of files that have the same naming convention, but sequential numbering, i.e. "book_author_001", "book_author_010", and so forth, then see if they sort properly when imported.
