### PR TITLE
Fix select all behavior

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		41C23402272E1960006BC7B8 /* SimpleTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412AB73B2702BDED00969618 /* SimpleTheme.swift */; };
 		41C23403272E1965006BC7B8 /* PlaybackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41546FF026F54F0600825180 /* PlaybackState.swift */; };
 		41C23404272E1966006BC7B8 /* PlaybackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41546FF026F54F0600825180 /* PlaybackState.swift */; };
+		41C2340C27324AB7006BC7B8 /* ItemListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C2340B27324AB7006BC7B8 /* ItemListTests.swift */; };
 		41C3394925E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 41C3394825E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel */; };
 		41C3394A25E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 41C3394825E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel */; };
 		41C3395225E040FB003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 41C3394825E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel */; };
@@ -718,6 +719,7 @@
 		41B2AC8D1D43CCE8005382A9 /* ChaptersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChaptersViewController.swift; sourceTree = "<group>"; };
 		41B30A32230232D200025D69 /* CarPlayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayManager.swift; sourceTree = "<group>"; };
 		41B68FFE2705477D00F657C3 /* StorageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCoordinator.swift; sourceTree = "<group>"; };
+		41C2340B27324AB7006BC7B8 /* ItemListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListTests.swift; sourceTree = "<group>"; };
 		41C3394825E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = MappingModel_v2_to_v3.xcmappingmodel; sourceTree = "<group>"; };
 		41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManagerTests.swift; sourceTree = "<group>"; };
 		41C8ABD026836F50003B67D1 /* ImportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportViewModel.swift; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 				41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */,
 				41A6A87420DEECC400B2C621 /* FolderTests.swift */,
 				4197FAF9267E38D900811CC8 /* LibraryTests.swift */,
+				41C2340B27324AB7006BC7B8 /* ItemListTests.swift */,
 				6279361D272D0CF50097837D /* Coordinators */,
 				418B6D141D2707F800F974FB /* Info.plist */,
 			);
