### PR TITLE
Fix loading chapters for m4b files

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -173,10 +173,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       NotificationCenter.default.post(name: .chapterChange, object: nil, userInfo: nil)
 
       // avoid loading the same item if it's already loaded
-      if let currentItem = self?.currentItem,
-         !currentItem.useChapterTimeContext,
-         let playingURL = (self?.audioPlayer.currentItem?.asset as? AVURLAsset)?.url,
-         currentItem.fileURL == playingURL {
+      if let playingURL = (self?.audioPlayer.currentItem?.asset as? AVURLAsset)?.url,
+         chapter.fileURL == playingURL {
         return
       }
 

--- a/Shared/CoreData/Lightweight-Models/PlayableChapter.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableChapter.swift
@@ -19,6 +19,10 @@ public struct PlayableChapter: Codable {
   public var end: TimeInterval {
     return start + duration
   }
+
+  public var fileURL: URL {
+    return DataManager.getProcessedFolderURL().appendingPathComponent(self.relativePath)
+  }
 }
 
 extension PlayableChapter: Equatable {

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -28,6 +28,10 @@ public final class PlayableItem: NSObject {
     return self.currentTime / self.duration
   }
 
+  public var fileURL: URL {
+    return DataManager.getProcessedFolderURL().appendingPathComponent(self.relativePath)
+  }
+
   enum CodingKeys: String, CodingKey {
     case title, author, chapters, currentTime, duration, relativePath, percentCompleted, isFinished, useChapterTimeContext
   }


### PR DESCRIPTION
## Bugfix

m4b books keeps looping on chapter change

## Related tasks

#716

## Approach

Avoid reloading the same file on chapter change (this is only needed for mp3 volumes)
