### PR TITLE
Fix boost volume being reset after resuming playback

### DIFF
--- a/BookPlayer/Library/LibraryViewController.swift
+++ b/BookPlayer/Library/LibraryViewController.swift
@@ -415,52 +415,53 @@ extension LibraryViewController {
 // MARK: - TableView Delegate
 
 extension LibraryViewController {
-    func tableView(_: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        guard indexPath.sectionValue == .data else { return nil }
+  func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    guard indexPath.sectionValue == .data else { return nil }
 
-        let item = items[indexPath.row]
+    let item = items[indexPath.row]
 
-        let optionsAction = UITableViewRowAction(style: .normal, title: "\("options_button".localized)…") { _, _ in
-            guard let sheet = self.createOptionsSheetController([item]) else { return }
+    let optionsAction = UIContextualAction(style: .normal, title: "\("options_button".localized)…") { _, _, completion in
+      guard let sheet = self.createOptionsSheetController([item]) else { return }
 
-            // "…" on a button indicates a follow up dialog instead of an immmediate action in macOS and iOS
-            var title = "\("delete_button".localized)…"
+      // "…" on a button indicates a follow up dialog instead of an immmediate action in macOS and iOS
+      var title = "\("delete_button".localized)…"
 
-            // Remove the dots if trying to delete an empty folder
-            if let folder = item as? Folder {
-                title = folder.hasBooks() ? title : "delete_button".localized
-            }
+      // Remove the dots if trying to delete an empty folder
+      if let folder = item as? Folder {
+          title = folder.hasBooks() ? title : "delete_button".localized
+      }
 
-            let deleteAction = UIAlertAction(title: title, style: .destructive) { _ in
-                guard let book = self.items[indexPath.row] as? Book else {
-                    guard let folder = self.items[indexPath.row] as? Folder else { return }
+      let deleteAction = UIAlertAction(title: title, style: .destructive) { _ in
+          guard let book = self.items[indexPath.row] as? Book else {
+              guard let folder = self.items[indexPath.row] as? Folder else { return }
 
-                    guard folder.hasBooks() else {
-                      do {
-                        try DataManager.delete([folder], library: self.library)
-                        self.deleteRows(at: [indexPath])
-                      } catch {
-                        self.showAlert("error_title".localized, message: error.localizedDescription)
-                      }
-
-                      return
-                    }
-
-                    self.handleDelete(items: [folder])
-
-                    return
+              guard folder.hasBooks() else {
+                do {
+                  try DataManager.delete([folder], library: self.library)
+                  self.deleteRows(at: [indexPath])
+                } catch {
+                  self.showAlert("error_title".localized, message: error.localizedDescription)
                 }
 
-                self.handleDelete(items: [book])
-            }
+                return
+              }
 
-            sheet.addAction(deleteAction)
+              self.handleDelete(items: [folder])
 
-            self.present(sheet, animated: true, completion: nil)
-        }
+              return
+          }
 
-        return [optionsAction]
+          self.handleDelete(items: [book])
+      }
+
+      sheet.addAction(deleteAction)
+
+      self.present(sheet, animated: true, completion: nil)
+      completion(true)
     }
+
+    return UISwipeActionsConfiguration(actions: [optionsAction])
+  }
 }
 
 // MARK: - TableView DataSource

--- a/BookPlayer/Library/PlaylistViewController.swift
+++ b/BookPlayer/Library/PlaylistViewController.swift
@@ -284,25 +284,26 @@ extension PlaylistViewController {
 // MARK: - TableView Delegate
 
 extension PlaylistViewController {
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        guard indexPath.sectionValue == .data else { return nil }
+  func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    guard indexPath.sectionValue == .data else { return nil }
 
-        let item = items[indexPath.row]
+    let item = items[indexPath.row]
 
-        let optionsAction = UITableViewRowAction(style: .normal, title: "\("options_button".localized)…") { _, _ in
-            guard let sheet = self.createOptionsSheetController([item]) else { return }
+    let optionsAction = UIContextualAction(style: .normal, title: "\("options_button".localized)…") { _, _, completion in
+      guard let sheet = self.createOptionsSheetController([item]) else { return }
 
-            let deleteAction = UIAlertAction(title: "delete_button".localized, style: .destructive, handler: { _ in
-                self.handleDelete(items: [item])
-            })
+      let deleteAction = UIAlertAction(title: "delete_button".localized, style: .destructive, handler: { _ in
+        self.handleDelete(items: [item])
+      })
 
-            sheet.addAction(deleteAction)
+      sheet.addAction(deleteAction)
 
-            self.present(sheet, animated: true, completion: nil)
-        }
-
-        return [optionsAction]
+      self.present(sheet, animated: true, completion: nil)
+      completion(true)
     }
+
+    return UISwipeActionsConfiguration(actions: [optionsAction])
+  }
 }
 
 // MARK: - Reorder Delegate

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -114,8 +114,6 @@ class PlayerManager: NSObject, TelemetryProtocol {
             self.audioPlayer.replaceCurrentItem(with: nil)
             self.audioPlayer.replaceCurrentItem(with: item)
 
-            self.boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
-
             // Update UI on main thread
             DispatchQueue.main.async {
                 // Set book metadata for lockscreen and control center
@@ -422,7 +420,7 @@ extension PlayerManager {
         }
 
         self.fadeTimer?.invalidate()
-        self.audioPlayer.volume = 1
+        self.boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
         // Set play state on player and control center
         self.audioPlayer.playImmediately(atRate: self.speed)
 

--- a/BookPlayer/Settings/PlusViewController.swift
+++ b/BookPlayer/Settings/PlusViewController.swift
@@ -106,7 +106,7 @@ class PlusViewController: UIViewController, TelemetryProtocol {
         self.gianniImageView.kf.setImage(with: self.contributorGianni.avatarURL)
         self.pichImageView.kf.setImage(with: self.contributorPichfl.avatarURL)
 
-        let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+        let activityIndicatorView = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.medium)
         activityIndicatorView.startAnimating()
         activityIndicatorView.color = self.themeProvider.currentTheme.useDarkVariant ? .white : .gray
         self.loadingBarButton = UIBarButtonItem(customView: activityIndicatorView)

--- a/BookPlayerTests/ImportOperationTests.swift
+++ b/BookPlayerTests/ImportOperationTests.swift
@@ -24,7 +24,6 @@ class ImportOperationTests: XCTestCase {
         let filename = "file.txt"
         let bookContents = "bookcontents".data(using: .utf8)!
         let documentsFolder = DataManager.getDocumentsFolderURL()
-        let destinationFolder = DataManager.getProcessedFolderURL()
 
         // Add test file to Documents folder
         let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: documentsFolder)


### PR DESCRIPTION
## Bugfix

- Boost volume was only being set when the book was loaded

## Linear tasks

[[BKPLY-50] Boost volume resetting after auto playback of next book
](https://linear.app/bookplayer/issue/BKPLY-50/boost-volume-resetting-after-auto-playback-of-next-book)

## Approach

- Move the boost volume assignment to right before the player `play` is called
