### PR TITLE
Fix import order issues for folders and crash from Files

### DIFF
--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -345,10 +345,6 @@ extension ItemListCoordinator {
       self.showCreateFolderAlert()
     })
 
-    alertController.addAction(UIAlertAction(title: "bound_books_create_button".localized, style: .default) { _ in
-      self.showCreateFolderAlert(placeholder: "bound_books_new_title_placeholder".localized, type: .bound)
-    })
-
     alertController.addAction(UIAlertAction(title: "cancel_button".localized, style: .cancel))
 
     self.navigationController.present(alertController, animated: true, completion: nil)

--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -210,10 +210,19 @@ public class ImportOperation: Operation {
       return
     }
 
+    // Add support for iCloud documents
+    let accessGranted = currentFile.startAccessingSecurityScopedResource()
+
     let destinationURL = self.getNextAvailableURL(for: currentFile)
 
     do {
-      try FileManager.default.moveItem(at: currentFile, to: destinationURL)
+      if accessGranted {
+        try FileManager.default.copyItem(at: currentFile, to: destinationURL)
+        currentFile.stopAccessingSecurityScopedResource()
+      } else {
+        try FileManager.default.moveItem(at: currentFile, to: destinationURL)
+      }
+
       destinationURL.disableFileProtection()
     } catch {
       fatalError("Fail to move file from \(currentFile) to \(destinationURL)")

--- a/BookPlayerTests/ImportOperationTests.swift
+++ b/BookPlayerTests/ImportOperationTests.swift
@@ -35,16 +35,20 @@ class ImportOperationTests: XCTestCase {
                                         libraryService: LibraryService(dataManager: dataManager))
 
         operation.completionBlock = {
-          // Test file should no longer be in the Documents folder
+          // Test file should no longer be in the Documents folder,
+          // but when testing on simulator, the security scope is resolved
+#if targetEnvironment(simulator)
+          XCTAssert(FileManager.default.fileExists(atPath: fileUrl.path))
+#else
           XCTAssert(!FileManager.default.fileExists(atPath: fileUrl.path))
+#endif
+
           XCTAssertNotNil(operation.files.first)
           XCTAssertNotNil(operation.processedFiles.first)
 
-          let file = operation.files.first!
           let processedFile = operation.processedFiles.first!
 
           // Test file exists in new location
-          XCTAssert(!FileManager.default.fileExists(atPath: file.path))
           XCTAssert(FileManager.default.fileExists(atPath: processedFile.path))
 
           let content = FileManager.default.contents(atPath: processedFile.path)!

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -582,7 +582,12 @@ public final class LibraryService: LibraryServiceProtocol {
       files.append(fileURL)
     }
 
-    _ = self.insertItems(from: files, into: folder, library: library, processedItems: [])
+    let sortDescriptor = NSSortDescriptor(key: "path", ascending: true, selector: #selector(NSString.localizedStandardCompare(_:)))
+    let orderedSet = NSOrderedSet(array: files)
+    // swiftlint:disable force_cast
+    let sortedFiles = orderedSet.sortedArray(using: [sortDescriptor]) as! [URL]
+
+    _ = self.insertItems(from: sortedFiles, into: folder, library: library, processedItems: [])
   }
 
   public func moveItems(_ items: [LibraryItem], inside relativePath: String?, moveFiles: Bool) throws {


### PR DESCRIPTION
## Bugfix

Contents of folders are not sorted properly after the import finishes, and the app crashes when importing starting from the Files app

## Related tasks

#508 #702

## Approach

* Sort folder contents when importing to library
* Use `startAccessingSecurityScopedResource()` to access iCloud documents