@@ -2344,6 +2347,7 @@
 			files = (
 				4137BBD6272DF693009ED9FE /* SettingsCoordinatorTests.swift in Sources */,
 				69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */,
+				41C2340C27324AB7006BC7B8 /* ItemListTests.swift in Sources */,
 				41A1B140226FEF9600EA0400 /* FolderTests.swift in Sources */,
 				41A1B13F226FEF9300EA0400 /* DataManagerTests.swift in Sources */,
 				4137BBD4272DF540009ED9FE /* PlayerCoordinatorTests.swift in Sources */,

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -37,7 +37,7 @@ class FolderListCoordinator: ItemListCoordinator {
                                         library: self.library,
                                         player: self.playerManager,
                                         dataManager: self.dataManager,
-                                        theme: ThemeManager.shared.currentTheme)
+                                        themeAccent: ThemeManager.shared.currentTheme.linkColor)
     viewModel.coordinator = self
     vc.viewModel = viewModel
     self.presentingViewController = vc

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -16,7 +16,7 @@ class LibraryListCoordinator: ItemListCoordinator {
                                         library: self.library,
                                         player: self.playerManager,
                                         dataManager: self.dataManager,
-                                        theme: ThemeManager.shared.currentTheme)
+                                        themeAccent: ThemeManager.shared.currentTheme.linkColor)
     viewModel.coordinator = self
     vc.viewModel = viewModel
     vc.navigationItem.largeTitleDisplayMode = .automatic

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -19,16 +19,16 @@ class FolderListViewModel: BaseViewModel<ItemListCoordinator> {
   let dataManager: DataManager
   var offset = 0
 
-  public var defaultArtwork: Data?
-  public var themeAccent: UIColor
-  public var itemsUpdates = PassthroughSubject<[SimpleLibraryItem], Never>()
-  public var itemProgressUpdates = PassthroughSubject<IndexPath, Never>()
-  public var items = [SimpleLibraryItem]()
+  public private(set) var defaultArtwork: Data?
+  private var themeAccent: UIColor
+  public private(set) var itemsUpdates = PassthroughSubject<[SimpleLibraryItem], Never>()
+  public private(set) var itemProgressUpdates = PassthroughSubject<IndexPath, Never>()
+  public private(set) var items = [SimpleLibraryItem]()
   private var bookSubscription: AnyCancellable?
   private var bookProgressSubscription: AnyCancellable?
   private var containingFolder: Folder?
 
-  private var maxItems: Int {
+  public var maxItems: Int {
     return self.folder?.items?.count ?? self.library.items?.count ?? 0
   }
 
@@ -36,13 +36,13 @@ class FolderListViewModel: BaseViewModel<ItemListCoordinator> {
        library: Library,
        player: PlayerManager,
        dataManager: DataManager,
-       theme: SimpleTheme) {
+       themeAccent: UIColor) {
     self.folder = folder
     self.library = library
     self.player = player
     self.dataManager = dataManager
-    self.themeAccent = theme.linkColor
-    self.defaultArtwork = ArtworkService.generateDefaultArtwork(from: theme.linkColor)?.pngData()
+    self.themeAccent = themeAccent
+    self.defaultArtwork = ArtworkService.generateDefaultArtwork(from: themeAccent)?.pngData()
     super.init()
 
     self.bindBookObserver()

--- a/BookPlayerTests/ItemListTests.swift
+++ b/BookPlayerTests/ItemListTests.swift
@@ -1,0 +1,123 @@
+//
+//  ItemListTests.swift
+//  BookPlayerTests
+//
+//  Created by Gianni Carlo on 2/11/21.
+//  Copyright © 2021 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import Combine
+import XCTest
+
+class ItemListTests: XCTestCase {
+  var viewModel: FolderListViewModel!
+  var subscription: AnyCancellable?
+
+  override func setUp() {
+    let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: "/dev/null"))
+
+    let playerManager = PlayerManager(dataManager: dataManager,
+                                      watchConnectivityService: WatchConnectivityService(dataManager: dataManager))
+
+    self.viewModel = FolderListViewModel(folder: nil,
+                                         library: dataManager.createLibrary(),
+                                         player: playerManager,
+                                         dataManager: dataManager,
+                                         themeAccent: .blue)
+
+    self.viewModel.library.insert(
+      item: StubFactory.book(dataManager: self.viewModel.dataManager, title: "book1", duration: 100)
+    )
+    self.viewModel.library.insert(
+      item: StubFactory.book(dataManager: self.viewModel.dataManager, title: "book2", duration: 100)
+    )
+    self.viewModel.library.insert(
+      item: StubFactory.book(dataManager: self.viewModel.dataManager, title: "book3", duration: 100)
+    )
+    self.viewModel.library.insert(
+      item: StubFactory.book(dataManager: self.viewModel.dataManager, title: "book4", duration: 100)
+    )
+  }
+
+  func testLoadingInitialItems() {
+    let loadedItems = self.viewModel.loadInitialItems()
+    XCTAssert(loadedItems.count == 4)
+    XCTAssert(self.viewModel.items.count == 4)
+    XCTAssert(self.viewModel.offset == 4)
+    XCTAssert(self.viewModel.maxItems == 4)
+  }
+
+  func testLoadingInitialItemsPagination() {
+    let partialLoadedItems = self.viewModel.loadInitialItems(pageSize: 2)
+    XCTAssert(partialLoadedItems.count == 2)
+    XCTAssert(self.viewModel.items.count == 2)
+    XCTAssert(self.viewModel.offset == 2)
+    XCTAssert(self.viewModel.maxItems == 4)
+
+    let completeLoadedItems = self.viewModel.loadInitialItems(pageSize: 4)
+    XCTAssert(completeLoadedItems.count == 4)
+    XCTAssert(self.viewModel.items.count == 4)
+    XCTAssert(self.viewModel.offset == 4)
+    XCTAssert(self.viewModel.maxItems == 4)
+  }
+
+  func testLoadingNextItems() {
+    self.subscription?.cancel()
+    let expectation = XCTestExpectation(description: "Item updates notification")
+
+    var loadedItems: [SimpleLibraryItem]!
+    self.subscription = self.viewModel.itemsUpdates.sink(receiveValue: { items in
+      loadedItems = items
+      expectation.fulfill()
+    })
+
+    self.viewModel.loadNextItems()
+    XCTAssert(loadedItems.count == 4)
+    XCTAssert(self.viewModel.items.count == 4)
+    XCTAssert(self.viewModel.offset == 4)
+    XCTAssert(self.viewModel.maxItems == 4)
+  }
+
+  func testLoadingNextItemsPagination() {
+    self.subscription?.cancel()
+    let expectation = XCTestExpectation(description: "Item updates notification")
+
+    var loadedItems: [SimpleLibraryItem]!
+    self.subscription = self.viewModel.itemsUpdates.sink(receiveValue: { items in
+      loadedItems = items
+      expectation.fulfill()
+    })
+
+    self.viewModel.loadNextItems(pageSize: 2)
+    XCTAssert(loadedItems.count == 2)
+    XCTAssert(self.viewModel.items.count == 2)
+    XCTAssert(self.viewModel.offset == 2)
+    XCTAssert(self.viewModel.maxItems == 4)
+
+    self.viewModel.loadNextItems(pageSize: 2)
+    XCTAssert(self.viewModel.items.count == 4)
+    XCTAssert(self.viewModel.offset == 4)
+    XCTAssert(self.viewModel.maxItems == 4)
+  }
+
+  func testLoadingAllItemsIfNeeded() {
+    self.subscription?.cancel()
+    let expectation = XCTestExpectation(description: "Item updates notification")
+
+    var loadedItems: [SimpleLibraryItem]!
+    self.subscription = self.viewModel.itemsUpdates.sink(receiveValue: { items in
+      loadedItems = items
+      expectation.fulfill()
+    })
+
+    self.viewModel.loadAllItemsIfNeeded()
+    XCTAssert(loadedItems.count == 4)
+    XCTAssert(self.viewModel.items.count == 4)
+    XCTAssert(self.viewModel.offset == 4)
+    XCTAssert(self.viewModel.maxItems == 4)
+  }
+}


### PR DESCRIPTION
## Bugfix

Select all wasn't selecting all the items, and it was getting items deselected after loading the next page

## Linear tasks

#663 

## Approach

- Keep a reference to selected items before reloading the table
- Separate the events to update from the actual variable (we now have two passthrough publishers, one for general updates, the other to update the current book progress)

## Screenshots


https://user-images.githubusercontent.com/14112819/140009639-5899bde4-4a48-4220-8cc1-85d78586bc86.mp4


