### PR TITLE
Adopt UIWindowSceneDelegate (CarPlay part 1)

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		9F82DF6F27DEE83E001B0EA8 /* SkipDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F82DF6E27DEE83E001B0EA8 /* SkipDirection.swift */; };
 		9F82DF7127DF8203001B0EA8 /* WatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F82DF7027DF8203001B0EA8 /* WatchConnectivityService.swift */; };
 		9F82DF9C27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */; };
+		9F89D89C27EDFCA400F73947 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F89D89B27EDFCA400F73947 /* SceneDelegate.swift */; };
 		9F8A9A5E27AC3F8C0093AA1C /* PlayableItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */; };
 		9FA334A927C0577E0064E8EA /* BookPlayerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA334A827C0577E0064E8EA /* BookPlayerApp.swift */; };
 		9FA334AB27C058210064E8EA /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA334AA27C058210064E8EA /* ItemListView.swift */; };
@@ -834,6 +835,7 @@
 		9F82DF6E27DEE83E001B0EA8 /* SkipDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipDirection.swift; sourceTree = "<group>"; };
 		9F82DF7027DF8203001B0EA8 /* WatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityService.swift; sourceTree = "<group>"; };
 		9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneWatchConnectivityService.swift; sourceTree = "<group>"; };
+		9F89D89B27EDFCA400F73947 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayableItemTests.swift; sourceTree = "<group>"; };
 		9FA334A827C0577E0064E8EA /* BookPlayerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookPlayerApp.swift; sourceTree = "<group>"; };
 		9FA334AA27C058210064E8EA /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -1175,6 +1177,7 @@
 				41B2A5EC21CCC6D100917584 /* AppNavigationController.swift */,
 				4165EE1120A7D1E100616EDF /* RootViewController.swift */,
 				418B6CFB1D2707F800F974FB /* AppDelegate.swift */,
+				9F89D89B27EDFCA400F73947 /* SceneDelegate.swift */,
 				418B6D011D2707F800F974FB /* Main.storyboard */,
 				418B6D061D2707F800F974FB /* LaunchScreen.storyboard */,
 				418B6D041D2707F800F974FB /* Assets.xcassets */,
@@ -2478,6 +2481,7 @@
 				41D20DAF25D5F5A100AAEE30 /* MappingModel_v1_to_v2.xcmappingmodel in Sources */,
 				41188D2A26ED4D8E0017124E /* ItemListViewModel.swift in Sources */,
 				C398559C20C492FF00BE9EC0 /* AddButton.swift in Sources */,
+				9F89D89C27EDFCA400F73947 /* SceneDelegate.swift in Sources */,
 				416AAC3323F51031005AD04F /* LocalizableButton.swift in Sources */,
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -20,171 +20,99 @@ import WatchConnectivity
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
-  let coordinator = LoadingCoordinator(
-    navigationController: UINavigationController(),
-    loadingViewController: LoadingViewController.instantiate(from: .Main)
-  )
   var wasPlayingBeforeInterruption: Bool = false
   var watcher: DirectoryWatcher?
-  var keyWindowRootVC: UIViewController? {
-    return UIApplication.shared.connectedScenes.filter({ $0.activationState == .foregroundActive })
-      .compactMap({ $0 as? UIWindowScene }).first?.windows
-      .filter({ $0.isKeyWindow }).first?.rootViewController
-  }
 
