### PR TITLE
Fix playback loop when using airplay 1

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -253,6 +253,12 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
     var currentTime = CMTimeGetSeconds(self.audioPlayer.currentTime())
 
+    // When using devices with AirPlay 1,
+    // `currentTime` can be negative when switching chapters
+    if currentTime < 0 {
+      currentTime = 0.05
+    }
+
     if currentItem.useChapterTimeContext {
       currentTime += currentItem.currentChapter.start
     }


### PR DESCRIPTION
## Bugfix

When connected to devices via AirPlay 1, there's a playback loop when a chapter ends when listening to multi-part books

## Approach

The player was for some reason, showing a current time less than 0, which resulted in the book to scrub back to the previous chapter, creating the loop
