### PR TITLE
CarPlay Title Selection

### DIFF
--- a/BookPlayer/Library/Themes/ThemeManager.swift
+++ b/BookPlayer/Library/Themes/ThemeManager.swift
@@ -52,7 +52,9 @@ final class ThemeManager: ThemeProvider {
     }
 
     guard let library = try? DataManager.getLibrary() else {
-      self.theme = SubscribableValue<Theme>(value: DataManager.getLocalThemes().first!)
+      let defaultTheme = DataManager.getLocalThemes().first!
+      defaultTheme.useDarkVariant = self.useDarkVariant
+      self.theme = SubscribableValue<Theme>(value: defaultTheme)
       return
     }
 

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -165,7 +165,7 @@ final class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableCon
     }
 
     let message: [AnyHashable: Any] = ["command": "play",
-                                       "identifier": book.identifier!]
+                                       "identifier": book.relativePath!]
 
     NotificationCenter.default.post(name: .messageReceived, object: nil, userInfo: message)
 


### PR DESCRIPTION
## Bugfix

- CarPlay selection title doesn't trigger playback
- Also this fixes showing dark mode for clean installs

## Linear tasks

[[BKPLY-55] CarPlay title Selection bug](https://linear.app/bookplayer/issue/BKPLY-55/carplay-selection-bug)

