### PR TITLE
Fix autoplay when selecting 'finished' books

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -137,7 +137,8 @@ class PlayerManager: NSObject, TelemetryProtocol {
 
                 if book.currentTime > 0.0 {
                     // if book is truly finished, start book again to avoid autoplaying next one
-                    let time = book.currentTime == book.duration ? 0 : book.currentTime
+                    // add 1 second as a finished threshold
+                    let time = (book.currentTime + 1) >= book.duration ? 0 : book.currentTime
                     self.jumpTo(time)
                 }
 
@@ -561,6 +562,8 @@ extension PlayerManager {
         }
 
         self.update()
+
+        self.markAsCompleted(true)
 
         guard let nextBook = self.currentBook?.nextBook() else { return }
 


### PR DESCRIPTION
## Bugfix

- Autoplay skips until it finds the next unfinished book, if user manually chooses a finished item, it should start playing, and if it's finished, it should restart

## Linear tasks

[[BKPLY-47] Bug when playing finished items inside a playlist
](https://linear.app/bookplayer/issue/BKPLY-47/bug-when-playing-finished-items-inside-a-playlist)

## Approach

- Add a 1 sec threshold when checking if the selected book's current time is equal or past the book's total time

## Screenshots

https://user-images.githubusercontent.com/14112819/128639586-c9260e80-1085-478d-b37c-3a8c192d2a1d.MP4

