### PR TITLE
[BKPLY-57] Autoplay not working when phone is locked

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -62,7 +62,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TelemetryProtocol {
         // register document's folder listener
         self.setupDocumentListener()
         // load themes if necessary
-        DataManager.setupDefaultTheme()
+        DataManager.setupDefaultState()
         // setup store required listeners
         self.setupStoreListener()
         // register for CarPlay

--- a/BookPlayer/Import/ImportOperation.swift
+++ b/BookPlayer/Import/ImportOperation.swift
@@ -119,7 +119,7 @@ public class ImportOperation: Operation {
 
       do {
         try FileManager.default.moveItem(at: file, to: destinationURL)
-        try (destinationURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
+        destinationURL.disableFileProtection()
       } catch {
         fatalError("Fail to move file from \(file) to \(destinationURL)")
       }

--- a/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
+++ b/BookPlayer/Library/DataManagement/DataManager+BookPlayer.swift
@@ -57,7 +57,7 @@ extension DataManager {
 
     saveContext()
 
-    DataManager.setupDefaultTheme()
+    DataManager.setupDefaultState()
 
     _ = DataManager.insertItems(from: files, into: nil, library: library)
 
@@ -156,7 +156,7 @@ extension DataManager {
 
     // MARK: - Themes
 
-  public class func setupDefaultTheme() {
+  public class func setupDefaultState() {
     let userDefaults = UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)
 
     // Migrate user defaults app icon
@@ -170,6 +170,13 @@ extension DataManager {
               sharedAppIcon != localAppIcon {
       userDefaults?.set(localAppIcon, forKey: Constants.UserDefaults.appIcon.rawValue)
       UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.appIcon.rawValue)
+    }
+
+    // Migrate protection for Processed folder
+    if !(userDefaults?
+        .bool(forKey: Constants.UserDefaults.fileProtectionMigration.rawValue) ?? false) {
+      self.getProcessedFolderURL().disableFileProtection()
+      userDefaults?.set(true, forKey: Constants.UserDefaults.fileProtectionMigration.rawValue)
     }
 
     // Exclude Processed folder from phone backups

--- a/BookPlayer/Services/Telemetry/TelemetryProtocol.swift
+++ b/BookPlayer/Services/Telemetry/TelemetryProtocol.swift
@@ -10,11 +10,14 @@ import TelemetryClient
 import UIKit
 
 protocol TelemetryProtocol {
-    func sendSignal(_ signal: TelemetrySignal, with params: [String: String]?)
+  func sendSignal(_ signal: TelemetrySignal, with params: [String: String]?)
 }
 
 extension TelemetryProtocol {
-    func sendSignal(_ signal: TelemetrySignal, with params: [String: String]?) {
-        TelemetryManager.shared.send(signal.rawValue, with: params ?? [:])
-    }
+  func sendSignal(_ signal: TelemetrySignal, with params: [String: String]?) {
+    // For the time being only allow tip jar screen and tip action event
+    guard signal == .tipJarScreen || signal == .tipAction else { return }
+
+    TelemetryManager.shared.send(signal.rawValue, with: params ?? [:])
+  }
 }

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -30,6 +30,9 @@ public enum Constants {
 
         case rewindInterval = "userSettingsRewindInterval"
         case forwardInterval = "userSettingsForwardInterval"
+
+      // One-time migrations
+      case fileProtectionMigration = "userFileProtectionMigration"
     }
 
     public enum SmartRewind: TimeInterval {

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -14,6 +14,24 @@ public extension URL {
         return (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
 
+  // Disable file protection for file and descendants if it's a directory
+  func disableFileProtection() {
+    try? (self as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
+
+    guard self.isDirectory else { return }
+
+    let enumerator = FileManager.default.enumerator(at: self,
+                                                    includingPropertiesForKeys: [.isDirectoryKey],
+                                                    options: [.skipsHiddenFiles], errorHandler: { (url, error) -> Bool in
+                                                      print("directoryEnumerator error at \(url): ", error)
+                                                      return true
+                                                    })!
+
+    for case let fileURL as URL in enumerator {
+      try? (fileURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
+    }
+  }
+
     func hasAppKey() -> Bool {
         do {
             _ = try self.extendedAttribute(forName: "\(Bundle.main.configurationString(for: .bundleIdentifier)).identifier")


### PR DESCRIPTION
## Bugfix

Autoplay is broken when the device is locked, this is linked to the default file protection

## Linear tasks

[[BKPLY-57] Autoplay not working when phone is locked](https://linear.app/bookplayer/issue/BKPLY-57/autoplay-not-working-when-phone-is-locked)

## Approach

- Add a one time migration to rewrite file protection for the Processed folder
- When importing directories, the `ImportOperation` will remove the protection from the items inside as well
