### PR TITLE
Chapter title not updating in control center

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -168,7 +168,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     self.playableChapterSubscription = item.$currentChapter.sink { [weak self] chapter in
       guard let chapter = chapter else { return }
 
-      self?.setNowPlayingBookTitle()
+      self?.setNowPlayingBookTitle(chapter: chapter)
       NotificationCenter.default.post(name: .chapterChange, object: nil, userInfo: nil)
 
       // avoid loading the same item if it's already loaded
@@ -207,7 +207,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
           MPNowPlayingInfoPropertyDefaultPlaybackRate: self.speedManager.getSpeed(relativePath: chapter.relativePath)
         ]
 
-        self.setNowPlayingBookTitle()
+        self.setNowPlayingBookTitle(chapter: chapter)
         self.setNowPlayingBookTime()
 
         ArtworkService.retrieveImageFromCache(for: chapter.relativePath) { result in
@@ -346,10 +346,10 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
   }
 
-  func setNowPlayingBookTitle() {
+  func setNowPlayingBookTitle(chapter: PlayableChapter) {
     guard let currentItem = self.currentItem else { return }
 
-    self.nowPlayingInfo[MPMediaItemPropertyTitle] = currentItem.currentChapter.title
+    self.nowPlayingInfo[MPMediaItemPropertyTitle] = chapter.title
     self.nowPlayingInfo[MPMediaItemPropertyArtist] = currentItem.title
     self.nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = currentItem.author
   }
@@ -464,7 +464,7 @@ extension PlayerManager {
     // Set last Play date
     self.libraryService.updateBookLastPlayDate(at: currentItem.relativePath, date: Date())
 
-    self.setNowPlayingBookTitle()
+    self.setNowPlayingBookTitle(chapter: currentItem.currentChapter)
 
     DispatchQueue.main.async {
       NotificationCenter.default.post(name: .bookPlayed, object: nil, userInfo: ["book": currentItem])


### PR DESCRIPTION
## Bugfix

For m4b files, when the chapter changes, the title is not getting updated until playback is paused and resumed

## Linear tasks

https://linear.app/bookplayer/issue/BKPLY-76/chapter-title-in-control-center-not-updating-for-m4b

## Approach

- Pass the new chapter to the `setNowPlayingBookTitle` function

## Screenshots

https://user-images.githubusercontent.com/14112819/152273645-b394d8a2-2b96-47a5-b392-4a502f74de06.mov