-  var topController: UIViewController? {
-    var topController = AppDelegate.delegateInstance.keyWindowRootVC
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    let defaults: UserDefaults = UserDefaults.standard
 
-    while let newTopController = topController?.presentedViewController {
-      topController = newTopController
+    // Perfrom first launch setup
+    if !defaults.bool(forKey: Constants.UserDefaults.completedFirstLaunch.rawValue) {
+      // Set default settings
+      defaults.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+      defaults.set(true, forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
+      defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch.rawValue)
     }
 
-    return topController
+    try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode(rawValue: convertFromAVAudioSessionMode(AVAudioSession.Mode.spokenAudio)), options: [])
+
+    // register to audio-interruption notifications
+    NotificationCenter.default.addObserver(self, selector: #selector(self.handleAudioInterruptions(_:)), name: AVAudioSession.interruptionNotification, object: nil)
+
+    NotificationCenter.default.addObserver(self, selector: #selector(self.messageReceived), name: .messageReceived, object: nil)
+
+    // register for remote events
+    self.setupMPRemoteCommands()
+    // register document's folder listener
+    self.setupDocumentListener()
+    // setup store required listeners
+    self.setupStoreListener()
+
+    // Create a Sentry client
+    SentrySDK.start { options in
+      options.dsn = "https://23b4d02f7b044c10adb55a0cc8de3881@sentry.io/1414296"
+      options.debug = false
+    }
+
+    return true
   }
 
-  static var delegateInstance: AppDelegate {
-    // swiftlint:disable force_cast
-    return (UIApplication.shared.delegate as! AppDelegate)
-    // swiftlint:enable force_cast
+  func application(_ application: UIApplication, handle intent: INIntent, completionHandler: @escaping (INIntentResponse) -> Void) {
+    ActionParserService.process(intent)
+
+    let response = INPlayMediaIntentResponse(code: .success, userActivity: nil)
+    completionHandler(response)
   }
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        let defaults: UserDefaults = UserDefaults.standard
+  @objc func messageReceived(_ notification: Notification) {
+    guard
+      let message = notification.userInfo as? [String: Any],
+      let action = CommandParser.parse(message) else {
+      return
+    }
 
-        // Perfrom first launch setup
-        if !defaults.bool(forKey: Constants.UserDefaults.completedFirstLaunch.rawValue) {
-            // Set default settings
-            defaults.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-            defaults.set(true, forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
-            defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch.rawValue)
-        }
+    DispatchQueue.main.async {
+      ActionParserService.handleAction(action)
+    }
+  }
 
-        // Appearance
-        UINavigationBar.appearance().titleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: UIColor(hex: "#37454E")
-        ]
+  // Playback may be interrupted by calls. Handle pause
+  @objc func handleAudioInterruptions(_ notification: Notification) {
+    guard let userInfo = notification.userInfo,
+          let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: typeValue),
+          let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else {
+      return
+    }
 
-        UINavigationBar.appearance().largeTitleTextAttributes = [
-          NSAttributedString.Key.foregroundColor: UIColor(hex: "#37454E")
-        ]
-
-        try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode(rawValue: convertFromAVAudioSessionMode(AVAudioSession.Mode.spokenAudio)), options: [])
-
-        // register to audio-interruption notifications
-        NotificationCenter.default.addObserver(self, selector: #selector(self.handleAudioInterruptions(_:)), name: AVAudioSession.interruptionNotification, object: nil)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.messageReceived), name: .messageReceived, object: nil)
-
-        // register for remote events
-        self.setupMPRemoteCommands()
-        // register document's folder listener
-        self.setupDocumentListener()
-        // setup store required listeners
-        self.setupStoreListener()
-
-        // Create a Sentry client
-        SentrySDK.start { options in
-            options.dsn = "https://23b4d02f7b044c10adb55a0cc8de3881@sentry.io/1414296"
-            options.debug = false
-        }
-
-      self.coordinator.start()
-
-      self.window = UIWindow(frame: UIScreen.main.bounds)
-      self.window?.rootViewController = self.coordinator.navigationController
-      self.window?.makeKeyAndVisible()
-
-      if let activityDictionary = launchOptions?[.userActivityDictionary] as? [UIApplication.LaunchOptionsKey: Any],
-          let activityType = activityDictionary[.userActivityType] as? String,
-          activityType == Constants.UserActivityPlayback {
-          self.playLastBook()
+    switch type {
+    case .began:
+      if mainCoordinator.playerManager.isPlaying {
+        mainCoordinator.playerManager.pause(fade: false)
+      }
+    case .ended:
+      guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+        return
       }
 
-      return true
+      let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+      if options.contains(.shouldResume) {
+        mainCoordinator.playerManager.play()
+      }
+    @unknown default:
+      break
     }
-
-    // Handles audio file urls, like when receiving files through AirDrop
-    // Also handles custom URL scheme 'bookplayer://'
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-      ActionParserService.process(url)
-      return true
-    }
-
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        ActionParserService.process(userActivity)
-
-        return true
-    }
-
-    func application(_ application: UIApplication, handle intent: INIntent, completionHandler: @escaping (INIntentResponse) -> Void) {
-        ActionParserService.process(intent)
-
-        let response = INPlayMediaIntentResponse(code: .success, userActivity: nil)
-        completionHandler(response)
-    }
-
-  func applicationDidBecomeActive(_ application: UIApplication) {
-    // Check if the app is on the PlayerViewController
-    guard let navigationVC = self.keyWindowRootVC,
-          navigationVC.presentedViewController?.presentedViewController is PlayerViewController else {
-            return
-          }
-
-    // Notify controller to see if it should ask for review
-    NotificationCenter.default.post(name: .requestReview, object: nil)
   }
 
