### PR TITLE
Refactor part of DataManager into LibraryService

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -313,6 +313,9 @@
 		6279361F272D0D110097837D /* MainCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6279361E272D0D110097837D /* MainCoordinatorTests.swift */; };
 		62AAE2252749283F001EB9FF /* MiniPlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE2242749283F001EB9FF /* MiniPlayerViewModelTests.swift */; };
 		62AAE22727492896001EB9FF /* PlayerManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22627492896001EB9FF /* PlayerManagerMock.swift */; };
+		62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
+		62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
+		62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */; };
 		62CADBA52725BCB200A4A98F /* AVAudioAssetImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624AB20A2724808600F6A486 /* AVAudioAssetImageDataProvider.swift */; };
 		62CADBA82725BCE800A4A98F /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 62CADBA72725BCE800A4A98F /* Kingfisher */; };
 		62CADBAA2725BCF000A4A98F /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 62CADBA92725BCF000A4A98F /* Kingfisher */; };
@@ -786,6 +789,8 @@
 		6279361E272D0D110097837D /* MainCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorTests.swift; sourceTree = "<group>"; };
 		62AAE2242749283F001EB9FF /* MiniPlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerViewModelTests.swift; sourceTree = "<group>"; };
 		62AAE22627492896001EB9FF /* PlayerManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerManagerMock.swift; sourceTree = "<group>"; };
+		62AAE22B274AA3EB001EB9FF /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
+		62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryServiceTests.swift; sourceTree = "<group>"; };
 		62CADB8D2724E41800A4A98F /* Audiobook Player 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 7.xcdatamodel"; sourceTree = "<group>"; };
 		62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportableItem.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
@@ -1190,6 +1195,7 @@
 		41A1B0F1226E9C5100EA0400 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				62AAE22F274AA6E9001EB9FF /* Services */,
 				C3AA3732207BF7670004DCFD /* CoreData */,
 				6279361B272CDA8A0097837D /* Artwork */,
 				41A1B106226E9DCA00EA0400 /* Extensions */,
@@ -1480,6 +1486,14 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		62AAE22F274AA6E9001EB9FF /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				62AAE22B274AA3EB001EB9FF /* LibraryService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		6906A551217211A300A9E0B2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -1508,6 +1522,7 @@
 			children = (
 				69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */,
 				6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */,
+				62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2182,6 +2197,7 @@
 				4138CE1726E584B60014F11E /* BookmarkType.swift in Sources */,
 				5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				419BD5992443FD04001E50A0 /* Intents.intentdefinition in Sources */,
+				62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */,
 				62CADBAF2725FE2C00A4A98F /* ArtworkService.swift in Sources */,
 				4140EA80227289D50009F794 /* Folder+CoreDataClass.swift in Sources */,
 				4140EA78227289BC0009F794 /* PlaybackRecord+CoreDataClass.swift in Sources */,
@@ -2375,6 +2391,7 @@
 				4137BBD4272DF540009ED9FE /* PlayerCoordinatorTests.swift in Sources */,
 				416A9D4B2743D51E00463621 /* StorageViewModelTests.swift in Sources */,
 				4137BBD2272DED79009ED9FE /* ItemListCoordinatorTests.swift in Sources */,
+				62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */,
 				6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */,
 				62AAE22727492896001EB9FF /* PlayerManagerMock.swift in Sources */,
 				6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */,
@@ -2395,6 +2412,7 @@
 				4138CE1626E584B60014F11E /* BookmarkType.swift in Sources */,
 				412AB7092701421600969618 /* ManualOrderMigrationUtils.swift in Sources */,
 				416AAC3423F515AF005AD04F /* String+BookPlayer.swift in Sources */,
