### PR TITLE
Fix crash when theme pulled from library

### DIFF
--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -50,8 +50,8 @@ class MainCoordinator: Coordinator {
 
     let library = (try? self.dataManager.getLibrary()) ?? self.dataManager.createLibrary()
 
-    if library.currentTheme != nil {
-      ThemeManager.shared.currentTheme = SimpleTheme(with: library.currentTheme)
+    if let currentTheme = try? dataManager.getLibraryCurrentTheme() {
+      ThemeManager.shared.currentTheme = SimpleTheme(with: currentTheme)
     }
 
     let libraryCoordinator = LibraryListCoordinator(


### PR DESCRIPTION
## Bugfix

App is crashing due to the current theme having some of its properties being faults (not loaded in memory from CoreData)

## Approach

Use the same approach we use for widgets with `getLibraryCurrentTheme()`
