### PR TITLE
Fix import process

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -120,18 +120,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TelemetryProtocol {
     // Handles audio file urls, like when receiving files through AirDrop
     // Also handles custom URL scheme 'bookplayer://'
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-      guard url.isFileURL else {
-        ActionParserService.process(url)
-        return true
-      }
-
-      guard let mainCoordinator = self.coordinator.getMainCoordinator(),
-            let libraryCoordinator = mainCoordinator.getLibraryCoordinator() else {
-        return true
-      }
-
-      libraryCoordinator.processFiles(urls: [url])
-
+      ActionParserService.process(url)
       return true
     }
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -20,7 +20,7 @@ class LibraryListCoordinator: ItemListCoordinator {
     viewModel.coordinator = self
     vc.viewModel = viewModel
     vc.navigationItem.largeTitleDisplayMode = .automatic
-    self.presentingViewController = vc
+    self.presentingViewController = self.navigationController
     self.navigationController.pushViewController(vc, animated: true)
     self.navigationController.delegate = self
     if let book = self.library.lastPlayedBook {

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -12,72 +12,84 @@ import Intents
 import TelemetryClient
 
 class ActionParserService {
-    public class func process(_ url: URL) {
-        guard let action = CommandParser.parse(url) else { return }
+  public class func process(_ url: URL) {
+    guard let action = CommandParser.parse(url) else { return }
 
-        self.handleAction(action)
+    self.handleAction(action)
+  }
+
+  public class func process(_ activity: NSUserActivity) {
+    guard let action = CommandParser.parse(activity) else { return }
+
+    self.handleAction(action)
+  }
+
+  public class func process(_ intent: INIntent) {
+    guard let action = CommandParser.parse(intent) else { return }
+
+    self.handleAction(action)
+  }
+
+  public class func handleAction(_ action: Action) {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+
+    appDelegate.coordinator.pendingURLActions.append(action)
+
+    guard let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else { return }
+
+    switch action.command {
+    case .play:
+      self.handlePlayAction(action)
+    case .download:
+      self.handleDownloadAction(action)
+    case .sleep:
+      self.handleSleepAction(action)
+    case .refresh:
+      mainCoordinator.watchConnectivityService.sendApplicationContext()
+      self.removeAction(action)
+    case .skipRewind:
+      mainCoordinator.playerManager.rewind()
+    case .skipForward:
+      mainCoordinator.playerManager.forward()
+    case .widget:
+      self.handleWidgetAction(action)
+    case .fileImport:
+      self.handleFileImportAction(action)
     }
 
-    public class func process(_ activity: NSUserActivity) {
-        guard let action = CommandParser.parse(activity) else { return }
-
-        self.handleAction(action)
+    // avoid registering actions not (necessarily) initiated by the user
+    if action.command != .refresh {
+      TelemetryManager.shared.send(TelemetrySignal.urlSchemeAction.rawValue, with: action.getParametersDictionary())
     }
+  }
 
-    public class func process(_ intent: INIntent) {
-        guard let action = CommandParser.parse(intent) else { return }
-
-        self.handleAction(action)
-    }
-
-    public class func handleAction(_ action: Action) {
-      guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
-
-      if !appDelegate.coordinator.pendingURLActions.contains(action) {
-        appDelegate.coordinator.pendingURLActions.append(action)
-      }
-
-      guard let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else { return }
-
-      switch action.command {
-      case .play:
-        self.handlePlayAction(action)
-      case .download:
-        self.handleDownloadAction(action)
-      case .sleep:
-        self.handleSleepAction(action)
-      case .refresh:
-        mainCoordinator.watchConnectivityService.sendApplicationContext()
-        self.removeAction(action)
-      case .skipRewind:
-        mainCoordinator.playerManager.rewind()
-      case .skipForward:
-        mainCoordinator.playerManager.forward()
-      case .widget:
-        self.handleWidgetAction(action)
-      }
-
-      // avoid registering actions not (necessarily) initiated by the user
-      if action.command != .refresh {
-        TelemetryManager.shared.send(TelemetrySignal.urlSchemeAction.rawValue, with: action.getParametersDictionary())
-      }
-    }
-
-    private class func handleSleepAction(_ action: Action) {
-        guard let value = action.getQueryValue(for: "seconds"),
-            let seconds = Double(value) else {
+  private class func handleFileImportAction(_ action: Action) {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+          let libraryCoordinator = appDelegate.coordinator.getMainCoordinator()?.getLibraryCoordinator(),
+          let urlString = action.getQueryValue(for: "url") else {
             return
-        }
+          }
 
-        switch seconds {
-        case -1:
-            SleepTimer.shared.reset()
-        case -2:
-            SleepTimer.shared.sleep(in: .endChapter)
-        default:
-            SleepTimer.shared.sleep(in: seconds)
-        }
+    let url = URL(fileURLWithPath: urlString)
+    self.removeAction(action)
+    libraryCoordinator.processFiles(urls: [url])
+  }
+
+  private class func handleSleepAction(_ action: Action) {
+    guard let value = action.getQueryValue(for: "seconds"),
+          let seconds = Double(value) else {
+            return
+          }
+
+    switch seconds {
+    case -1:
+      SleepTimer.shared.reset()
+    case -2:
+      SleepTimer.shared.sleep(in: .endChapter)
+    default:
+      SleepTimer.shared.sleep(in: seconds)
     }
+  }
 
   private class func handlePlayAction(_ action: Action) {
     guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
@@ -104,7 +116,7 @@ class ActionParserService {
     }
 
     if let loadedBook = mainCoordinator.playerManager.currentBook,
-       loadedBook.identifier == bookIdentifier {
+       loadedBook.relativePath == bookIdentifier {
       self.removeAction(action)
       mainCoordinator.playerManager.play()
       return
@@ -142,6 +154,8 @@ class ActionParserService {
       let sleepAction = Action(command: .sleep, parameters: action.parameters)
       self.handleAction(sleepAction)
     }
+
+    self.removeAction(action)
   }
 
   public class func removeAction(_ action: Action) {

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -1957,10 +1957,10 @@ second line</string>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F2n-b4-57S">
-                                <rect key="frame" x="15" y="89" width="355" height="16"/>
+                                <rect key="frame" x="15" y="89" width="344" height="16"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="FILES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jt5-NR-llg" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="292.5" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="303" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="Gha-dS-EpK"/>
                                         </constraints>
@@ -1972,9 +1972,9 @@ second line</string>
                                         </userDefinedRuntimeAttributes>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6d-Tb-whR">
-                                        <rect key="frame" x="292.5" y="0.0" width="62.5" height="16"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Fix All"/>
+                                        <rect key="frame" x="303" y="0.0" width="41" height="16"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Fix All"/>
                                     </button>
                                 </subviews>
                                 <constraints>
@@ -1993,7 +1993,7 @@ second line</string>
                         <color key="backgroundColor" red="0.93345028159999999" green="0.93702846770000003" blue="0.94902259109999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstItem="kHX-5q-lMZ" firstAttribute="leading" secondItem="B6j-AA-kzz" secondAttribute="leading" id="0Sb-cO-jxD"/>
-                            <constraint firstItem="fzw-Ck-HgH" firstAttribute="trailing" secondItem="F2n-b4-57S" secondAttribute="trailing" constant="5" id="0eq-JQ-3bJ"/>
+                            <constraint firstItem="fzw-Ck-HgH" firstAttribute="trailing" secondItem="F2n-b4-57S" secondAttribute="trailing" constant="16" id="0eq-JQ-3bJ"/>
                             <constraint firstItem="k0M-TZ-Hac" firstAttribute="trailing" secondItem="fzw-Ck-HgH" secondAttribute="trailing" id="2Fb-8Z-wEu"/>
                             <constraint firstItem="fzw-Ck-HgH" firstAttribute="bottom" secondItem="B6j-AA-kzz" secondAttribute="bottom" id="CwE-CD-CrH"/>
                             <constraint firstItem="F2n-b4-57S" firstAttribute="leading" secondItem="fzw-Ck-HgH" secondAttribute="leading" constant="15" id="F4t-uC-CdB"/>

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -10,118 +10,118 @@ import Foundation
 import Intents
 
 public class CommandParser {
-    public class func parse(_ activity: NSUserActivity) -> Action? {
-        if let intent = activity.interaction?.intent {
-            return self.parse(intent)
-        } else if activity.activityType == "\(Bundle.main.bundleIdentifier!).activity.playback" {
-            return Action(command: .play)
-        }
-
-        return nil
+  public class func parse(_ activity: NSUserActivity) -> Action? {
+    if let intent = activity.interaction?.intent {
+      return self.parse(intent)
+    } else if activity.activityType == "\(Bundle.main.bundleIdentifier!).activity.playback" {
+      return Action(command: .play)
     }
 
-    public class func parse(_ intent: INIntent) -> Action? {
-        if let sleepIntent = intent as? SleepTimerIntent {
-            var queryItem: URLQueryItem
+    return nil
+  }
 
-            if let seconds = sleepIntent.seconds {
-                queryItem = URLQueryItem(name: "seconds", value: seconds.stringValue)
-            } else {
-                let seconds = TimeParser.getSeconds(from: sleepIntent.option)
-                queryItem = URLQueryItem(name: "seconds", value: String(seconds))
-            }
+  public class func parse(_ intent: INIntent) -> Action? {
+    if let sleepIntent = intent as? SleepTimerIntent {
+      var queryItem: URLQueryItem
 
-            return Action(command: .sleep, parameters: [queryItem])
-        }
-
-        if intent is INPlayMediaIntent {
-            return Action(command: .play)
-        }
-
-        return nil
-    }
-
-    public class func parse(_ url: URL) -> Action? {
-        guard let host = url.host else {
-            return nil
-        }
-
-        guard let command = Command(rawValue: host) else { return nil }
-
-        if command == .download {
-            guard let query = url.query, let parameter = query.components(separatedBy: "url=").last else { return nil }
-
-            let paramURLstring = parameter.replacingOccurrences(of: "'", with: "").replacingOccurrences(of: "\"", with: "").replacingOccurrences(of: "%22", with: "")
-
-            let queryItem = URLQueryItem(name: "url", value: paramURLstring)
-
-            return Action(command: command, parameters: [queryItem])
-        }
-
-        var parameters = [URLQueryItem]()
-
-        if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-            let queryItems = components.queryItems {
-            parameters = queryItems
-        }
-
-        return Action(command: command, parameters: parameters)
-    }
-
-    public class func parse(_ message: [String: Any]) -> Action? {
-        guard let commandString = message["command"] as? String,
-            let command = Command(rawValue: commandString) else { return nil }
-
-        var dictionary = message
-        dictionary.removeValue(forKey: "command")
-
-        var parameters = [URLQueryItem]()
-
-        for (key, value) in dictionary {
-            guard let stringValue = value as? String else { continue }
-
-            let queryItem = URLQueryItem(name: key, value: stringValue)
-            parameters.append(queryItem)
-        }
-
-        return Action(command: command, parameters: parameters)
-    }
-
-    public class func createActionString(from command: Command, parameters: [URLQueryItem]) -> String {
-        var actionString = "bookplayer://\(command.rawValue)?"
-
-        actionString = parameters.reduce(actionString) { (text, item) -> String in
-            guard let value = item.value else { return text }
-
-            return "\(text)\(item.name)=\(value)&"
-        }
-
-        return actionString
-    }
-
-    public class func createWidgetActionString(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double) -> String {
-      var actionString = "bookplayer://widget?autoplay=\(autoplay)&seconds=\(timerSeconds)"
-
-      if let identifier = bookIdentifier {
-        actionString += "&identifier=\(identifier)"
+      if let seconds = sleepIntent.seconds {
+        queryItem = URLQueryItem(name: "seconds", value: seconds.stringValue)
+      } else {
+        let seconds = TimeParser.getSeconds(from: sleepIntent.option)
+        queryItem = URLQueryItem(name: "seconds", value: String(seconds))
       }
 
-      if let encodedActionString = actionString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-        actionString = encodedActionString
-      }
-
-      return actionString
+      return Action(command: .sleep, parameters: [queryItem])
     }
+
+    if intent is INPlayMediaIntent {
+      return Action(command: .play)
+    }
+
+    return nil
+  }
+
+  public class func parse(_ url: URL) -> Action? {
+    guard let host = url.host else {
+      return nil
+    }
+
+    guard let command = Command(rawValue: host) else { return nil }
+
+    if command == .download {
+      guard let query = url.query, let parameter = query.components(separatedBy: "url=").last else { return nil }
+
+      let paramURLstring = parameter.replacingOccurrences(of: "'", with: "").replacingOccurrences(of: "\"", with: "").replacingOccurrences(of: "%22", with: "")
+
+      let queryItem = URLQueryItem(name: "url", value: paramURLstring)
+
+      return Action(command: command, parameters: [queryItem])
+    }
+
+    var parameters = [URLQueryItem]()
+
+    if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+       let queryItems = components.queryItems {
+      parameters = queryItems
+    }
+
+    return Action(command: command, parameters: parameters)
+  }
+
+  public class func parse(_ message: [String: Any]) -> Action? {
+    guard let commandString = message["command"] as? String,
+          let command = Command(rawValue: commandString) else { return nil }
+
+    var dictionary = message
+    dictionary.removeValue(forKey: "command")
+
+    var parameters = [URLQueryItem]()
+
+    for (key, value) in dictionary {
+      guard let stringValue = value as? String else { continue }
+
+      let queryItem = URLQueryItem(name: key, value: stringValue)
+      parameters.append(queryItem)
+    }
+
+    return Action(command: command, parameters: parameters)
+  }
+
+  public class func createActionString(from command: Command, parameters: [URLQueryItem]) -> String {
+    var actionString = "bookplayer://\(command.rawValue)?"
+
+    actionString = parameters.reduce(actionString) { (text, item) -> String in
+      guard let value = item.value else { return text }
+
+      return "\(text)\(item.name)=\(value)&"
+    }
+
+    return actionString
+  }
+
+  public class func createWidgetActionString(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double) -> String {
+    var actionString = "bookplayer://widget?autoplay=\(autoplay)&seconds=\(timerSeconds)"
+
+    if let identifier = bookIdentifier {
+      actionString += "&identifier=\(identifier)"
+    }
+
+    if let encodedActionString = actionString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+      actionString = encodedActionString
+    }
+
+    return actionString
+  }
 }
 
 public enum Command: String {
-    case play
-    case download
-    case refresh
-    case skipRewind
-    case skipForward
-    case sleep
-    case widget
+  case play
+  case download
+  case refresh
+  case skipRewind
+  case skipForward
+  case sleep
+  case widget
 }
 
 public struct Action: Equatable {
@@ -153,53 +153,53 @@ public struct Action: Equatable {
 }
 
 public class TimeParser {
-    public class func getSeconds(from option: TimerOption) -> TimeInterval {
-        switch option {
-        case .cancel:
-            return -1
-        case .fiveMinutes:
-            return 300
-        case .tenMinutes:
-            return 600
-        case .fifteenMinutes:
-            return 900
-        case .thirtyMinutes:
-            return 1800
-        case .fortyFiveMinutes:
-            return 2700
-        case .oneHour:
-            return 3600
-        case .endChapter:
-            return -2
-        default:
-            return 0
-        }
+  public class func getSeconds(from option: TimerOption) -> TimeInterval {
+    switch option {
+    case .cancel:
+      return -1
+    case .fiveMinutes:
+      return 300
+    case .tenMinutes:
+      return 600
+    case .fifteenMinutes:
+      return 900
+    case .thirtyMinutes:
+      return 1800
+    case .fortyFiveMinutes:
+      return 2700
+    case .oneHour:
+      return 3600
+    case .endChapter:
+      return -2
+    default:
+      return 0
+    }
+  }
+
+  public class func getTimerOption(from seconds: TimeInterval) -> TimerOption {
+    var option: TimerOption
+
+    switch seconds {
+    case -1:
+      option = .cancel
+    case 300:
+      option = .fiveMinutes
+    case 600:
+      option = .tenMinutes
+    case 900:
+      option = .fifteenMinutes
+    case 1800:
+      option = .thirtyMinutes
+    case 2700:
+      option = .fortyFiveMinutes
+    case 3600:
+      option = .oneHour
+    default:
+      option = .endChapter
     }
 
-    public class func getTimerOption(from seconds: TimeInterval) -> TimerOption {
-        var option: TimerOption
-
-        switch seconds {
-        case -1:
-            option = .cancel
-        case 300:
-            option = .fiveMinutes
-        case 600:
-            option = .tenMinutes
-        case 900:
-            option = .fifteenMinutes
-        case 1800:
-            option = .thirtyMinutes
-        case 2700:
-            option = .fortyFiveMinutes
-        case 3600:
-            option = .oneHour
-        default:
-            option = .endChapter
-        }
-
-        return option
-    }
+    return option
+  }
 
   // utility function to transform seconds to format MM:SS or HH:MM:SS
   public class func formatTime(_ time: TimeInterval) -> String {

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -42,6 +42,10 @@ public class CommandParser {
   }
 
   public class func parse(_ url: URL) -> Action? {
+    if url.isFileURL {
+      return Action(command: .fileImport, parameters: [URLQueryItem(name: "url", value: url.path)])
+    }
+
     guard let host = url.host else {
       return nil
     }
@@ -122,6 +126,7 @@ public enum Command: String {
   case skipForward
   case sleep
   case widget
+  case fileImport
 }
 
 public struct Action: Equatable {


### PR DESCRIPTION
## Bugfix

Import screen is not shown when the app is launched by airdrop event

## Related tasks

#684 

## Approach

- Add a new action `fileImport` to the `ActionParserService` and route everything through there now. If the app hasn't loaded completely yet, this flow has a retry of all pending actions once the app loads
- There were two other issues, the first one, the presentingViewController was not the correct one, instead of using the navigation which is already in the hierarchy, the app was trying to use the ItemListVC that was just being pushed into the stack, making the presentation of the import screen fail. The second issue is that the events may have not been triggered if the files being added, were already loaded in-memory.