### PR TITLE
Add skip track support

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -33,6 +33,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TelemetryProtocol {
       .filter({ $0.isKeyWindow }).first?.rootViewController
   }
 
+  var topController: UIViewController? {
+    var topController = AppDelegate.delegateInstance.keyWindowRootVC
+
+    while let newTopController = topController?.presentedViewController {
+      topController = newTopController
+    }
+
+    return topController
+  }
+
   static var delegateInstance: AppDelegate {
     // swiftlint:disable force_cast
     return (UIApplication.shared.delegate as! AppDelegate)

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -95,20 +95,6 @@ class PlayerViewController: BaseViewController<PlayerCoordinator, PlayerViewMode
     NotificationCenter.default.post(name: .playerPresented, object: nil)
     self.closeButton.accessibilityLabel = "voiceover_dismiss_player_title".localized
 
-    let leftChevron = UIImage(
-      systemName: "chevron.left",
-      withConfiguration: UIImage.SymbolConfiguration(pointSize: 18,
-                                                     weight: .semibold)
-    )
-    self.previousChapterButton.setImage(leftChevron, for: .normal)
-
-    let rightChevron = UIImage(
-      systemName: "chevron.right",
-      withConfiguration: UIImage.SymbolConfiguration(pointSize: 18,
-                                                     weight: .semibold)
-    )
-    self.nextChapterButton.setImage(rightChevron, for: .normal)
-
     self.chapterTitleButton.titleLabel?.numberOfLines = 2
     self.chapterTitleButton.titleLabel?.textAlignment = .center
   }
@@ -155,8 +141,19 @@ class PlayerViewController: BaseViewController<PlayerCoordinator, PlayerViewMode
       self.progressSlider.setProgress(progressObject.sliderValue)
     }
 
-    self.previousChapterButton.isEnabled = self.viewModel.hasPreviousChapter()
-    self.nextChapterButton.isEnabled = self.viewModel.hasNextChapter()
+    let leftChevron = UIImage(
+      systemName: progressObject.prevChapterImageName,
+      withConfiguration: UIImage.SymbolConfiguration(pointSize: 18,
+                                                     weight: .semibold)
+    )
+    let rightChevron = UIImage(
+      systemName: progressObject.nextChapterImageName,
+      withConfiguration: UIImage.SymbolConfiguration(pointSize: 18,
+                                                     weight: .semibold)
+    )
+
+    self.previousChapterButton.setImage(leftChevron, for: .normal)
+    self.nextChapterButton.setImage(rightChevron, for: .normal)
   }
 }
 

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -40,26 +40,36 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     return self.playerManager.hasChapters.eraseToAnyPublisher()
   }
 