-    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        self.playLastBook()
-    }
-
-    @objc func messageReceived(_ notification: Notification) {
-        guard
-            let message = notification.userInfo as? [String: Any],
-            let action = CommandParser.parse(message) else {
-            return
-        }
-
-        DispatchQueue.main.async {
-            ActionParserService.handleAction(action)
-        }
-    }
-
-    // Playback may be interrupted by calls. Handle pause
-    @objc func handleAudioInterruptions(_ notification: Notification) {
-      guard let userInfo = notification.userInfo,
-            let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-            let type = AVAudioSession.InterruptionType(rawValue: typeValue),
-            let mainCoordinator = self.coordinator.getMainCoordinator() else {
-            return
-        }
-
-        switch type {
-        case .began:
-          if mainCoordinator.playerManager.isPlaying {
-            mainCoordinator.playerManager.pause(fade: false)
-          }
-        case .ended:
-            guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
-                return
-            }
-
-            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-            if options.contains(.shouldResume) {
-              mainCoordinator.playerManager.play()
-            }
-            @unknown default:
-            break
-        }
-    }
-
   override func accessibilityPerformMagicTap() -> Bool {
-    guard let mainCoordinator = self.coordinator.getMainCoordinator(),
-          mainCoordinator.playerManager.currentItem != nil else {
-            UIAccessibility.post(notification: .announcement, argument: "voiceover_no_title".localized)
-            return false
-          }
+    guard
+      let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator(),
+      mainCoordinator.playerManager.currentItem != nil
+    else {
+      UIAccessibility.post(notification: .announcement, argument: "voiceover_no_title".localized)
+      return false
+    }
 
     mainCoordinator.playerManager.playPause()
     return true
@@ -199,7 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Play / Pause
     MPRemoteCommandCenter.shared().togglePlayPauseCommand.isEnabled = true
     MPRemoteCommandCenter.shared().togglePlayPauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.playPause()
       return .success
@@ -207,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     MPRemoteCommandCenter.shared().playCommand.isEnabled = true
     MPRemoteCommandCenter.shared().playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.play()
       return .success
@@ -215,18 +143,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     MPRemoteCommandCenter.shared().pauseCommand.isEnabled = true
     MPRemoteCommandCenter.shared().pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.pause(fade: false)
       return .success
     }
 
     MPRemoteCommandCenter.shared().changePlaybackPositionCommand.isEnabled = true
