### PR TITLE
Adjust remaining time based on the selected speed rate

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		9F64C6212793C31600B2493C /* PlayerControlsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */; };
 		9F64C6242793C3DA00B2493C /* PlayerControlsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */; };
 		9F64C6262793D5B100B2493C /* PlayerControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */; };
+		9F8A9A5E27AC3F8C0093AA1C /* PlayableItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */; };
 		9FC7101A27961C940058504C /* SpeedManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC7101927961C940058504C /* SpeedManagerMock.swift */; };
 		C30B66AE20E2D8CF00FC0030 /* ArtworkControl.xib in Resources */ = {isa = PBXBuildFile; fileRef = C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */; };
 		C318D3AD208CF624000666F8 /* PlayerJumpIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C318D3AC208CF624000666F8 /* PlayerJumpIcon.swift */; };
@@ -822,6 +823,7 @@
 		9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsCoordinator.swift; sourceTree = "<group>"; };
 		9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewModel.swift; sourceTree = "<group>"; };
 		9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewController.swift; sourceTree = "<group>"; };
+		9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayableItemTests.swift; sourceTree = "<group>"; };
 		9FC7101927961C940058504C /* SpeedManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedManagerMock.swift; sourceTree = "<group>"; };
 		C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BookPlayer.swift"; sourceTree = "<group>"; };
 		C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ArtworkControl.xib; sourceTree = "<group>"; };
@@ -1185,6 +1187,7 @@
 				41C2340B27324AB7006BC7B8 /* ItemListViewModelTests.swift */,
 				416A9D4A2743D51E00463621 /* StorageViewModelTests.swift */,
 				62AAE2242749283F001EB9FF /* MiniPlayerViewModelTests.swift */,
+				9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */,
 				6279361D272D0CF50097837D /* Coordinators */,
 				418B6D141D2707F800F974FB /* Info.plist */,
 			);
@@ -2428,6 +2431,7 @@
 				9FC7101A27961C940058504C /* SpeedManagerMock.swift in Sources */,
 				4137BBD0272DEBEC009ED9FE /* LoadingCoordinatorTests.swift in Sources */,
 				41A1B13E226FEF8000EA0400 /* DataTestUtils.swift in Sources */,
