### PR TITLE
Recover Library on failed migration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,3 +9,6 @@ disabled_rules:
   - identifier_name
   - trailing_comma
   - private_over_fileprivate
+  - force_try
+  - type_body_length
+  - file_length

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -194,3 +194,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -85,7 +85,7 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
     // CoreData may fail if device doesn't have space
     if (error.domain == NSPOSIXErrorDomain && error.code == ENOSPC) ||
         (error.domain == NSCocoaErrorDomain && error.code == NSFileWriteOutOfSpaceError) {
-      self.showAlert("error_title".localized, message: "The library couldn't be loaded, the device is out of disk space")
+      self.showAlert("error_title".localized, message: "coredata_error_diskfull_description".localized)
       return
     }
 
@@ -98,7 +98,7 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
         error.code == NSMigrationManagerSourceStoreError ||
         error.code == NSMigrationManagerDestinationStoreError ||
         error.code == NSEntityMigrationPolicyError {
-      self.showAlert("error_title".localized, message: "A migration of the database failed, we'll reconstruct the library as a last resort") {
+      self.showAlert("error_title".localized, message: "coredata_error_migration_description".localized) {
         DataManager.cleanAndReloadLibrary()
       }
       return

--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -8,6 +8,7 @@
 
 import BookPlayerKit
 import Combine
+import CoreData
 import MediaPlayer
 import SwiftReorder
 import UIKit
@@ -28,6 +29,8 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
 
         // enables pop gesture on pushed controller
         self.navigationController!.interactivePopGestureRecognizer!.delegate = self
+
+        self.handleCoreDataError()
 
         self.loadLibrary()
 
@@ -75,8 +78,39 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
     self.present(nav, animated: true, completion: nil)
   }
 
+  func handleCoreDataError() {
+    guard let coreDataError = DataManager.loadingDataError else { return }
+
+    let error = coreDataError as NSError
+    // CoreData may fail if device doesn't have space
+    if (error.domain == NSPOSIXErrorDomain && error.code == ENOSPC) ||
+        (error.domain == NSCocoaErrorDomain && error.code == NSFileWriteOutOfSpaceError) {
+      self.showAlert("error_title".localized, message: "The library couldn't be loaded, the device is out of disk space")
+      return
+    }
+
+    // Handle data error migration by reloading library
+    if error.code == NSMigrationError ||
+        error.code == NSMigrationConstraintViolationError ||
+        error.code == NSMigrationCancelledError ||
+        error.code == NSMigrationMissingSourceModelError ||
+        error.code == NSMigrationMissingMappingModelError ||
+        error.code == NSMigrationManagerSourceStoreError ||
+        error.code == NSMigrationManagerDestinationStoreError ||
+        error.code == NSEntityMigrationPolicyError {
+      self.showAlert("error_title".localized, message: "A migration of the database failed, we'll reconstruct the library as a last resort") {
+        DataManager.cleanAndReloadLibrary()
+      }
+      return
+    }
+
+    fatalError("Unresolved error \(error), \(error.userInfo)")
+  }
+
     func loadLibrary() {
-        self.library = DataManager.getLibrary()
+        guard let library = try? DataManager.getLibrary() else { return }
+
+        self.library = library
 
         self.toggleEmptyStateView()
 
@@ -108,7 +142,7 @@ class LibraryViewController: ItemListViewController, UIGestureRecognizerDelegate
     }
 
     func loadLastBook() {
-        guard let book = self.library.lastPlayedBook else {
+        guard self.library != nil, let book = self.library.lastPlayedBook else {
             return
         }
 

--- a/BookPlayer/Library/Themes/ThemeManager.swift
+++ b/BookPlayer/Library/Themes/ThemeManager.swift
@@ -38,25 +38,30 @@ final class ThemeManager: ThemeProvider {
         self.useDarkVariant = UIScreen.main.traitCollection.userInterfaceStyle == .dark
     }
 
-    private init() {
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) {
-            self.useDarkVariant = UIScreen.main.traitCollection.userInterfaceStyle == .dark
-        } else {
-            self.useDarkVariant = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
-        }
-
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) {
-            let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
-            let brightness = (UIScreen.main.brightness * 100).rounded() / 100
-            self.useDarkVariant = brightness <= CGFloat(threshold)
-        }
-
-        let currentTheme: Theme = DataManager.getLibrary().currentTheme
-        currentTheme.useDarkVariant = self.useDarkVariant
-        self.theme = SubscribableValue<Theme>(value: currentTheme)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.brightnessChanged(_:)), name: UIScreen.brightnessDidChangeNotification, object: nil)
+  private init() {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) {
+      self.useDarkVariant = UIScreen.main.traitCollection.userInterfaceStyle == .dark
+    } else {
+      self.useDarkVariant = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
     }
