### PR TITLE
Remove UITableViewDiffableDatasource

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -28,8 +28,6 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
   private var previousLeftButtons: [UIBarButtonItem]?
   lazy var selectButton: UIBarButtonItem = UIBarButtonItem(title: "select_all_title".localized, style: .plain, target: self, action: #selector(selectButtonPressed))
 
-  var dataSource: ItemListTableDataSource!
-
   var defaultArtwork: UIImage? {
     return UIImage(data: self.viewModel.defaultArtwork!)
   }
@@ -100,37 +98,6 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
     self.tableView.dragDelegate = self
     self.tableView.dropDelegate = self
 
-    self.dataSource = ItemListTableDataSource(tableView: tableView) { (tableView, indexPath, item) -> UITableViewCell? in
-      guard indexPath.sectionValue != .add,
-          let cell = tableView.dequeueReusableCell(withIdentifier: "BookCellView", for: indexPath) as? BookCellView else {
-          return tableView.dequeueReusableCell(withIdentifier: "AddCellView", for: indexPath)
-      }
-
-      cell.onArtworkTap = { [weak self] in
-        guard !tableView.isEditing else {
-          if cell.isSelected {
-            tableView.deselectRow(at: indexPath, animated: true)
-          } else {
-            tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
-          }
-          return
-        }
-
-        self?.viewModel.playNextBook(after: item)
-      }
-
-      cell.title = item.title
-      cell.subtitle = item.details
-      cell.progress = item.progress
-      cell.duration = item.duration
-      cell.type = item.type
-      cell.playbackState = item.playbackState
-      cell.artworkView.kf.setImage(with: ArtworkService.getArtworkProvider(for: item.relativePath),
-                                   placeholder: self.defaultArtwork)
-
-      return cell
-    }
-
     self.updateSnapshot(with: self.viewModel.getInitialItems(), animated: false)
   }
 
@@ -189,7 +156,7 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
         return
       }
 
-      let selectedItems = indexPaths.compactMap({ self.dataSource.itemIdentifier(for: $0) })
+      let selectedItems = indexPaths.compactMap({ self.viewModel.items.value[$0.row] })
 
       self.viewModel.showMoveOptions(selectedItems: selectedItems)
     }
@@ -199,7 +166,7 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
         return
       }
 
-      let selectedItems = indexPaths.compactMap({ self.dataSource.itemIdentifier(for: $0) })
+      let selectedItems = indexPaths.compactMap({ self.viewModel.items.value[$0.row] })
 
       self.viewModel.showDeleteOptions(selectedItems: selectedItems)
     }
@@ -209,7 +176,7 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
         return
       }
 
-      let selectedItems = indexPaths.compactMap({ self.dataSource.itemIdentifier(for: $0) })
+      let selectedItems = indexPaths.compactMap({ self.viewModel.items.value[$0.row] })
 
       self.viewModel.showMoreOptions(selectedItems: selectedItems)
     }
@@ -218,11 +185,6 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
   func bindDataItems() {
     self.viewModel.items.sink { [weak self] items in
       self?.updateSnapshot(with: items, animated: true)
-    }
-    .store(in: &disposeBag)
-
-    self.dataSource.reorderUpdates.sink { [weak self] (item, sourceIndexPath, destinationIndexPath) in
-      self?.viewModel.reorder(item: item, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
     }
     .store(in: &disposeBag)
   }
@@ -294,12 +256,7 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
   func updateSnapshot(with items: [SimpleLibraryItem], animated: Bool) {
     self.toggleEmptyStateView()
 
-    var snapshot = NSDiffableDataSourceSnapshot<SectionType, SimpleLibraryItem>()
-    snapshot.appendSections([.data])
-    snapshot.appendItems(items, toSection: .data)
-    snapshot.appendSections([.add])
-    snapshot.appendItems([SimpleLibraryItem()], toSection: .add)
-    self.dataSource.apply(snapshot, animatingDifferences: false)
+    self.tableView.reloadData()
   }
 
   func updateSelectionStatus() {
@@ -344,7 +301,75 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, FolderList
   }
 }
 
