### PR TITLE
[BKPLY-58] Bug importing zip files

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -279,16 +279,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TelemetryProtocol {
         }
     }
 
-    func setupDocumentListener() {
-        let documentsUrl = DataManager.getDocumentsFolderURL()
-        self.watcher = DirectoryWatcher.watch(documentsUrl)
+  func setupDocumentListener() {
+    let documentsUrl = DataManager.getDocumentsFolderURL()
 
-        self.watcher?.onNewFiles = { newFiles in
-            for url in newFiles {
-                DataManager.processFile(at: url)
-            }
-        }
+    self.watcher = DirectoryWatcher.watch(documentsUrl)
+    self.watcher?.ignoreDirectories = false
+
+    self.watcher?.onNewFiles = { newFiles in
+      for url in newFiles {
+        DataManager.processFile(at: url)
+      }
     }
+  }
 
     func setupStoreListener() {
         SwiftyStoreKit.completeTransactions(atomically: true) { purchases in


### PR DESCRIPTION
## Bugfix

When importing zip files, all the internal folders were being ignored, until the app was re-launched

## Linear tasks

[[BKPLY-58] Bug importing zip files](https://linear.app/bookplayer/issue/BKPLY-58/bug-importing-zip-files)

## Approach

Enable directory detection on the DirectoryWatcher dependency

## Screenshots

https://user-images.githubusercontent.com/14112819/131930102-f13d57fd-4fac-4bc6-b34e-62f78ec5c6f7.mov
