### PR TITLE
Add inbox urls as part of the clean-up of pending files

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -412,6 +412,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
 
   func notifyPendingFiles() {
     let documentsFolder = DataManager.getDocumentsFolderURL()
+    let inboxFolder = DataManager.getInboxFolderURL()
 
     // Get reference of all the files located inside the Documents folder
     guard let urls = try? FileManager.default.contentsOfDirectory(at: documentsFolder, includingPropertiesForKeys: nil, options: .skipsSubdirectoryDescendants) else {
@@ -419,9 +420,14 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     }
 
     // Filter out Processed and Inbox folders from file URLs.
-    let filteredUrls = urls.filter {
+    var filteredUrls = urls.filter {
       $0.lastPathComponent != DataManager.processedFolderName
       && $0.lastPathComponent != DataManager.inboxFolderName
+    }
+
+    // Consider items in the Inbox folder
+    if let inboxUrls = try? FileManager.default.contentsOfDirectory(at: inboxFolder, includingPropertiesForKeys: nil, options: .skipsSubdirectoryDescendants) {
+      filteredUrls += inboxUrls
     }
 
     guard !filteredUrls.isEmpty else { return }

--- a/BookPlayer/Player/SleepTimer.swift
+++ b/BookPlayer/Player/SleepTimer.swift
@@ -22,7 +22,7 @@ final class SleepTimer {
 
   @Published private var timeLeft: TimeInterval = 0.0
 
-  private let defaultMessage: String = "player_sleep_title".localized
+  private let defaultMessage: String
   private let intervals: [TimeInterval] = [
     300.0,
     600.0,
@@ -59,6 +59,7 @@ final class SleepTimer {
   // MARK: Internals
 
   private init() {
+    self.defaultMessage = "player_sleep_title".localized
     self.durationFormatter.unitsStyle = .positional
     self.durationFormatter.allowedUnits = [.minute, .second]
     self.durationFormatter.collapsesLargestUnit = true

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -40,6 +40,22 @@ public class DataManager {
     return processedFolderURL
   }
 
+  public class func getInboxFolderURL() -> URL {
+    let documentsURL = self.getDocumentsFolderURL()
+
+    let inboxFolderURL = documentsURL.appendingPathComponent(self.inboxFolderName)
+
+    if !FileManager.default.fileExists(atPath: inboxFolderURL.path) {
+      do {
+        try FileManager.default.createDirectory(at: inboxFolderURL, withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        fatalError("Couldn't create Inbox folder")
+      }
+    }
+
+    return inboxFolderURL
+  }
+
   public func getContext() -> NSManagedObjectContext {
     return self.coreDataStack.managedContext
   }


### PR DESCRIPTION
## Bugfix

If an import operation fails (via Airdrop), or no action is taken and the app is force closed, the files remain in the Inbox folder

## Related tasks

#707 

## Approach

Add the inbox folder contents into the notifyPendingFiles that runs on every app launch to handle,

## Things to be aware of / Things to focus on

Even though Inbox is a folder created by the system, it is not cleared with time automatically

## Screenshots

https://user-images.githubusercontent.com/14112819/145378308-ccba6d71-a867-42a3-ac9b-c2a3418e2df5.mov