-  func hasPreviousChapter() -> Bool {
-    return self.playerManager.currentBook?.previousChapter() != nil
+  func hasChapter(before chapter: Chapter?) -> Bool {
+    guard let chapter = chapter else { return false }
+    return self.playerManager.currentBook?.hasChapter(before: chapter) ?? false
   }
 
-  func hasNextChapter() -> Bool {
-    return self.playerManager.currentBook?.nextChapter() != nil
+  func hasChapter(after chapter: Chapter?) -> Bool {
+    guard let chapter = chapter else { return false }
+    return self.playerManager.currentBook?.hasChapter(after: chapter) ?? false
   }
 
   func handlePreviousChapterAction() {
-    guard let previousChapter = self.playerManager.currentBook?.previousChapter() else { return }
-
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-    self.playerManager.jumpTo(previousChapter.start + 0.5)
+
+    if let currentChapter = self.playerManager.currentBook?.currentChapter,
+       let previousChapter = self.playerManager.currentBook?.previousChapter(before: currentChapter) {
+      self.playerManager.jumpTo(previousChapter.start + 0.5)
+    } else {
+      self.playerManager.playPreviousItem()
+    }
   }
 
   func handleNextChapterAction() {
-    guard let nextChapter = self.playerManager.currentBook?.nextChapter() else { return }
-
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-    self.playerManager.jumpTo(nextChapter.start + 0.5)
+
+    if let currentChapter = self.playerManager.currentBook?.currentChapter,
+       let nextChapter = self.playerManager.currentBook?.nextChapter(after: currentChapter) {
+      self.playerManager.jumpTo(nextChapter.start + 0.5)
+    } else {
+      self.playerManager.playNextItem()
+    }
   }
 
   func isBookFinished() -> Bool {
@@ -151,11 +161,20 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     // Update local chapter
     self.chapterBeforeSliderValueChange = self.playerManager.currentBook?.currentChapter
 
+    let prevChapterImageName = self.hasChapter(before: self.playerManager.currentBook?.currentChapter)
+    ? "chevron.left"
+    : "chevron.left.2"
+    let nextChapterImageName = self.hasChapter(after: self.playerManager.currentBook?.currentChapter)
+    ? "chevron.right"
+    : "chevron.right.2"
+
     return ProgressObject(
       currentTime: currentTime,
       progress: progress,
       maxTime: maxTimeInContext,
       sliderValue: sliderValue,
+      prevChapterImageName: prevChapterImageName,
+      nextChapterImageName: nextChapterImageName,
       chapterTitle: self.playerManager.currentBook?.currentChapter?.title
       ?? self.playerManager.currentBook?.lastPathComponent
       ?? ""
@@ -173,27 +192,45 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func processSliderValueChangedEvent(with value: Float) -> ProgressObject {
-    var newCurrentTime = getBookTimeFromSlider(value: value)
     var chapterTitle: String?
-
+    var prevChapterImageName = "chevron.left.2"
+    var nextChapterImageName = "chevron.right.2"
+    var newCurrentTime: TimeInterval
     if self.prefersChapterContext,
        let currentChapter = self.chapterBeforeSliderValueChange {
       newCurrentTime = TimeInterval(value) * currentChapter.duration
       chapterTitle = currentChapter.title
+
+      if self.hasChapter(before: currentChapter) {
+        prevChapterImageName = "chevron.left"
+      }
+      if self.hasChapter(after: currentChapter) {
+        nextChapterImageName = "chevron.right"
+      }
+    } else {
+      newCurrentTime = self.getBookTimeFromSlider(value: value)
+      if let chapter = self.playerManager.currentBook?.getChapter(at: newCurrentTime) {
+        chapterTitle = chapter.title
+
+        if self.hasChapter(before: chapter) {
+          prevChapterImageName = "chevron.left"
+        }
+        if self.hasChapter(after: chapter) {
+          nextChapterImageName = "chevron.right"
+        }
+      }
+    }
+
+    var progress: String?
+    if !self.playerManager.hasChapters.value || !self.prefersChapterContext {
+      progress = "\(Int(round(value * 100)))%"
     }
 
     var newMaxTime: TimeInterval?
-
     if self.prefersRemainingTime {
       let durationTimeInContext = self.playerManager.currentBook?.durationTimeInContext(self.prefersChapterContext) ?? 0
 
       newMaxTime = newCurrentTime - durationTimeInContext
-    }
-
-    var progress: String?
-
-    if !(self.playerManager.currentBook?.hasChapters ?? false) || !self.prefersChapterContext {
-      progress = "\(Int(round(value * 100)))%"
     }
 
     return ProgressObject(
@@ -201,7 +238,11 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
       progress: progress,
       maxTime: newMaxTime,
       sliderValue: value,
-      chapterTitle: chapterTitle ?? self.playerManager.currentBook?.lastPathComponent ?? ""
+      prevChapterImageName: prevChapterImageName,
+      nextChapterImageName: nextChapterImageName,
+      chapterTitle: chapterTitle ?? self.chapterBeforeSliderValueChange?.title
+      ?? self.playerManager.currentBook?.lastPathComponent
+      ?? ""
     )
   }
 

--- a/BookPlayer/Player/Player Screen/ProgressObject.swift
+++ b/BookPlayer/Player/Player Screen/ProgressObject.swift
@@ -14,6 +14,8 @@ struct ProgressObject {
   let progress: String?
   let maxTime: TimeInterval?
   let sliderValue: Float
+  let prevChapterImageName: String
+  let nextChapterImageName: String
   let chapterTitle: String
 
   var formattedCurrentTime: String {

--- a/BookPlayer/Settings/Plus Screen/Views/PlusBannerView.swift
+++ b/BookPlayer/Settings/Plus Screen/Views/PlusBannerView.swift
@@ -26,13 +26,7 @@ class PlusBannerView: NibLoadableView {
     @IBAction func showPlus(_ sender: UIButton) {
       let vc = PlusNavigationController.instantiate(from: .Settings)
 
-      var topController = AppDelegate.delegateInstance.keyWindowRootVC
-
-      while let newTopController = topController?.presentedViewController {
-        topController = newTopController
-      }
-
-      topController?.present(vc, animated: true, completion: nil)
+      AppDelegate.delegateInstance.topController?.present(vc, animated: true, completion: nil)
     }
 }
 

--- a/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
@@ -132,7 +132,7 @@ public class Book: LibraryItem {
         }
 
         guard let currentChapter = (chapters.first { (chapter) -> Bool in
-            chapter.start <= self.currentTime && chapter.end > self.currentTime
+          return chapter.start <= self.currentTime && chapter.end >= self.currentTime
         }) else { return }
 
         self.currentChapter = currentChapter

--- a/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
@@ -248,6 +248,34 @@ public class Folder: LibraryItem {
         return nil
     }
 
+  func getPreviousBook(before book: Book) -> Book? {
+    guard let items = self.items?.array as? [LibraryItem] else {
+      return nil
+    }
+
+    guard let indexFound = self.itemIndex(with: book.relativePath) else {
+      return nil
+    }
+
+    let targetIndex = indexFound - 1
+
+    for (index, item) in items.enumerated() {
+      guard index == targetIndex else { continue }
+
+      if item.isFinished {
+        item.setCurrentTime(0.0)
+      }
+
+      if let book = item as? Book {
+        return book
+      } else if let folder = item as? Folder {
+        return folder.getPreviousBook(before: book)
+      }
+    }
+
+    return nil
+  }
+
     // Used for player autoplay
     func getNextBook(after book: Book) -> Book? {
         guard let items = self.items?.array as? [LibraryItem] else {

--- a/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
@@ -65,22 +65,55 @@ public class Library: NSManagedObject, Codable {
         return itemFound
     }
 
-    func getNextItem(after item: LibraryItem) -> LibraryItem? {
-        guard let items = self.items?.array as? [LibraryItem] else { return nil }
-
-        guard let indexFound = self.itemIndex(with: item.relativePath) else { return nil }
-
-        for (index, item) in items.enumerated() {
-            guard index > indexFound,
-                !item.isFinished else { continue }
-
-            if let folder = item as? Folder, !folder.hasBooks() { continue }
-
-            return item
-        }
-
-        return nil
+  func getPreviousBook(before book: Book) -> Book? {
+    guard let items = self.items?.array as? [LibraryItem] else {
+      return nil
     }
+
+    guard let indexFound = self.itemIndex(with: book.relativePath) else {
+      return nil
+    }
+
+    let targetIndex = indexFound - 1
+
+    for (index, item) in items.enumerated() {
+      guard index == targetIndex else { continue }
+
+      if item.isFinished {
+        item.setCurrentTime(0.0)
+      }
+
+      if let book = item as? Book {
+        return book
+      } else if let folder = item as? Folder {
+        return folder.getPreviousBook(before: book)
+      }
+    }
+
+    return nil
+  }
+
+  func getNextBook(after book: Book) -> Book? {
+    guard let items = self.items?.array as? [LibraryItem] else { return nil }
+
+    guard let indexFound = self.itemIndex(with: book.relativePath) else { return nil }
+
+    for (index, item) in items.enumerated() {
+      guard index > indexFound else { continue }
+
+      if item.isFinished {
+        item.setCurrentTime(0.0)
+      }
+
+      if let book = item as? Book {
+        return book
+      } else if let folder = item as? Folder {
+        return folder.getNextBook(after: book)
+      }
+    }
+
+    return nil
+  }
 
     public func getItemsOrderedByDate() -> [LibraryItem] {
         guard let items = self.items?.array as? [LibraryItem] else {

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -23,18 +23,12 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
 
   public static func == (lhs: SimpleLibraryItem, rhs: SimpleLibraryItem) -> Bool {
     return lhs.id == rhs.id
-    && lhs.title == rhs.title
-    && lhs.details == rhs.details
-    && lhs.relativePath == rhs.relativePath
-    && lhs.progress == rhs.progress
-    && lhs.playbackState == rhs.playbackState
   }
 
   public func hash(into hasher: inout Hasher) {
     hasher.combine(id)
     hasher.combine(title)
     hasher.combine(details)
-    hasher.combine(relativePath)
     hasher.combine(progress)
     hasher.combine(playbackState)
   }


### PR DESCRIPTION
## Purpose

The new controls `<`, `>` only work in the chapter context to skip chapters, this may cause confusion to users that listen to mp3s. We've added support to skip items, and for those cases the controls would look like `<<`, `>>`