### PR TITLE
[BKPLY-71] Fix linebreak for chapter title

### DIFF
--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -102,6 +102,8 @@ class PlayerViewController: BaseViewController<PlayerCoordinator, PlayerViewMode
   func setupPlayerView(with currentBook: Book) {
     guard !currentBook.isFault else { return }
 
+    self.chapterTitleButton.titleLabel?.lineBreakMode = currentBook.hasChapters ? .byWordWrapping : .byCharWrapping
+
     self.artworkControl.setupInfo(with: currentBook)
 
     self.updateView(with: self.viewModel.getCurrentProgressState())


### PR DESCRIPTION
## Bugfix

Right now we have it set to break on a character level, which makes sense for mp3s, but for m4bs which usually have chapter info, we should set to break on a word level

## Linear tasks

[[BKPLY-71]  Fix linebreak for chapter title](https://linear.app/bookplayer/issue/BKPLY-71/line-break-mode-for-chapter-title-in-player-view)