+extension ItemListViewController: UITableViewDataSource {
+  func numberOfSections(in tableView: UITableView) -> Int {
+    return Section.allCases.count
+  }
+
+  func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    guard section == SectionType.data.rawValue else { return 1 }
+
+    return self.viewModel.items.value.count
+  }
+
+  func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    guard indexPath.sectionValue != .add,
+          let cell = tableView.dequeueReusableCell(withIdentifier: "BookCellView", for: indexPath) as? BookCellView else {
+            return tableView.dequeueReusableCell(withIdentifier: "AddCellView", for: indexPath)
+          }
+
+    let item = self.viewModel.items.value[indexPath.row]
+
+    cell.onArtworkTap = { [weak self] in
+      guard !tableView.isEditing else {
+        if cell.isSelected {
+          tableView.deselectRow(at: indexPath, animated: true)
+        } else {
+          tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
+        }
+        return
+      }
+
+      self?.viewModel.playNextBook(after: item)
+    }
+
+    cell.title = item.title
+    cell.subtitle = item.details
+    cell.progress = item.progress
+    cell.duration = item.duration
+    cell.type = item.type
+    cell.playbackState = item.playbackState
+    cell.artworkView.kf.setImage(with: ArtworkService.getArtworkProvider(for: item.relativePath),
+                                 placeholder: self.defaultArtwork)
+
+    return cell
+  }
+}
+
 extension ItemListViewController: UITableViewDelegate {
+  // MARK: reordering support
+
+  func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+    return indexPath.sectionValue == .data
+  }
+
+  func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+    guard sourceIndexPath.sectionValue == .data,
+          destinationIndexPath.sectionValue == .data,
+          sourceIndexPath.row != destinationIndexPath.row else {
+        return
+    }
+
+    let item = self.viewModel.items.value[sourceIndexPath.row]
+    self.viewModel.reorder(item: item, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
+  }
+
+  // MARK: editing support
+
+  func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+    return indexPath.sectionValue == .data
+  }
+
   func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     guard indexPath.sectionValue == .data else { return 66 }
 
@@ -357,7 +382,6 @@ extension ItemListViewController: UITableViewDelegate {
 
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
-
       self.viewModel.loadNextItems()
     }
   }
@@ -387,16 +411,14 @@ extension ItemListViewController: UITableViewDelegate {
       return
     }
 
-    guard let item = self.dataSource.itemIdentifier(for: indexPath) else {
-      return
-    }
-
+    let item = self.viewModel.items.value[indexPath.row]
     self.viewModel.showItemContents(item)
   }
 
   func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-    guard indexPath.sectionValue == .data,
-          let item = self.dataSource.itemIdentifier(for: indexPath) else { return nil }
+    guard indexPath.sectionValue == .data else { return nil }
+
+    let item = self.viewModel.items.value[indexPath.row]
 
     let optionsAction = UIContextualAction(style: .normal, title: "\("options_button".localized)…") { _, _, completion in
       self.viewModel.showMoreOptions(selectedItems: [item])

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -124,6 +124,10 @@ class FolderListViewModel: BaseViewModel<ItemListCoordinator> {
   }
 
   func loadNextItems(pageSize: Int = 13) {
+    let maxItems = self.folder?.items?.count ?? self.library.items?.count ?? 0
+
+    guard self.offset < maxItems else { return }
+
     guard let fetchedItems = self.dataManager.fetchContents(of: self.folder, or: library, limit: pageSize, offset: self.offset),
           !fetchedItems.isEmpty else {
       return

--- a/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
@@ -282,22 +282,22 @@ public class Folder: LibraryItem {
             return nil
         }
 
-        guard let indexFound = self.itemIndex(with: book.relativePath) else {
-            return nil
-        }
+        let indexFound = self.itemIndex(with: book.relativePath)
 
         for (index, item) in items.enumerated() {
+          if let indexFound = indexFound {
             guard index > indexFound else { continue }
+          }
 
-            if item.isFinished {
-                item.setCurrentTime(0.0)
-            }
+          if item.isFinished {
+            item.setCurrentTime(0.0)
+          }
 
-            if let book = item as? Book {
-                return book
-            } else if let folder = item as? Folder {
-                return folder.getNextBook(after: book)
-            }
+          if let book = item as? Book {
+            return book
+          } else if let folder = item as? Folder {
+            return folder.getNextBook(after: book)
+          }
         }
 
         return nil

--- a/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
@@ -96,10 +96,12 @@ public class Library: NSManagedObject, Codable {
   func getNextBook(after book: Book) -> Book? {
     guard let items = self.items?.array as? [LibraryItem] else { return nil }
 
-    guard let indexFound = self.itemIndex(with: book.relativePath) else { return nil }
+    let indexFound = self.itemIndex(with: book.relativePath)
 
     for (index, item) in items.enumerated() {
-      guard index > indexFound else { continue }
+      if let indexFound = indexFound {
+        guard index > indexFound else { continue }
+      }
 
       if item.isFinished {
         item.setCurrentTime(0.0)


### PR DESCRIPTION
## Purpose

Remove UITableViewDiffableDatasource, which may be the cause of crashes when updating the snapshot

## Approach

- Go back to the regular data source delegates for the UITableView

## Things to be aware of / Things to focus on

UITableViewDiffableDatasource was promising, first implementation was done by always applying a new snapshot to the datasource. This for some users made the app crash with the error that it was trying to apply a snapshot with duplicated identifiers.
The second try, was to keep one snapshot, and insert, reload, delete the items it has reference too. The main problem was with reloading, it didn't actually update the UI, it triggered the re-rendering of the cell, and it was up to us, to query for the updated item in the viewmodel, which kinds of defeat the 'simplicity' that was promised with the new feature