+				9F8A9A5E27AC3F8C0093AA1C /* PlayableItemTests.swift in Sources */,
 				4163E313214AC43000072AA2 /* ImportOperationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -342,11 +342,20 @@ extension PlayerViewController {
       self.setupPlayerView(with: item)
     }.store(in: &disposeBag)
 
-    self.viewModel.currentSpeedObserver().sink { [weak self] speed in
+    self.viewModel.currentSpeedObserver()
+      .removeDuplicates()
+      .sink { [weak self] speed in
       guard let self = self else { return }
 
       self.speedButton.title = self.formatSpeed(speed)
       self.speedButton.accessibilityLabel = String(describing: self.formatSpeed(speed) + " \("speed_title".localized)")
+
+      // Only update progress if the player is in pause state
+      guard !self.playIconView.isPlaying else { return }
+
+      let progressObject = self.viewModel.getCurrentProgressState()
+
+      self.updateView(with: progressObject)
     }.store(in: &disposeBag)
   }
 }

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -273,7 +273,11 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func getBookMaxTime() -> TimeInterval {
-    return self.playerManager.currentItem?.maxTimeInContext(self.prefersChapterContext, self.prefersRemainingTime) ?? 0
+    return self.playerManager.currentItem?.maxTimeInContext(
+      prefersChapterContext: self.prefersChapterContext,
+      prefersRemainingTime: self.prefersRemainingTime,
+      at: self.playerManager.getCurrentSpeed()
+    ) ?? 0
   }
 
   func getBookTimeFromSlider(value: Float) -> TimeInterval {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -359,7 +359,11 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
     let prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
     let currentTimeInContext = currentItem.currentTimeInContext(prefersChapterContext)
-    let maxTimeInContext = currentItem.maxTimeInContext(prefersChapterContext, false)
+    let maxTimeInContext = currentItem.maxTimeInContext(
+      prefersChapterContext: prefersChapterContext,
+      prefersRemainingTime: false,
+      at: self.getCurrentSpeed()
+    )
 
     self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = self.speedManager.getSpeed(relativePath: currentItem.relativePath)
     self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTimeInContext

--- a/BookPlayerTests/PlayableItemTests.swift
+++ b/BookPlayerTests/PlayableItemTests.swift
@@ -1,0 +1,86 @@
+//
+//  PlayableItemTests.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 3/2/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import Combine
+import XCTest
+
+class PlayableItemTests: XCTestCase {
+  var sut: PlayableItem!
+
+  private func generatePlayableItem() {
+
+  }
+
+  override func setUp() {
+    let testChapter = PlayableChapter(
+      title: "test chapter",
+      author: "test author",
+      start: 0,
+      duration: 50,
+      relativePath: "",
+      index: 1
+    )
+    let testChapter2 = PlayableChapter(
+      title: "test chapter2",
+      author: "test author",
+      start: 51,
+      duration: 100,
+      relativePath: "",
+      index: 1
+    )
+    self.sut = PlayableItem(
+      title: "test book",
+      author: "test author",
+      chapters: [testChapter, testChapter2],
+      currentTime: 0,
+      duration: 100,
+      relativePath: "",
+      percentCompleted: 10,
+      isFinished: false,
+      useChapterTimeContext: false
+    )
+  }
+
+  func testMaxTimeInContext() {
+    let totalDurationInChapter = sut.maxTimeInContext(
+      prefersChapterContext: true,
+      prefersRemainingTime: false,
+      at: 2
+    )
+
+    XCTAssert(totalDurationInChapter == 50)
+
+    let totalDurationInBook = sut.maxTimeInContext(
+      prefersChapterContext: false,
+      prefersRemainingTime: false,
+      at: 2
+    )
+
+    XCTAssert(totalDurationInBook == 100)
+
+    let remainingTimeInChapter = sut.maxTimeInContext(
+      prefersChapterContext: true,
+      prefersRemainingTime: true,
+      at: 2
+    )
+
+    XCTAssert(remainingTimeInChapter == -25)
+
+    let remainingTimeInBook = sut.maxTimeInContext(
+      prefersChapterContext: false,
+      prefersRemainingTime: true,
+      at: 2
+    )
+
+    XCTAssert(remainingTimeInBook == -50)
+  }
+}

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1164,7 +1164,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(book.lastPlayDate == now)
   }
 
-  func testGetItemSpeec() throws {
+  func testGetItemSpeed() throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -91,18 +91,26 @@ public final class PlayableItem: NSObject {
     : self.currentTime
   }
 
-  public func maxTimeInContext(_ prefersChapterContext: Bool, _ prefersRemainingTime: Bool) -> TimeInterval {
+  public func maxTimeInContext(
+    prefersChapterContext: Bool,
+    prefersRemainingTime: Bool,
+    at speedRate: Float
+  ) -> TimeInterval {
     guard prefersChapterContext else {
-      return prefersRemainingTime
-      ? self.currentTimeInContext(prefersChapterContext) - self.duration
-      : self.duration
+      if prefersRemainingTime {
+        let time = self.currentTimeInContext(prefersChapterContext) - self.duration
+        return time / Double(speedRate)
+      } else {
+        return self.duration
+      }
     }
 
-    let time = prefersRemainingTime
-    ? self.currentTimeInContext(prefersChapterContext) - self.currentChapter.duration
-    : self.currentChapter.duration
-
-    return time
+    if prefersRemainingTime {
+      let time = self.currentTimeInContext(prefersChapterContext) - self.currentChapter.duration
+      return time / Double(speedRate)
+    } else {
+      return self.currentChapter.duration
+    }
   }
 
   public func durationTimeInContext(_ prefersChapterContext: Bool) -> TimeInterval {


### PR DESCRIPTION
## Purpose

Adjust remaining time based on the selected speed rate

## Related tasks

* https://linear.app/bookplayer/issue/BKPLY-36/real-remaining-time-vs-playback-speed
* https://github.com/TortugaPower/BookPlayer/issues/685

## Screenshots


https://user-images.githubusercontent.com/14112819/152459416-f5f2ba27-e385-4d44-9794-ad5938f37ae0.MP4


