### PR TITLE
Timer option for end of chapter not working

### DIFF
--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -97,12 +97,11 @@ class PlayerViewController: BaseViewController<PlayerCoordinator, PlayerViewMode
 
     self.chapterTitleButton.titleLabel?.numberOfLines = 2
     self.chapterTitleButton.titleLabel?.textAlignment = .center
+    self.chapterTitleButton.titleLabel?.lineBreakMode = .byWordWrapping
   }
 
   func setupPlayerView(with currentBook: Book) {
     guard !currentBook.isFault else { return }
-
-    self.chapterTitleButton.titleLabel?.lineBreakMode = currentBook.hasChapters ? .byWordWrapping : .byCharWrapping
 
     self.artworkControl.setupInfo(with: currentBook)
 

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -106,7 +106,7 @@ class PlayerViewController: BaseViewController<PlayerCoordinator, PlayerViewMode
 
     self.artworkControl.setupInfo(with: currentBook)
 
-    self.updateView(with: self.viewModel.getCurrentProgressState())
+    self.updateView(with: self.viewModel.getCurrentProgressState(currentBook))
 
     applyTheme(self.themeProvider.currentTheme)
 

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -140,31 +140,33 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     return self.getCurrentProgressState()
   }
 
-  func getCurrentProgressState() -> ProgressObject {
+  func getCurrentProgressState(_ book: Book? = nil) -> ProgressObject {
     let currentTime = self.getBookCurrentTime()
     let maxTimeInContext = self.getBookMaxTime()
     let progress: String
     let sliderValue: Float
 
+    let currentBook = book ?? self.playerManager.currentBook
+
     if self.prefersChapterContext,
-       let currentBook = self.playerManager.currentBook,
+       let currentBook = currentBook,
        currentBook.hasChapters,
        let chapters = currentBook.chapters,
        let currentChapter = currentBook.currentChapter {
       progress = String.localizedStringWithFormat("player_chapter_description".localized, currentChapter.index, chapters.count)
       sliderValue = Float((currentBook.currentTime - currentChapter.start) / currentChapter.duration)
     } else {
-      progress = "\(Int(round((self.playerManager.currentBook?.progressPercentage ?? 0) * 100)))%"
-      sliderValue = Float(self.playerManager.currentBook?.progressPercentage ?? 0)
+      progress = "\(Int(round((currentBook?.progressPercentage ?? 0) * 100)))%"
+      sliderValue = Float(currentBook?.progressPercentage ?? 0)
     }
 
     // Update local chapter
-    self.chapterBeforeSliderValueChange = self.playerManager.currentBook?.currentChapter
+    self.chapterBeforeSliderValueChange = currentBook?.currentChapter
 
-    let prevChapterImageName = self.hasChapter(before: self.playerManager.currentBook?.currentChapter)
+    let prevChapterImageName = self.hasChapter(before: currentBook?.currentChapter)
     ? "chevron.left"
     : "chevron.left.2"
-    let nextChapterImageName = self.hasChapter(after: self.playerManager.currentBook?.currentChapter)
+    let nextChapterImageName = self.hasChapter(after: currentBook?.currentChapter)
     ? "chevron.right"
     : "chevron.right.2"
 
@@ -175,8 +177,8 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
       sliderValue: sliderValue,
       prevChapterImageName: prevChapterImageName,
       nextChapterImageName: nextChapterImageName,
-      chapterTitle: self.playerManager.currentBook?.currentChapter?.title
-      ?? self.playerManager.currentBook?.title
+      chapterTitle: currentBook?.currentChapter?.title
+      ?? currentBook?.title
       ?? ""
     )
   }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -552,38 +552,30 @@ extension PlayerManager {
   func playPreviousItem() {
     guard let previousBook = self.currentBook?.previousBook() else { return }
 
-    self.preload(previousBook)
-    self.load(previousBook, completion: { success in
-      guard success else { return }
-
-      let userInfo = ["book": previousBook]
-
-      NotificationCenter.default.post(name: .bookChange,
-                                      object: nil,
-                                      userInfo: userInfo)
-      // Resume playback if it's paused
-      if !self.isPlaying {
-        self.play()
-      }
-    })
+    self.playItem(previousBook)
   }
 
   func playNextItem(autoPlayed: Bool = false) {
     guard let nextBook = self.currentBook?.nextBook(autoplayed: autoPlayed) else { return }
 
-    self.preload(nextBook)
-    self.load(nextBook, completion: { success in
+    self.playItem(nextBook)
+  }
+
+  func playItem(_ book: Book) {
+    self.preload(book)
+    self.load(book, completion: { success in
       guard success else { return }
 
-      let userInfo = ["book": nextBook]
-
-      NotificationCenter.default.post(name: .bookChange,
-                                      object: nil,
-                                      userInfo: userInfo)
       // Resume playback if it's paused
       if !self.isPlaying {
         self.play()
       }
+
+      let userInfo = ["book": book]
+
+      NotificationCenter.default.post(name: .bookChange,
+                                      object: nil,
+                                      userInfo: userInfo)
     })
   }
 


### PR DESCRIPTION
## Bugfix

When a book ends, the sleep timer is pausing, but the player is playing up again the next file

## Approach

Send the `.bookChange` event after the play action

## Things to be aware of / Things to focus on

This PR also fixes a little UI glitch when changing books, the chapter title would not show the info right away

## Screenshots

https://user-images.githubusercontent.com/14112819/140084145-ded1b840-5072-47de-aab2-6d9532f5e464.mov