+				62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */,
 				41A1B126226F88C500EA0400 /* LibraryItem+CoreDataProperties.swift in Sources */,
 				62CADBAB2725C23A00A4A98F /* ArtworkService.swift in Sources */,
 				41A1B128226F88C500EA0400 /* Library+CoreDataProperties.swift in Sources */,

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -48,9 +48,10 @@ class MainCoordinator: Coordinator {
     self.rootViewController.miniPlayerContainer.addSubview(miniPlayerVC.view)
     miniPlayerVC.didMove(toParent: self.rootViewController)
 
-    let library = (try? self.dataManager.getLibrary()) ?? self.dataManager.createLibrary()
+    let libraryService = LibraryService(dataManager: dataManager)
+    let library = libraryService.getLibrary()
 
-    if let currentTheme = try? dataManager.getLibraryCurrentTheme() {
+    if let currentTheme = try? libraryService.getLibraryCurrentTheme() {
       ThemeManager.shared.currentTheme = SimpleTheme(with: currentTheme)
     }
 

--- a/BookPlayer/Loading/LoadingViewModel.swift
+++ b/BookPlayer/Loading/LoadingViewModel.swift
@@ -103,7 +103,9 @@ class LoadingViewModel: BaseViewModel<LoadingCoordinator> {
 
       self?.setupDefaultState(dataManager: dataManager)
 
-      let library = (try? dataManager.getLibrary()) ?? dataManager.createLibrary()
+      let libraryService = LibraryService(dataManager: dataManager)
+
+      let library = libraryService.getLibrary()
 
       _ = dataManager.insertItems(from: files, into: nil, library: library)
 
@@ -160,7 +162,8 @@ class LoadingViewModel: BaseViewModel<LoadingCoordinator> {
     }
 
     // Load default theme into library if needed
-    let library = (try? dataManager.getLibrary()) ?? dataManager.createLibrary()
+    let libraryService = LibraryService(dataManager: dataManager)
+    let library = libraryService.getLibrary()
 
     if library.currentTheme == nil,
        let defaultTheme = dataManager.getTheme(with: "Default / Dark") {

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -96,7 +96,22 @@ final class StorageViewModel: BaseViewModel<StorageCoordinator>, ObservableObjec
   }
 
   public func getLibrarySize() -> String {
-    return DataManager.sizeOfItem(at: self.folderURL)
+    var folderSize: Int64 = 0
+
+    let enumerator = FileManager.default.enumerator(
+      at: self.folderURL,
+      includingPropertiesForKeys: [],
+      options: [.skipsHiddenFiles], errorHandler: { (url, error) -> Bool in
+        print("directoryEnumerator error at \(url): ", error)
+        return true
+      })!
+
+    for case let fileURL as URL in enumerator {
+      guard let fileAttributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path) else { continue }
+      folderSize += fileAttributes[FileAttributeKey.size] as? Int64 ?? 0
+    }
+
+    return ByteCountFormatter.string(fromByteCount: folderSize, countStyle: ByteCountFormatter.CountStyle.file)
   }
 
   public func observeFiles() -> AnyPublisher<[StorageItem]?, Never> {

--- a/BookPlayer/Settings/Themes Screen/ThemeManager.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemeManager.swift
@@ -26,7 +26,9 @@ final class ThemeManager: ThemeProvider {
 
       if let title = newValue.title,
          let storedTheme = self.dataManager.getTheme(with: title) {
-        self.dataManager.setCurrentTheme(storedTheme)
+        let libraryService = LibraryService(dataManager: dataManager)
+        let library = libraryService.getLibrary()
+        self.dataManager.setCurrentTheme(storedTheme, for: library)
       }
     }
   }

--- a/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
@@ -111,21 +111,7 @@ class ThemesViewController: UIViewController, TelemetryProtocol {
         self.extractedThemesTableView.reloadData()
     }
 
-    func extractTheme() {
-      /* Disabled at the moment
-        let vc = ItemSelectionViewController()
-
-        guard let books = DataManager.getBooks() else { return }
-
-        vc.items = books
-        vc.onItemSelected = { _ in }
-
-        let nav = AppNavigationController(rootViewController: vc)
-        self.present(nav, animated: true) {
-            self.extractedThemesTableView.reloadData()
-        }
-       **/
-    }
+    func extractTheme() {}
 
     @IBAction func sliderUpdated(_ sender: UISlider) {
         let lowerBounds: Float = 0.22

--- a/BookPlayer/Utils/Extensions/DataManager+BookPlayer.swift
+++ b/BookPlayer/Utils/Extensions/DataManager+BookPlayer.swift
@@ -137,20 +137,7 @@ extension DataManager {
     return response
   }
 
-  public func getExtractedThemes() -> [Theme] {
-    let library = try? self.getLibrary()
-    return library?.extractedThemes?.array as? [Theme] ?? []
-  }
-
-  public func addExtractedTheme(_ theme: Theme) {
-    guard let library = try? self.getLibrary() else { return }
-
-    library.addToExtractedThemes(theme)
-    self.saveContext()
-  }
-
-  public func setCurrentTheme(_ theme: Theme) {
-    guard let library = try? self.getLibrary() else { return }
+  public func setCurrentTheme(_ theme: Theme, for library: Library) {
     library.currentTheme = theme
     self.saveContext()
   }

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -20,7 +20,7 @@ class LibraryListCoordinatorTests: XCTestCase {
 
     self.libraryListCoordinator = LibraryListCoordinator(
       navigationController: UINavigationController(),
-      library: dataManager.createLibrary(),
+      library: StubFactory.library(dataManager: dataManager),
       playerManager: PlayerManagerMock(),
       importManager: ImportManager(dataManager: dataManager),
       dataManager: dataManager
@@ -89,7 +89,7 @@ class FolderListCoordinatorTests: XCTestCase {
 
     self.folderListCoordinator = FolderListCoordinator(
       navigationController: UINavigationController(),
-      library: dataManager.createLibrary(),
+      library: StubFactory.library(dataManager: dataManager),
       folder: try! StubFactory.folder(dataManager: dataManager, title: "folder 1"),
       playerManager: PlayerManagerMock(),
       importManager: ImportManager(dataManager: dataManager),

--- a/BookPlayerTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/SettingsCoordinatorTests.swift
@@ -20,7 +20,7 @@ class SettingsCoordinatorTests: XCTestCase {
 
     self.settingsCoordinator = SettingsCoordinator(
       dataManager: dataManager,
-      library: dataManager.createLibrary(),
+      library: StubFactory.library(dataManager: dataManager),
       navigationController: UINavigationController()
     )
     self.settingsCoordinator.start()

--- a/BookPlayerTests/ItemListViewModelTests.swift
+++ b/BookPlayerTests/ItemListViewModelTests.swift
@@ -21,7 +21,7 @@ class ItemListViewModelTests: XCTestCase {
     let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: "/dev/null"))
 
     self.sut = ItemListViewModel(folder: nil,
-                                 library: dataManager.createLibrary(),
+                                 library: StubFactory.library(dataManager: dataManager),
                                  playerManager: PlayerManagerMock(),
                                  dataManager: dataManager,
                                  themeAccent: .blue)

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1,0 +1,85 @@
+//
+//  LibraryServiceTests.swift
+//  BookPlayerTests
+//
+//  Created by Gianni Carlo on 11/21/21.
+//  Copyright © 2021 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import Combine
+import XCTest
+
+class LibraryServiceTests: XCTestCase {
+  var sut: LibraryService!
+
+  override func setUp() {
+    let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: "/dev/null"))
+    self.sut = LibraryService(dataManager: dataManager)
+  }
+
+  func testGetNewLibrary() {
+    let library = self.sut.getLibrary()
+    XCTAssert(library.items!.array.isEmpty)
+  }
+
+  func testGetExistingLibrary() {
+    let book = StubFactory.book(
+      dataManager: self.sut.dataManager,
+      title: "test-book1",
+      duration: 100
+    )
+
+    let newLibrary = self.sut.createLibrary()
+    newLibrary.insert(item: book)
+
+    let loadedLibrary = self.sut.getLibrary()
+    XCTAssert(!loadedLibrary.items!.array.isEmpty)
+  }
+
+  func testGetEmptyLibraryLastBook() {
+    let lastBook = try! self.sut.getLibraryLastBook()
+    XCTAssert(lastBook == nil)
+  }
+
+  func testGetLibraryLastBook() {
+    let book = StubFactory.book(
+      dataManager: self.sut.dataManager,
+      title: "test-book1",
+      duration: 100
+    )
+
+    let newLibrary = self.sut.createLibrary()
+    XCTAssert(newLibrary.lastPlayedBook == nil)
+    newLibrary.lastPlayedBook = book
+    newLibrary.insert(item: book)
+
+    self.sut.dataManager.saveContext()
+
+    let lastBook = try! self.sut.getLibraryLastBook()
+    XCTAssert(lastBook?.relativePath == book.relativePath)
+  }
+
+  func testGetEmptyLibraryCurrentTheme() {
+    let currentTheme = try! self.sut.getLibraryCurrentTheme()
+    XCTAssert(currentTheme == nil)
+  }
+
+  func testGetLibraryCurrentTheme() {
+    let theme = Theme(context: self.sut.dataManager.getContext())
+    theme.title = "theme-test"
+
+    let newLibrary = self.sut.createLibrary()
+    XCTAssert(newLibrary.currentTheme == nil)
+    newLibrary.currentTheme = theme
+
+    self.sut.dataManager.saveContext()
+
+    let currentTheme = try! self.sut.getLibraryCurrentTheme()
+    XCTAssert(currentTheme?.title == theme.title)
+  }
+}
+

--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -39,7 +39,7 @@ class StorageViewModelMissingFileTests: XCTestCase {
     let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: self.testPath))
 
     self.viewModel = StorageViewModel(dataManager: dataManager,
-                                      library: dataManager.createLibrary(),
+                                      library: StubFactory.library(dataManager: dataManager),
                                       folderURL: self.directoryURL)
   }
 

--- a/BookPlayerTests/Support/StubFactory.swift
+++ b/BookPlayerTests/Support/StubFactory.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 class StubFactory {
-  public class func book(dataManager: DataManager, title: String, duration: Double, metaDataTitle: String? = nil) -> Book {
+  public class func book(dataManager: DataManager, title: String, duration: Double) -> Book {
     let filename = "\(title).txt"
     let bookContents = "bookcontents".data(using: .utf8)!
     let processedFolder = DataManager.getProcessedFolderURL()
@@ -28,6 +28,7 @@ class StubFactory {
   }
 
   public class func library(dataManager: DataManager) -> Library {
-    return (try? dataManager.getLibrary()) ?? dataManager.createLibrary()
+    let libraryService = LibraryService(dataManager: dataManager)
+    return libraryService.getLibrary()
   }
 }

--- a/BookPlayerWidgetUI/LastPlayedWidgetView.swift
+++ b/BookPlayerWidgetUI/LastPlayedWidgetView.swift
@@ -26,9 +26,10 @@ struct PlayAndSleepProvider: IntentTimelineProvider {
         }
 
         let dataManager = DataManager(coreDataStack: stack)
+        let libraryService = LibraryService(dataManager: dataManager)
 
-        guard let lastPlayedBook = try? dataManager.getLibraryLastBook(),
-              let currentTheme = try? dataManager.getLibraryCurrentTheme() else {
+        guard let lastPlayedBook = try? libraryService.getLibraryLastBook(),
+              let currentTheme = try? libraryService.getLibraryCurrentTheme() else {
                 completion(self.placeholder(in: context))
                 return
               }
@@ -59,9 +60,10 @@ struct PlayAndSleepProvider: IntentTimelineProvider {
         }
 
         let dataManager = DataManager(coreDataStack: stack)
+        let libraryService = LibraryService(dataManager: dataManager)
 
-        guard let lastPlayedBook = try? dataManager.getLibraryLastBook(),
-              let currentTheme = try? dataManager.getLibraryCurrentTheme() else {
+        guard let lastPlayedBook = try? libraryService.getLibraryLastBook(),
+              let currentTheme = try? libraryService.getLibraryCurrentTheme() else {
                 completion(Timeline(entries: [], policy: .atEnd))
                 return
               }

--- a/BookPlayerWidgetUI/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgetUI/RecentBooksWidgetView.swift
@@ -28,9 +28,10 @@ struct RecentBooksProvider: IntentTimelineProvider {
       }
 
       let dataManager = DataManager(coreDataStack: stack)
+      let libraryService = LibraryService(dataManager: dataManager)
 
       guard let items = dataManager.getOrderedBooks(limit: self.numberOfBooks),
-            let currentTheme = try? dataManager.getLibraryCurrentTheme() else {
+            let currentTheme = try? libraryService.getLibraryCurrentTheme() else {
               completion(self.placeholder(in: context))
               return
             }
@@ -60,9 +61,10 @@ struct RecentBooksProvider: IntentTimelineProvider {
       }
 
       let dataManager = DataManager(coreDataStack: stack)
+      let libraryService = LibraryService(dataManager: dataManager)
 
       guard let items = dataManager.getOrderedBooks(limit: self.numberOfBooks),
-            let currentTheme = try? dataManager.getLibraryCurrentTheme() else {
+            let currentTheme = try? libraryService.getLibraryCurrentTheme() else {
               completion(Timeline(entries: [], policy: .atEnd))
               return
             }

--- a/BookPlayerWidgetUI/TimeListened/TimeListenedWidgetView.swift
+++ b/BookPlayerWidgetUI/TimeListened/TimeListenedWidgetView.swift
@@ -38,8 +38,10 @@ struct TimeListenedProvider: IntentTimelineProvider {
       var title: String?
       var theme: SimpleTheme?
 
-      if let lastPlayedBook = try? dataManager.getLibraryLastBook(),
-         let currentTheme = try? dataManager.getLibraryCurrentTheme() {
+      let libraryService = LibraryService(dataManager: dataManager)
+
+      if let lastPlayedBook = try? libraryService.getLibraryLastBook(),
+         let currentTheme = try? libraryService.getLibraryCurrentTheme() {
         title = lastPlayedBook.title
         theme = SimpleTheme(with: currentTheme)
       }
@@ -79,8 +81,10 @@ struct TimeListenedProvider: IntentTimelineProvider {
       var title: String?
       var theme: SimpleTheme?
 
-      if let lastPlayedBook = try? dataManager.getLibraryLastBook(),
-         let currentTheme = try? dataManager.getLibraryCurrentTheme() {
+      let libraryService = LibraryService(dataManager: dataManager)
+
+      if let lastPlayedBook = try? libraryService.getLibraryLastBook(),
+         let currentTheme = try? libraryService.getLibraryCurrentTheme() {
         title = lastPlayedBook.title
         theme = SimpleTheme(with: currentTheme)
       }

--- a/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
@@ -24,10 +24,6 @@ public class Book: LibraryItem {
         self.folder?.resetCachedProgress()
     }
 
-    var displayTitle: String {
-        return self.title
-    }
-
     public override var progress: Double {
         guard self.duration > 0 else { return 0 }
 

--- a/Shared/CoreData/Migrations/ManualOrderMigrationUtils.swift
+++ b/Shared/CoreData/Migrations/ManualOrderMigrationUtils.swift
@@ -11,8 +11,10 @@ import Foundation
 
 extension DataMigrationManager {
   func migrateLibraryOrder(dataManager: DataManager) {
-    guard let library = try? dataManager.getLibrary(),
-          let items = library.items?.array as? [LibraryItem] else { return }
+    let libraryService = LibraryService(dataManager: dataManager)
+    let library = libraryService.getLibrary()
+    
+    guard let items = library.items?.array as? [LibraryItem] else { return }
 
     for (index, item) in items.enumerated() {
       item.orderRank = Int16(index)

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1,0 +1,70 @@
+//
+//  LibraryService.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 11/21/21.
+//  Copyright © 2021 Tortuga Power. All rights reserved.
+//
+
+import CoreData
+import Foundation
+import UIKit
+
+public protocol LibraryServiceProtocol {
+  func getLibrary() -> Library
+  func getLibraryLastBook() throws -> Book?
+}
+
+public final class LibraryService {
+  let dataManager: DataManager
+
+  public init(dataManager: DataManager) {
+    self.dataManager = dataManager
+  }
+
+  /**
+   Gets the library for the App. There should be only one Library object at all times
+   */
+  public func getLibrary() -> Library {
+    let context = self.dataManager.getContext()
+    let fetch: NSFetchRequest<Library> = Library.fetchRequest()
+    fetch.returnsObjectsAsFaults = false
+
+    return (try? context.fetch(fetch).first) ?? self.createLibrary()
+  }
+
+  func createLibrary() -> Library {
+    let context = self.dataManager.getContext()
+    let library = Library.create(in: context)
+    self.dataManager.saveContext()
+    return library
+  }
+
+  public func getLibraryLastBook() throws -> Book? {
+    let context = self.dataManager.getContext()
+    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Library")
+    fetchRequest.propertiesToFetch = ["lastPlayedBook"]
+    fetchRequest.resultType = .dictionaryResultType
+
+    guard let dict = try context.fetch(fetchRequest).first as? [String: NSManagedObjectID],
+          let lastPlayedBookId = dict["lastPlayedBook"] else {
+      return nil
+    }
+
+    return try? context.existingObject(with: lastPlayedBookId) as? Book
+  }
+
+  public func getLibraryCurrentTheme() throws -> Theme? {
+    let context = self.dataManager.getContext()
+    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Library")
+    fetchRequest.propertiesToFetch = ["currentTheme"]
+    fetchRequest.resultType = .dictionaryResultType
+
+    guard let dict = try context.fetch(fetchRequest).first as? [String: NSManagedObjectID],
+          let themeId = dict["currentTheme"] else {
+            return self.dataManager.getTheme(with: "Default / Dark")
+          }
+
+    return try? context.existingObject(with: themeId) as? Theme
+  }
+}


### PR DESCRIPTION
## Purpose

This is the first part of refactoring the entire DataManager class into multiple services that use DataManager to access the CoreData layer

## Approach

- Create `LibraryService` and move `getLibrary()`, `createLibrary()`, `getLibraryLastBook()`, `getLibraryCurrentTheme()` into it

## Things to be aware of / Things to focus on

More functionality may be added to this new class in the future as the refactor goes on
