### PR TITLE
Clear out smart rewind key after book/chapter finishes

### DIFF
--- a/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
@@ -141,7 +141,7 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
         case .success(let value):
           self.artworkImage.image = value.image
           self.artworkImage.isHidden = false
-        case .failure(_):
+        case .failure:
           self.artworkImage.image = nil
           self.artworkImage.isHidden = true
         }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -217,7 +217,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
           switch result {
           case .success(let value):
             image = value.image
-          case .failure(_):
+          case .failure:
             image = ArtworkService.generateDefaultArtwork(from: ThemeManager.shared.currentTheme.linkColor)!
           }
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -636,6 +636,10 @@ extension PlayerManager {
   func playerDidFinishPlaying(_ notification: Notification) {
     guard let currentItem = self.currentItem else { return }
 
+    // Clear out smart rewind key from finished item
+    let lastPauseTimeKey = "\(Constants.UserDefaults.lastPauseTime)_\(currentItem.relativePath)"
+    UserDefaults.standard.set(nil, forKey: lastPauseTimeKey)
+
     // Stop book/chapter change if the EOC sleep timer is active
     if SleepTimer.shared.isEndChapterActive() {
       NotificationCenter.default.post(name: .bookEnd, object: nil)

--- a/BookPlayer/Player/SpeedManager.swift
+++ b/BookPlayer/Player/SpeedManager.swift
@@ -40,7 +40,7 @@ class SpeedManager {
 
   public func getSpeed(relativePath: String?) -> Float {
     let speed: Float
-    
+
     if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue) {
       speed = UserDefaults.standard.float(forKey: "global_speed")
     } else if let relativePath = relativePath {
@@ -48,9 +48,9 @@ class SpeedManager {
     } else {
       speed = self.currentSpeed.value
     }
-    
+
     self.currentSpeed.value = speed > 0 ? speed : 1.0
-    
+
     return self.currentSpeed.value
   }
 

--- a/BookPlayer/Player/SpeedManager.swift
+++ b/BookPlayer/Player/SpeedManager.swift
@@ -13,10 +13,10 @@ import Foundation
 class SpeedManager {
   private let libraryService: LibraryServiceProtocol
   let speedOptions: [Float] = [
-    3.5, 3.4, 3.3, 3.2, 3.1, 3,
-    2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2,
-    1.9, 1.8, 1.75, 1.7, 1.6, 1.5, 1.4, 1.3, 1.25, 1.2, 1.15, 1.1, 1,
-    0.9, 0.8, 0.75, 0.7, 0.6, 0.5
+    0.5, 0.6, 0.7, 0.75, 0.8, 0.9,
+    1, 1.1, 1.15, 1.2, 1.25, 1.3, 1.4, 1.5, 1.6, 1.7, 1.75, 1.8, 1.9,
+    2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
+    3, 3.1, 3.2, 3.3, 3.4, 3.5
   ]
 
   public private(set) var currentSpeed = CurrentValueSubject<Float, Never>(1.0)

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -159,7 +159,7 @@ final class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableCon
       switch result {
       case .success(let value):
         image = value.image
-      case .failure(_):
+      case .failure:
         image = self.defaultArtwork
       }
 

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1163,7 +1163,7 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     XCTAssert(book.lastPlayDate == now)
   }
-  
+
   func testGetItemSpeec() throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
@@ -1172,26 +1172,26 @@ class ModifyLibraryTests: LibraryServiceTests {
     )
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
     try self.sut.moveItems([book], inside: folder.relativePath, moveFiles: true)
-    
+
     XCTAssert(book.speed == 1.0)
     XCTAssert(folder.speed == 1.0)
-    
+
     let speed0 = self.sut.getItemSpeed(at: "")
-    
+
     XCTAssert(speed0 == 1.0)
-    
+
     let speed1 = self.sut.getItemSpeed(at: book.relativePath)
-    
+
     XCTAssert(speed1 == 1.0)
-    
+
     self.sut.updateBookSpeed(at: book.relativePath, speed: 3.0)
-    
+
     let speed2 = self.sut.getItemSpeed(at: book.relativePath)
-    
+
     XCTAssert(speed2 == 3.0)
-    
+
     let speed3 = self.sut.getItemSpeed(at: folder.relativePath)
-    
+
     XCTAssert(speed3 == 3.0)
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -373,10 +373,10 @@ public final class LibraryService: LibraryServiceProtocol {
 
     self.dataManager.saveContext()
   }
-  
+
   public func getItemSpeed(at relativePath: String) -> Float {
     guard let item = self.getItem(with: relativePath) else { return 1.0 }
-    
+
     return item.folder?.speed ?? item.speed
   }
 


### PR DESCRIPTION
## Bugfix

After a book finishes, the rewind date should be cleared to avoid a rewinding on a finished book or chapter

## Related tasks

#721