+
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) {
+      let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
+      let brightness = (UIScreen.main.brightness * 100).rounded() / 100
+      self.useDarkVariant = brightness <= CGFloat(threshold)
+    }
+
+    guard let library = try? DataManager.getLibrary() else {
+      self.theme = SubscribableValue<Theme>(value: DataManager.getLocalThemes().first!)
+      return
+    }
+
+    let currentTheme: Theme = library.currentTheme
+    currentTheme.useDarkVariant = self.useDarkVariant
+    self.theme = SubscribableValue<Theme>(value: currentTheme)
+
+    NotificationCenter.default.addObserver(self, selector: #selector(self.brightnessChanged(_:)), name: UIScreen.brightnessDidChangeNotification, object: nil)
+  }
 
     @objc private func brightnessChanged(_ notification: Notification) {
         guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) else { return }

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -95,9 +95,8 @@ class ActionParserService {
             return
         }
 
-        let library = DataManager.getLibrary()
-
-        guard let book = DataManager.getBook(with: bookIdentifier, from: library) else { return }
+        guard let library = try? DataManager.getLibrary(),
+              let book = DataManager.getBook(with: bookIdentifier, from: library) else { return }
 
         guard let libraryVC = appDelegate.getLibraryVC() else {
             return

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -50,14 +50,16 @@ enum IndexGuide {
 class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableContentDelegate {
     static let shared = CarPlayManager()
 
-    var library: Library!
+    var library: Library?
 
     typealias Tab = (identifier: String, title: String, imageName: String)
     let tabs: [Tab] = [("tab-library", "library_title".localized, "carplayLibrary"),
                        ("tab-recent", "carplay_recent_title".localized, "carplayRecent")]
 
     private override init() {
-        self.library = DataManager.getLibrary()
+      guard let library = try? DataManager.getLibrary() else { return }
+
+      self.library = library
     }
 
     func createTabItem(for indexPath: IndexPath) -> MPContentItem {
@@ -209,11 +211,11 @@ class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableContentDe
     private func getItems(for indexPath: IndexPath) -> [LibraryItem]? {
         // Recently played items
         if indexPath[0] == IndexGuide.tab.recentlyPlayed {
-            return self.library.getItemsOrderedByDate()
+            return self.library?.getItemsOrderedByDate()
         }
 
         // Library items
-        return self.library.items?.array as? [LibraryItem]
+        return self.library?.items?.array as? [LibraryItem]
     }
 
     func setNowPlayingInfo(with book: Book) {

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -193,3 +193,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -199,3 +199,5 @@ Carl&nbsp;regarding the key settings_credits_title it's basically a section that
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -193,3 +193,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -194,3 +194,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -194,3 +194,5 @@
 "sort_most_recent_button" = "Más Reciente";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Invertir Orden";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -209,3 +209,5 @@ Carl&nbsp;regarding the key settings_credits_title it's basically a section that
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -230,3 +230,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Fordított sorrendben";
 "voiceover_continue_playback_title" = "Lejátszás folytatása";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -221,3 +221,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -230,3 +230,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Odwrotna kolejność";
 "voiceover_continue_playback_title" = "Kontynuuj odtwarzanie";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -229,4 +229,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 "sort_most_recent_button" = "Mais recente";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Ordem Reversa";
-
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -208,3 +208,5 @@ Carl&nbsp;regarding the key settings_credits_title it's basically a section that
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -193,3 +193,5 @@
 "sort_most_recent_button" = "Самый недавний";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Обратить порядок";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -221,3 +221,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -193,3 +193,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -221,3 +221,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -221,3 +221,5 @@ Alessio Franceschi&nbsp;this is the label for the active sleep timer button when
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -190,3 +190,5 @@
 "sort_most_recent_button" = "Most Recent";
 /* One of the sort options, this one reverts the current order of selected items */
 "sort_reversed_button" = "Reverse Order";
+"coredata_error_diskfull_description" = "The library couldn't be loaded, the device is out of disk space.";
+"coredata_error_migration_description" = "A migration of the database failed, the library will have to be reinitialized.";

--- a/BookPlayerTests/DataManagerTests.swift
+++ b/BookPlayerTests/DataManagerTests.swift
@@ -74,20 +74,21 @@ class InsertBooksTests: DataManagerTests {
     override func setUp() {
         super.setUp()
 
-        let library = DataManager.getLibrary()
+        let library = try! StubFactory.library()
         DataManager.delete(library)
     }
 
     func testInsertEmptyBooksInLibrary() throws {
-      let library = DataManager.getLibrary()
+
+      let library = try StubFactory.library()
 
       try DataManager.moveItems([], into: library)
 
       XCTAssert(library.items?.count == 0)
     }
 
-    func testInsertOneBookInLibrary() {
-        let library = DataManager.getLibrary()
+    func testInsertOneBookInLibrary() throws {
+        let library = try StubFactory.library()
 
         let filename = "file.txt"
         let bookContents = "bookcontents".data(using: .utf8)!
@@ -102,8 +103,8 @@ class InsertBooksTests: DataManagerTests {
         XCTAssert(processedItems.count == 1)
     }
 
-    func testInsertMultipleBooksInLibrary() {
-        let library = DataManager.getLibrary()
+    func testInsertMultipleBooksInLibrary() throws {
+        let library = try StubFactory.library()
 
         let filename1 = "file1.txt"
         let book1Contents = "book1contents".data(using: .utf8)!
@@ -122,7 +123,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertEmptyBooksIntoPlaylist() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder = try XCTUnwrap(try DataManager.createFolder(with: "test-folder", in: nil, library: library))
       XCTAssert(library.items?.count == 1)
 
@@ -131,7 +132,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertOneBookIntoPlaylist() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder = try DataManager.createFolder(with: "test-folder", in: nil, library: library)
 
       XCTAssert(library.items?.count == 1)
@@ -150,7 +151,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertMultipleBooksIntoPlaylist() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder = try DataManager.createFolder(with: "test-folder", in: nil, library: library)
 
       XCTAssert(library.items?.count == 1)
@@ -173,7 +174,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertExistingBookFromLibraryIntoPlaylist() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder = try DataManager.createFolder(with: "test-folder", in: nil, library: library)
 
       XCTAssert(library.items?.count == 1)
@@ -197,7 +198,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertExistingBookFromPlaylistIntoLibrary() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder = try DataManager.createFolder(with: "test-folder", in: nil, library: library)
 
       XCTAssert(library.items?.count == 1)
@@ -224,7 +225,7 @@ class InsertBooksTests: DataManagerTests {
     }
 
     func testInsertExistingBookFromPlaylistIntoPlaylist() throws {
-      let library = DataManager.getLibrary()
+      let library = try StubFactory.library()
       let folder1 = try DataManager.createFolder(with: "test-folder1", in: nil, library: library)
       let folder2 = try DataManager.createFolder(with: "test-folder2", in: nil, library: library)
 
@@ -260,12 +261,12 @@ class ModifyLibraryTests: DataManagerTests {
     override func setUp() {
         super.setUp()
 
-        let library = DataManager.getLibrary()
+        let library = try! StubFactory.library()
         DataManager.delete(library)
     }
 
     func testMoveItemsIntoFolder() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         library.insert(item: book1)
         let book2 = StubFactory.book(title: "book2", duration: 100)
@@ -296,7 +297,7 @@ class ModifyLibraryTests: DataManagerTests {
     }
 
     func testMoveItemsIntoLibrary() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         let book2 = StubFactory.book(title: "book2", duration: 100)
         let folder = try StubFactory.folder(title: "folder")
@@ -327,7 +328,7 @@ class ModifyLibraryTests: DataManagerTests {
     }
 
     func testFolderShallowDeleteWithOneBook() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         let folder = try StubFactory.folder(title: "folder")
         folder.insert(item: book1)
@@ -345,7 +346,7 @@ class ModifyLibraryTests: DataManagerTests {
     }
 
     func testFolderShallowDeleteWithMultipleBooks() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         library.insert(item: book1)
         let book2 = StubFactory.book(title: "book2", duration: 100)
@@ -371,7 +372,7 @@ class ModifyLibraryTests: DataManagerTests {
     }
 
     func testFolderDeepDeleteWithOneBook() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         let folder = try StubFactory.folder(title: "folder")
         let folder2 = try StubFactory.folder(title: "folder2")
@@ -393,7 +394,7 @@ class ModifyLibraryTests: DataManagerTests {
     }
 
     func testFolderDeepDeleteWithMultipleBooks() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         library.insert(item: book1)
         let book2 = StubFactory.book(title: "book2", duration: 100)

--- a/BookPlayerTests/LibraryTests.swift
+++ b/BookPlayerTests/LibraryTests.swift
@@ -14,7 +14,7 @@ class LibraryTests: XCTestCase {
     override func setUp() {
       super.setUp()
 
-      let library = DataManager.getLibrary()
+      let library = try! StubFactory.library()
       DataManager.delete(library)
 
       let documentsFolder = DataManager.getDocumentsFolderURL()
@@ -24,7 +24,7 @@ class LibraryTests: XCTestCase {
     }
 
     func testRelativePath() throws {
-        let library = DataManager.getLibrary()
+        let library = try StubFactory.library()
         let book1 = StubFactory.book(title: "book1", duration: 100)
         let book2 = StubFactory.book(title: "book2", duration: 100)
         let book3 = StubFactory.book(title: "book3", duration: 100)

--- a/BookPlayerTests/Support/StubFactory.swift
+++ b/BookPlayerTests/Support/StubFactory.swift
@@ -26,4 +26,8 @@ class StubFactory {
 
       return folder
     }
+
+  class func library() throws -> Library {
+    return try DataManager.getLibrary() ?? Library.create(in: DataManager.getContext())
+  }
 }

--- a/BookPlayerWidget/TodayViewController.swift
+++ b/BookPlayerWidget/TodayViewController.swift
@@ -36,9 +36,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
 
     func updateBookDetails() {
-        let library = DataManager.getLibrary()
-
-        guard let book = library.lastPlayedBook else { return }
+        guard let library = try? DataManager.getLibrary(),
+              let book = library.lastPlayedBook else { return }
 
         self.titleLabel.text = book.title
         self.authorLabel.text = book.author

--- a/BookPlayerWidgetUI/LastPlayedWidgetView.swift
+++ b/BookPlayerWidgetUI/LastPlayedWidgetView.swift
@@ -18,32 +18,38 @@ struct PlayAndSleepProvider: IntentTimelineProvider {
     }
 
     func getSnapshot(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (Entry) -> Void) {
-        let library = DataManager.getLibrary()
-        let title = library.lastPlayedBook?.currentChapter?.title
-            ?? library.lastPlayedBook?.title
-        let autoplay = configuration.autoplay?.boolValue ?? true
-        let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+      guard let library = try? DataManager.getLibrary() else {
+        completion(placeholder(in: context))
+        return
+      }
 
-        let entry = SimpleEntry(date: Date(),
-                                title: title,
-                                artwork: library.lastPlayedBook?.getArtwork(for: library.currentTheme),
-                                theme: library.currentTheme,
-                                timerSeconds: seconds,
-                                autoplay: autoplay)
+      let title = library.lastPlayedBook?.currentChapter?.title ?? library.lastPlayedBook?.title
+      let autoplay = configuration.autoplay?.boolValue ?? true
+      let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
 
-        completion(entry)
+      let entry = SimpleEntry(date: Date(),
+                              title: title,
+                              artwork: library.lastPlayedBook?.getArtwork(for: library.currentTheme),
+                              theme: library.currentTheme,
+                              timerSeconds: seconds,
+                              autoplay: autoplay)
+
+      completion(entry)
     }
 
     func getTimeline(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
-        let library = DataManager.getLibrary()
-        let title = library.lastPlayedBook?.currentChapter?.title
-            ?? library.lastPlayedBook?.title
-        let autoplay = configuration.autoplay?.boolValue ?? true
-        let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+      guard let library = try? DataManager.getLibrary() else {
+        completion(Timeline(entries: [], policy: .atEnd))
+        return
+      }
 
-        let entries: [SimpleEntry] = [SimpleEntry(date: Date(), title: title, artwork: library.lastPlayedBook?.getArtwork(for: library.currentTheme), theme: library.currentTheme, timerSeconds: seconds, autoplay: autoplay)]
-        let timeline = Timeline(entries: entries, policy: .atEnd)
-        completion(timeline)
+      let title = library.lastPlayedBook?.currentChapter?.title ?? library.lastPlayedBook?.title
+      let autoplay = configuration.autoplay?.boolValue ?? true
+      let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+
+      let entries: [SimpleEntry] = [SimpleEntry(date: Date(), title: title, artwork: library.lastPlayedBook?.getArtwork(for: library.currentTheme), theme: library.currentTheme, timerSeconds: seconds, autoplay: autoplay)]
+      let timeline = Timeline(entries: entries, policy: .atEnd)
+      completion(timeline)
     }
 }
 

--- a/BookPlayerWidgetUI/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgetUI/RecentBooksWidgetView.swift
@@ -18,26 +18,34 @@ struct RecentBooksProvider: IntentTimelineProvider {
     }
 
     func getSnapshot(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (LibraryEntry) -> Void) {
-        let library = DataManager.getLibrary()
-        let autoplay = configuration.autoplay?.boolValue ?? true
-        let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+      guard let library = try? DataManager.getLibrary() else {
+        completion(placeholder(in: context))
+        return
+      }
 
-        let entry = LibraryEntry(date: Date(),
-                                 library: library,
-                                 timerSeconds: seconds,
-                                 autoplay: autoplay)
+      let autoplay = configuration.autoplay?.boolValue ?? true
+      let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
 
-        completion(entry)
+      let entry = LibraryEntry(date: Date(),
+                               library: library,
+                               timerSeconds: seconds,
+                               autoplay: autoplay)
+
+      completion(entry)
     }
 
     func getTimeline(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (Timeline<LibraryEntry>) -> Void) {
-        let library = DataManager.getLibrary()
-        let autoplay = configuration.autoplay?.boolValue ?? true
-        let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+      guard let library = try? DataManager.getLibrary() else {
+        completion(Timeline(entries: [], policy: .atEnd))
+        return
+      }
 
-        let entries: [LibraryEntry] = [LibraryEntry(date: Date(), library: library, timerSeconds: seconds, autoplay: autoplay)]
-        let timeline = Timeline(entries: entries, policy: .atEnd)
-        completion(timeline)
+      let autoplay = configuration.autoplay?.boolValue ?? true
+      let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+
+      let entries: [LibraryEntry] = [LibraryEntry(date: Date(), library: library, timerSeconds: seconds, autoplay: autoplay)]
+      let timeline = Timeline(entries: entries, policy: .atEnd)
+      completion(timeline)
     }
 }
 

--- a/BookPlayerWidgetUI/TimeListened/TimeListenedWidgetView.swift
+++ b/BookPlayerWidgetUI/TimeListened/TimeListenedWidgetView.swift
@@ -18,29 +18,36 @@ struct TimeListenedProvider: IntentTimelineProvider {
     }
 
     func getSnapshot(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (TimeListenedEntry) -> Void) {
-        let library = DataManager.getLibrary()
-        let autoplay = configuration.autoplay?.boolValue ?? true
-        let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
+      guard let library = try? DataManager.getLibrary() else {
+        completion(placeholder(in: context))
+        return
+      }
 
-        var records: [PlaybackRecordViewer]
+      let autoplay = configuration.autoplay?.boolValue ?? true
+      let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
 
-        if context.family == .systemMedium {
-            records = WidgetUtils.getPlaybackRecords()
-        } else {
-            records = [WidgetUtils.getPlaybackRecord()]
-        }
+      var records: [PlaybackRecordViewer]
 
-        let entry = TimeListenedEntry(date: Date(),
-                                      library: library,
-                                      timerSeconds: seconds,
-                                      autoplay: autoplay,
-                                      playbackRecords: records)
+      if context.family == .systemMedium {
+        records = WidgetUtils.getPlaybackRecords()
+      } else {
+        records = [WidgetUtils.getPlaybackRecord()]
+      }
 
-        completion(entry)
+      let entry = TimeListenedEntry(date: Date(),
+                                    library: library,
+                                    timerSeconds: seconds,
+                                    autoplay: autoplay,
+                                    playbackRecords: records)
+
+      completion(entry)
     }
 
     func getTimeline(for configuration: PlayAndSleepActionIntent, in context: Context, completion: @escaping (Timeline<TimeListenedEntry>) -> Void) {
-        let library = DataManager.getLibrary()
+      guard let library = try? DataManager.getLibrary() else {
+        completion(Timeline(entries: [], policy: .after(WidgetUtils.getNextDayDate())))
+        return
+      }
         let autoplay = configuration.autoplay?.boolValue ?? true
         let seconds = TimeParser.getSeconds(from: configuration.sleepTimer)
 

--- a/Shared/CoreDataStack.swift
+++ b/Shared/CoreDataStack.swift
@@ -10,7 +10,9 @@ import CoreData
 import Foundation
 
 public class CoreDataStack {
-    private let modelName: String
+  private let modelName: String
+  private let loadCompletionHandler: (NSPersistentStoreDescription, Error?) -> Void
+
     public lazy var managedContext: NSManagedObjectContext = {
         self.storeContainer.viewContext
     }()
@@ -19,9 +21,10 @@ public class CoreDataStack {
         FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)!.appendingPathComponent("BookPlayer.sqlite")
     }()
 
-    public init(modelName: String) {
-        self.modelName = modelName
-    }
+  public init(modelName: String, loadCompletionHandler: @escaping (NSPersistentStoreDescription, Error?) -> Void) {
+    self.modelName = modelName
+    self.loadCompletionHandler = loadCompletionHandler
+  }
 
     private lazy var storeContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: self.modelName)
@@ -33,11 +36,7 @@ public class CoreDataStack {
 
         container.persistentStoreDescriptions = [description]
 
-        container.loadPersistentStores(completionHandler: { _, error in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
+        container.loadPersistentStores(completionHandler: self.loadCompletionHandler)
 
         return container
     }()

--- a/Shared/Models/Migrations/DataMigrationManager.swift
+++ b/Shared/Models/Migrations/DataMigrationManager.swift
@@ -34,7 +34,6 @@ class DataMigrationManager {
 
     private static var storeURL: URL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)!.appendingPathComponent("\(DataMigrationManager.storeName).sqlite")
 
-
     private var storeModel: NSManagedObjectModel? {
         return NSManagedObjectModel.modelVersionsFor(modelNamed: self.modelName)
             .filter {

--- a/Shared/WatchConnectivityService.swift
+++ b/Shared/WatchConnectivityService.swift
@@ -54,9 +54,8 @@ public class WatchConnectivityService: NSObject, WCSessionDelegate {
     public func sessionDidDeactivate(_ session: WCSession) {}
 
     public func sendApplicationContext() {
-        guard self.validReachableSession != nil else { return }
-
-        let library = DataManager.getLibrary()
+        guard self.validReachableSession != nil,
+              let library = try? DataManager.getLibrary() else { return }
 
         guard let jsonData = try? JSONEncoder().encode(library) else {
             return


### PR DESCRIPTION
## Purpose

- Add a core data error handler

## Linear tasks

[[BKPLY-51] Recover Library on failed migration
](https://linear.app/bookplayer/issue/BKPLY-51/library-recover-on-failed-migration)

## Approach

- `DataManager` has now a property `loadingDataError` which stores the possible error from `loadPersistentStores` so it can be handled later in the app

## Things to be aware of / Things to focus on

There are two types of errors being handled:
  - In case the iPhone is full, it may fail to load the database so we just present an alert informing the user about the problem
  - If a migration failed for some reason, our last resort is to erase and reload the entire library. The progress for all the items will be lost, but the use won't have to delete, install and re-import their entire library

We still maintain a final `fatalError` in case it's an unknown error being thrown