-    MPRemoteCommandCenter.shared().changePlaybackPositionCommand.addTarget { [weak self] remoteEvent in
-      guard let self = self,
-            let mainCoordinator = self.coordinator.getMainCoordinator(),
-            let currentItem = mainCoordinator.playerManager.currentItem,
-            let event = remoteEvent as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
+    MPRemoteCommandCenter.shared().changePlaybackPositionCommand.addTarget { remoteEvent in
+      guard
+        let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator(),
+        let currentItem = mainCoordinator.playerManager.currentItem,
+        let event = remoteEvent as? MPChangePlaybackPositionCommandEvent
+      else { return .commandFailed }
 
       var newTime = event.positionTime
 
@@ -246,14 +175,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Forward
     MPRemoteCommandCenter.shared().skipForwardCommand.preferredIntervals = [NSNumber(value: PlayerManager.forwardInterval)]
     MPRemoteCommandCenter.shared().skipForwardCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.forward()
       return .success
     }
 
     MPRemoteCommandCenter.shared().nextTrackCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.forward()
       return .success
@@ -264,7 +193,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return .success
       }
 
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .success }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .success }
 
       // End seeking
       mainCoordinator.playerManager.forward()
@@ -274,14 +203,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Rewind
     MPRemoteCommandCenter.shared().skipBackwardCommand.preferredIntervals = [NSNumber(value: PlayerManager.rewindInterval)]
     MPRemoteCommandCenter.shared().skipBackwardCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.rewind()
       return .success
     }
 
     MPRemoteCommandCenter.shared().previousTrackCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .commandFailed }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .commandFailed }
 
       mainCoordinator.playerManager.rewind()
       return .success
@@ -292,7 +221,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return .success
       }
 
-      guard let mainCoordinator = self.coordinator.getMainCoordinator() else { return .success }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return .success }
 
       // End seeking
       mainCoordinator.playerManager.rewind()
