### PR TITLE
Add drag and drop support

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
 		5126F122258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
 		5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
+		62F2F25F25E18C7500E1D6A0 /* ImportableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
@@ -668,6 +669,7 @@
 		41F898AE2402080C00F58B8A /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZipArchive.framework; path = Carthage/Build/iOS/ZipArchive.framework; sourceTree = "<group>"; };
 		5126F120258E9F18009965DC /* URL+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+BookPlayer.swift"; sourceTree = "<group>"; };
 		5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
+		62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportableItem.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
 		69225C4E2159C2650004739E /* BookSortService+SortError+PlayListSortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookSortService+SortError+PlayListSortOrder.swift"; sourceTree = "<group>"; };
@@ -873,6 +875,7 @@
 				41A1B136226FED4000EA0400 /* DataManager+CoreData.swift */,
 				416B63A72146354B007D04B1 /* ImportManager.swift */,
 				41E34E4F2138EA8200A3997C /* ImportOperation.swift */,
+				62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */,
 			);
 			path = DataManagement;
 			sourceTree = "<group>";
@@ -2027,6 +2030,7 @@
 				C36C4D5C20A23E1800AFDB76 /* MiniPlayerViewController.swift in Sources */,
 				C33E843C20C6E179004A0489 /* ItemProgress.swift in Sources */,
 				411373912552371D00295022 /* TelemetryProtocol.swift in Sources */,
+				62F2F25F25E18C7500E1D6A0 /* ImportableItem.swift in Sources */,
 				41A1B12E226FC7E500EA0400 /* ImportOperation.swift in Sources */,
 				5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				410D0FED1EDCF4B000A52EB9 /* SettingsViewController.swift in Sources */,

--- a/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
+++ b/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
@@ -103,6 +103,19 @@ extension DataManager {
     private class func filterFiles(_ urls: [URL]) -> [URL] {
         return urls.filter { !$0.hasDirectoryPath }
     }
+    
+    public class func importData(from item: ImportableItem) {
+        let filename = item.suggestedName ?? "\(Date().timeIntervalSince1970).\(item.fileExtension)"
+
+        let destinationURL = self.getDocumentsFolderURL()
+            .appendingPathComponent(filename)
+
+        do {
+            try item.data.write(to: destinationURL)
+        } catch {
+            print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
+        }
+    }
 
     /**
      Notifies the ImportManager about the new file

--- a/BookPlayer/Library/DataManagement/ImportableItem.swift
+++ b/BookPlayer/Library/DataManagement/ImportableItem.swift
@@ -1,0 +1,43 @@
+//
+//  ImportableItem.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 2/20/21.
+//  Copyright © 2021 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+public class ImportableItem: NSObject, NSItemProviderReading {
+    let data: Data
+    let typeIdentifier: String
+    var suggestedName: String?
+
+    var fileExtension: String {
+        switch self.typeIdentifier {
+        case "public.audio":
+            return "mp3"
+        case "public.movie":
+            return "mp4"
+        case "com.pkware.zip-archive":
+            return "zip"
+        default:
+            return "mp3"
+        }
+    }
+    
+    required init(dataObject: Data, type: String) {
+        data = dataObject
+        typeIdentifier = type
+    }
+    
+    public static var readableTypeIdentifiersForItemProvider: [String] {
+        return ["public.audio", "com.pkware.zip-archive", "public.movie"]
+    }
+    
+    public static func object(withItemProviderData data: Data, typeIdentifier: String) throws -> Self {
+        return self.init(dataObject: data, type: typeIdentifier)
+    }
+    
+    
+}


### PR DESCRIPTION
After getting a Mac M1, I was able to test the app running on a Mac, and overall it works, but the first thing I tried, was to drag and drop books from finder into the app (which didn't work out of the box of course). With this, we can turn on the Catalyst version of the app so people with M1 Macs can install it from the App Store

Side benefit of this, is that it's the same API for drag and drop support for iPad, so when we get there, we'll already have this built-in