### PR TITLE
Fix artwork aspect ratio

### DIFF
--- a/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
@@ -80,7 +80,7 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
 
     self.artworkImage.clipsToBounds = false
     // artwork now has the main info regarding the title and author
-    self.artworkImage.contentMode = .scaleToFill
+    self.artworkImage.contentMode = .scaleAspectFit
     self.artworkImage.layer.cornerRadius = 9.5
     self.artworkImage.layer.masksToBounds = true
     self.artworkImage.layer.borderColor = UIColor.clear.cgColor
@@ -119,7 +119,19 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
   public func setupInfo(with book: Book) {
     self.titleLabel.text = book.title
     self.authorLabel.text = book.author
-    self.artworkImage.kf.setImage(with: ArtworkService.getArtworkProvider(for: book.relativePath))
+    self.artworkImage.kf.setImage(
+      with: ArtworkService.getArtworkProvider(for: book.relativePath),
+      completionHandler: { result in
+        switch result {
+        case .success(let value):
+          self.artworkImage.image = value.image
+          self.artworkImage.isHidden = false
+        case .failure(_):
+          self.artworkImage.image = nil
+          self.artworkImage.isHidden = true
+        }
+      }
+    )
     self.artworkOverlay.isAccessibilityElement = true
     self.artworkOverlay.accessibilityLabel = VoiceOverService().playerMetaText(book: book)
   }

--- a/BookPlayer/Player/Player Screen/Views/ArtworkControl.xib
+++ b/BookPlayer/Player/Player Screen/Views/ArtworkControl.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -54,8 +54,9 @@
                     <rect key="frame" x="0.0" y="0.0" width="325" height="325"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="b1B-eO-wd8" customClass="BPArtworkView" customModule="BookPlayer" customModuleProvider="target">
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="b1B-eO-wd8" customClass="BPArtworkView" customModule="BookPlayer" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="325" height="325"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QW8-uv-3SO" customClass="AVRoutePickerView">
                     <rect key="frame" x="284" y="12" width="29" height="29"/>


### PR DESCRIPTION
## Purpose

Portrait artwork was getting distorted in the player view

## Approach

Added a black background and changed scaleToFill to aspectFit. The black background is to keep the artwork 'shaped' as a square and have the airplay icon be part of the artwork too

## Screenshots

![IMG_AB594B4A2A45-1](https://user-images.githubusercontent.com/14112819/139669566-ee9b1e45-0e2f-48f7-872d-8a0638aa4eaa.jpeg)