@@ -307,8 +236,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.watcher?.ignoreDirectories = false
 
     self.watcher?.onNewFiles = { newFiles in
-      guard let mainCoordinator = self.coordinator.getMainCoordinator(),
-            let libraryCoordinator = mainCoordinator.getLibraryCoordinator() else {
+      guard
+        let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator(),
+        let libraryCoordinator = mainCoordinator.getLibraryCoordinator()
+      else {
         return
       }
 
@@ -316,55 +247,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
   }
 
-    func setupStoreListener() {
-        SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
-            for purchase in purchases {
-                guard purchase.transaction.transactionState == .purchased
-                    || purchase.transaction.transactionState == .restored
-                else { continue }
+  func setupStoreListener() {
+    SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
+      for purchase in purchases {
+        guard purchase.transaction.transactionState == .purchased
+                || purchase.transaction.transactionState == .restored
+        else { continue }
 
-                UserDefaults.standard.set(true, forKey: Constants.UserDefaults.donationMade.rawValue)
-                NotificationCenter.default.post(name: .donationMade, object: nil)
+        UserDefaults.standard.set(true, forKey: Constants.UserDefaults.donationMade.rawValue)
+        NotificationCenter.default.post(name: .donationMade, object: nil)
 
-                if purchase.needsFinishTransaction {
-                    SwiftyStoreKit.finishTransaction(purchase.transaction)
-                }
-            }
+        if purchase.needsFinishTransaction {
+          SwiftyStoreKit.finishTransaction(purchase.transaction)
         }
-
-        SwiftyStoreKit.shouldAddStorePaymentHandler = { _, _ in
-            true
-        }
-    }
-}
-
-// MARK: - Actions (custom scheme)
-
-extension AppDelegate {
-  func playLastBook() {
-    guard let mainCoordinator = self.coordinator.getMainCoordinator(),
-          mainCoordinator.playerManager.hasLoadedBook() else {
-      UserDefaults.standard.set(true, forKey: Constants.UserActivityPlayback)
-      return
+      }
     }
 
-    mainCoordinator.playerManager.play()
-  }
-
-  func showPlayer() {
-    guard let mainCoordinator = self.coordinator.getMainCoordinator(),
-          mainCoordinator.playerManager.hasLoadedBook() else {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.showPlayer.rawValue)
-      return
-    }
-
-    if !mainCoordinator.hasPlayerShown() {
-      mainCoordinator.showPlayer()
+    SwiftyStoreKit.shouldAddStorePaymentHandler = { _, _ in
+      true
     }
   }
 }
 
 // Helper function inserted by Swift 4.2 migrator.
 private func convertFromAVAudioSessionMode(_ input: AVAudioSession.Mode) -> String {
-    return input.rawValue
+  return input.rawValue
 }

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -120,4 +120,17 @@ class MainCoordinator: Coordinator {
   func getLibraryCoordinator() -> LibraryListCoordinator? {
     return self.childCoordinators.first as? LibraryListCoordinator
   }
+
+  func getTopController() -> UIViewController? {
+    return getPresentingController(coordinator: self)
+  }
+
+  func getPresentingController(coordinator: Coordinator) -> UIViewController? {
+    guard let lastCoordinator = coordinator.childCoordinators.last else {
+      return coordinator.presentingViewController?.getTopViewController()
+      ?? coordinator.navigationController
+    }
+
+    return getPresentingController(coordinator: lastCoordinator)
+  }
 }

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -2,6 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(BP_BUNDLE_IDENTIFIER).background</string>

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -509,7 +509,9 @@ extension PlayerManager {
 
     guard item.status == .readyToPlay else {
       if item.status == .failed {
-        AppDelegate.delegateInstance.topController?.showAlert("error_title".localized, message: item.error?.localizedDescription)
+        SceneDelegate.shared?.coordinator.getMainCoordinator()?
+          .getTopController()?
+          .showAlert("error_title".localized, message: item.error?.localizedDescription)
       }
       return
     }

--- a/BookPlayer/Player/SleepTimer.swift
+++ b/BookPlayer/Player/SleepTimer.swift
@@ -114,8 +114,7 @@ final class SleepTimer {
     self.reset()
     self.subscription?.cancel()
 
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else { return }
+    guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return }
 
     mainCoordinator.playerManager.pause(fade: true)
   }

--- a/BookPlayer/SceneDelegate.swift
+++ b/BookPlayer/SceneDelegate.swift
@@ -1,0 +1,114 @@
+//
+//  SceneDelegate.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 25/3/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import AVFoundation
+import BookPlayerKit
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  static weak var shared: SceneDelegate?
+  var window: UIWindow?
+  let coordinator = LoadingCoordinator(
+    navigationController: UINavigationController(),
+    loadingViewController: LoadingViewController.instantiate(from: .Main)
+  )
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    Self.shared = self
+
+    // Appearance
+    UINavigationBar.appearance().titleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: UIColor(hex: "#37454E")
+    ]
+
+    UINavigationBar.appearance().largeTitleTextAttributes = [
+      NSAttributedString.Key.foregroundColor: UIColor(hex: "#37454E")
+    ]
+
+    if let activityType = connectionOptions.userActivities.first?.activityType,
+       activityType == Constants.UserActivityPlayback {
+      playLastBook()
+    }
+
+    handleOpening(URLContexts: connectionOptions.urlContexts)
+
+    guard let windowScene = (scene as? UIWindowScene) else { return }
+
+    let appWindow = UIWindow(frame: windowScene.coordinateSpace.bounds)
+    appWindow.windowScene = windowScene
+
+    coordinator.start()
+
+    appWindow.rootViewController = coordinator.navigationController
+    appWindow.makeKeyAndVisible()
+
+    window = appWindow
+  }
+
+  // Handles audio file urls, like when receiving files through AirDrop
+  // Also handles custom URL scheme 'bookplayer://'
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    handleOpening(URLContexts: URLContexts)
+  }
+
+  func handleOpening(URLContexts: Set<UIOpenURLContext>) {
+    for context in URLContexts {
+      ActionParserService.process(context.url)
+    }
+  }
+
+  func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+    playLastBook()
+    completionHandler(true)
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    // Check if the app is on the PlayerViewController
+    guard
+      let mainCoordinator = coordinator.getMainCoordinator(),
+      mainCoordinator.hasPlayerShown()
+    else {
+      return
+    }
+
+    // Notify controller to see if it should ask for review
+    NotificationCenter.default.post(name: .requestReview, object: nil)
+  }
+
+  func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+    ActionParserService.process(userActivity)
+  }
+}
+
+extension SceneDelegate {
+  func playLastBook() {
+    guard
+      let mainCoordinator = coordinator.getMainCoordinator(),
+      mainCoordinator.playerManager.hasLoadedBook()
+    else {
+      UserDefaults.standard.set(true, forKey: Constants.UserActivityPlayback)
+      return
+    }
+
+    mainCoordinator.playerManager.play()
+  }
+
+  func showPlayer() {
+    guard
+      let mainCoordinator = coordinator.getMainCoordinator(),
+      mainCoordinator.playerManager.hasLoadedBook()
+    else {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.showPlayer.rawValue)
+      return
+    }
+
+    if !mainCoordinator.hasPlayerShown() {
+      mainCoordinator.showPlayer()
+    }
+  }
+}

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -30,11 +30,11 @@ class ActionParserService {
   }
 
   public class func handleAction(_ action: Action) {
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    guard let sceneDelegate = SceneDelegate.shared else { return }
 
-    appDelegate.coordinator.pendingURLActions.append(action)
+    sceneDelegate.coordinator.pendingURLActions.append(action)
 
-    guard let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else { return }
+    guard let mainCoordinator = sceneDelegate.coordinator.getMainCoordinator() else { return }
 
     switch action.command {
     case .play:
@@ -69,8 +69,7 @@ class ActionParserService {
     guard
       let valueString = action.getQueryValue(for: "start"),
       let chapterStart = Double(valueString),
-      let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-      let mainCoordinator = appDelegate.coordinator.getMainCoordinator()
+      let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()
     else {
       return
     }
@@ -89,8 +88,7 @@ class ActionParserService {
     let roundedValue = round(speedRate * 100) / 100.0
 
     guard
-      let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-      let mainCoordinator = appDelegate.coordinator.getMainCoordinator()
+      let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()
     else {
       return
     }
@@ -107,8 +105,7 @@ class ActionParserService {
     let isOn = valueString == "true"
 
     guard
-      let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-      let mainCoordinator = appDelegate.coordinator.getMainCoordinator()
+      let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()
     else {
       return
     }
@@ -121,11 +118,12 @@ class ActionParserService {
   }
 
   private class func handleFileImportAction(_ action: Action) {
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let libraryCoordinator = appDelegate.coordinator.getMainCoordinator()?.getLibraryCoordinator(),
-          let urlString = action.getQueryValue(for: "url") else {
-            return
-          }
+    guard
+      let libraryCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()?.getLibraryCoordinator(),
+      let urlString = action.getQueryValue(for: "url")
+    else {
+      return
+    }
 
     let url = URL(fileURLWithPath: urlString)
     self.removeAction(action)
@@ -150,8 +148,7 @@ class ActionParserService {
 
   private class func handlePauseAction(_ action: Action) {
     guard
-      let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-      let mainCoordinator = appDelegate.coordinator.getMainCoordinator()
+      let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()
     else {
       return
     }
@@ -160,15 +157,17 @@ class ActionParserService {
   }
 
   private class func handlePlayAction(_ action: Action) {
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else {
-            return
-          }
+    guard
+      let sceneDelegate = SceneDelegate.shared,
+      let mainCoordinator = sceneDelegate.coordinator.getMainCoordinator()
+    else {
+      return
+    }
 
     if let value = action.getQueryValue(for: "showPlayer"),
        let showPlayer = Bool(value),
        showPlayer {
-      appDelegate.showPlayer()
+      sceneDelegate.showPlayer()
     }
 
     if let value = action.getQueryValue(for: "autoplay"),
@@ -179,7 +178,7 @@ class ActionParserService {
 
     guard let bookIdentifier = action.getQueryValue(for: "identifier") else {
       self.removeAction(action)
-      appDelegate.playLastBook()
+      sceneDelegate.playLastBook()
       return
     }
 
@@ -197,11 +196,12 @@ class ActionParserService {
   }
 
   private class func handleDownloadAction(_ action: Action) {
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let libraryCoordinator = appDelegate.coordinator.getMainCoordinator()?.getLibraryCoordinator(),
-          let urlString = action.getQueryValue(for: "url")?.replacingOccurrences(of: "\"", with: "") else {
-            return
-          }
+    guard
+      let libraryCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator()?.getLibraryCoordinator(),
+      let urlString = action.getQueryValue(for: "url")?.replacingOccurrences(of: "\"", with: "")
+    else {
+      return
+    }
 
     guard let url = URL(string: urlString) else {
       libraryCoordinator.showAlert("error_title".localized, message: String.localizedStringWithFormat("invalid_url_title".localized, urlString))
@@ -227,11 +227,13 @@ class ActionParserService {
   }
 
   public class func removeAction(_ action: Action) {
-    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let index = appDelegate.coordinator.pendingURLActions.firstIndex(of: action) else {
-            return
-          }
+    guard
+      let sceneDelegate = SceneDelegate.shared,
+      let index = sceneDelegate.coordinator.pendingURLActions.firstIndex(of: action)
+    else {
+      return
+    }
 
-    appDelegate.coordinator.pendingURLActions.remove(at: index)
+    sceneDelegate.coordinator.pendingURLActions.remove(at: index)
   }
 }

--- a/BookPlayer/Settings/PlayerSettingsViewController.swift
+++ b/BookPlayer/Settings/PlayerSettingsViewController.swift
@@ -109,8 +109,7 @@ class PlayerSettingsViewController: UITableViewController {
     @objc func boostVolumeToggleDidChange() {
       UserDefaults.standard.set(self.boostVolumeSwitch.isOn, forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
 
-      guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-            let mainCoordinator = appDelegate.coordinator.getMainCoordinator() else { return }
+      guard let mainCoordinator = SceneDelegate.shared?.coordinator.getMainCoordinator() else { return }
 
       mainCoordinator.playerManager.boostVolume = self.boostVolumeSwitch.isOn
     }

--- a/BookPlayer/Settings/Plus Screen/Views/PlusBannerView.swift
+++ b/BookPlayer/Settings/Plus Screen/Views/PlusBannerView.swift
@@ -26,7 +26,9 @@ class PlusBannerView: NibLoadableView {
     @IBAction func showPlus(_ sender: UIButton) {
       let vc = PlusNavigationController.instantiate(from: .Settings)
 
-      AppDelegate.delegateInstance.topController?.present(vc, animated: true, completion: nil)
+      SceneDelegate.shared?.coordinator.getMainCoordinator()?
+        .getTopController()?
+        .present(vc, animated: true, completion: nil)
     }
 }
 

--- a/BookPlayer/Settings/Themes Screen/ThemeManager.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemeManager.swift
@@ -86,8 +86,12 @@ final class ThemeManager: ThemeProvider {
   }
 
   private func setNewTheme(_ newTheme: SimpleTheme) {
+    guard
+      let sceneDelegate = SceneDelegate.shared,
+      let window = sceneDelegate.window
+    else { return }
+
     let newTheme = SimpleTheme(with: newTheme, useDarkVariant: self.useDarkVariant)
-    let window = UIApplication.shared.delegate!.window!!
     UIView.transition(with: window,
                       duration: 0.3,
                       options: [.transitionCrossDissolve],


### PR DESCRIPTION
## Purpose

To use the new iOS 14 APIs for CarPlay, it's necessary that the app adopts the new SceneDelegate introduced in iOS 13

## Related tasks

- https://github.com/TortugaPower/BookPlayer/issues/738
- https://linear.app/bookplayer/issue/BKPLY-86/rewrite-carplay-with-ios-14-apis

## Approach

Create new class `SceneDelegate`, and move all UI configurations over there:
- Move coordinators reference and setup
- Launch options is now passed over there
- Airdrop and custom url scheme handler
- Requesting review catch
- Siri shortcuts handler

## Things to be aware of / Things to focus on

- We are only supporting one scene at a time for the app, I don't think it makes sense to support multiple scenes whenever we get to support iPad
- There are still some references throughout the app to the SceneDelegate (now instead of AppDelegate) that I do think we have to get rid of 🤔 
