### PR TITLE
Exclude library from phone backups

### DIFF
--- a/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
+++ b/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
@@ -172,6 +172,13 @@ extension DataManager {
       UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.appIcon.rawValue)
     }
 
+    // Exclude Processed folder from phone backups
+    var resourceValues = URLResourceValues()
+    resourceValues.isExcludedFromBackup = true
+    var processedFolderURL = self.getProcessedFolderURL()
+
+    try? processedFolderURL.setResourceValues(resourceValues)
+
     // Set system theme as default
     if UserDefaults.standard.object(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) == nil {
       UserDefaults.standard.set(true, forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue)


### PR DESCRIPTION
## Purpose

- Exclude Library files from iPhone backups

## Linear tasks

[[BKPLY-56] Exclude Library from iPhone backups](https://linear.app/bookplayer/issue/BKPLY-56/exclude-library-from-iphone-backups)

## Approach

- Use the `isExcludedFromBackup` property for the Processed folder that contains the library files

## Screenshots

### Before

![IMG_3958](https://user-images.githubusercontent.com/14112819/130561438-a09900ce-b110-4ded-bfd4-8fab66377047.jpg)

### After

![IMG_3959](https://user-images.githubusercontent.com/14112819/130561452-018c9b7f-ad2b-473f-8e97-c789bcc3381f.jpg)

