### PR TITLE
Rework CarPlayManager to handle new iOS 14 CarPlay APIs

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
 		69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */; };
 		9F1804B827A4AEC500FEDFE5 /* AccessibleSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1804B727A4AEC500FEDFE5 /* AccessibleSliderView.swift */; };
+		9F2DA27F27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2DA27E27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift */; };
 		9F64C6212793C31600B2493C /* PlayerControlsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */; };
 		9F64C6242793C3DA00B2493C /* PlayerControlsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */; };
 		9F64C6262793D5B100B2493C /* PlayerControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */; };
@@ -825,6 +826,7 @@
 		9F1804BF27A739D400FEDFE5 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fi; path = fi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		9F1804C027A739D400FEDFE5 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F1804C127A739D400FEDFE5 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9F2DA27E27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsCoordinator.swift; sourceTree = "<group>"; };
 		9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewModel.swift; sourceTree = "<group>"; };
 		9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewController.swift; sourceTree = "<group>"; };
@@ -1178,6 +1180,7 @@
 				4165EE1120A7D1E100616EDF /* RootViewController.swift */,
 				418B6CFB1D2707F800F974FB /* AppDelegate.swift */,
 				9F89D89B27EDFCA400F73947 /* SceneDelegate.swift */,
+				9F2DA27E27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift */,
 				418B6D011D2707F800F974FB /* Main.storyboard */,
 				418B6D061D2707F800F974FB /* LaunchScreen.storyboard */,
 				418B6D041D2707F800F974FB /* Assets.xcassets */,
@@ -2473,6 +2476,7 @@
 				41A1B12E226FC7E500EA0400 /* ImportOperation.swift in Sources */,
 				5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
 				410D0FED1EDCF4B000A52EB9 /* SettingsViewController.swift in Sources */,
+				9F2DA27F27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift in Sources */,
 				4193E202243A91AE004D6A82 /* ActionParserService.swift in Sources */,
 				41A359C3276232E00020D5F5 /* MappingModel_v7_to_v8.xcmappingmodel in Sources */,
 				41C8ABD126836F50003B67D1 /* ImportViewModel.swift in Sources */,

--- a/BookPlayer/BookPlayer.entitlements
+++ b/BookPlayer/BookPlayer.entitlements
@@ -18,8 +18,8 @@
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-    <key>com.apple.developer.playable-content</key>
-    <true/>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(CFBundleIdentifier).files</string>

--- a/BookPlayer/CarPlaySceneDelegate.swift
+++ b/BookPlayer/CarPlaySceneDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  CarPlaySceneDelegate.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 27/3/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import CarPlay
+
+class CarPlaySceneDelegate: NSObject, CPTemplateApplicationSceneDelegate {
+  let manager = CarPlayManager()
+
+  func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,
+                                didConnect interfaceController: CPInterfaceController) {
+    manager.connect(interfaceController)
+  }
+
+  func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
+    manager.disconnect()
+  }
+}

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -79,11 +79,7 @@ class MainCoordinator: Coordinator {
     self.childCoordinators.append(libraryCoordinator)
     libraryCoordinator.start()
 
-    self.setupCarPlay()
     self.watchConnectivityService.startSession()
-  }
-
-  private func setupCarPlay() {
   }
 
   func showPlayer() {

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -18,7 +18,6 @@ class MainCoordinator: Coordinator {
   let playbackService: PlaybackServiceProtocol
   let speedManager: SpeedManagerProtocol
   let watchConnectivityService: PhoneWatchConnectivityService
-  var carPlayManager: CarPlayManager!
 
   init(
     rootController: RootViewController,
@@ -85,9 +84,6 @@ class MainCoordinator: Coordinator {
   }
 
   private func setupCarPlay() {
-    self.carPlayManager = CarPlayManager(libraryService: self.libraryService)
-    MPPlayableContentManager.shared().dataSource = self.carPlayManager
-    MPPlayableContentManager.shared().delegate = self.carPlayManager
   }
 
   func showPlayer() {

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -5,12 +5,25 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlaySceneConfiguration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+				</dict>
+			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>
 			<array>
 				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneConfigurationName</key>

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -8,259 +8,333 @@
 
 import BookPlayerKit
 import Combine
-import Kingfisher
-import MediaPlayer
-import Themeable
-import UIKit
+import CarPlay
 
-enum IndexGuide {
-  case tab
+class CarPlayManager: NSObject {
+  var interfaceController: CPInterfaceController?
+  let mainCoordinator: MainCoordinator
+  var recentItems = [PlayableItem]()
 
-  var recentlyPlayed: Int {
-    return 1
-  }
-
-  case library
-  case folder
-
-  var count: Int {
-    switch self {
-    case .tab:
-      return 1
-    case .library:
-      return 2
-    case .folder:
-      return 3
-    }
-  }
-
-  var content: Int {
-    switch self {
-    case .tab:
-      return 0
-    case .library:
-      return 1
-    case .folder:
-      return 2
-    }
-  }
-}
-
-final class CarPlayManager: NSObject, MPPlayableContentDataSource, MPPlayableContentDelegate {
-  typealias Tab = (identifier: String, title: String, imageName: String)
-  let tabs: [Tab] = [("tab-library", "library_title".localized, "books.vertical.fill"),
-                     ("tab-recent", "recent_title".localized, "clock.fill")]
-  var cachedDataStore = [IndexPath: [SimpleLibraryItem]]()
-  let libraryService: LibraryServiceProtocol
-  var themeAccent: UIColor
   private var disposeBag = Set<AnyCancellable>()
-  public private(set) var defaultArtwork: UIImage
+  /// Reference for updating boost volume title
+  let boostVolumeItem = CPListItem(text: "", detailText: nil)
+  ///
+  var needsReload = false
 
-  init(libraryService: LibraryServiceProtocol) {
-    self.libraryService = libraryService
-    self.themeAccent = UIColor(hex: "3488D1")
-    self.defaultArtwork = ArtworkService.generateDefaultArtwork(from: nil)!
+  override init() {
+    self.mainCoordinator = SceneDelegate.shared!.coordinator.getMainCoordinator()!
 
     super.init()
+
     self.bindObservers()
-    self.setUpTheming()
+  }
+
+  // MARK: - Lifecycle
+
+  func connect(_ interfaceController: CPInterfaceController) {
+    self.interfaceController = interfaceController
+    self.interfaceController?.delegate = self
+    self.loadRecentItems()
+    self.setupNowPlayingTemplate()
+    self.setRootTemplateRecentItems()
+  }
+
+  func disconnect() {
+    self.interfaceController = nil
+    self.needsReload = false
   }
 
   func bindObservers() {
-    NotificationCenter.default.publisher(for: .bookPlayed)
-      .sink { [weak self] notification in
-        guard let self = self,
-              let userInfo = notification.userInfo,
-              let book = userInfo["book"] as? Book else {
-                return
-              }
+    NotificationCenter.default.publisher(for: .bookReady, object: nil)
+      .sink(receiveValue: { [weak self] notification in
+        guard
+          let self = self,
+          let loaded = notification.userInfo?["loaded"] as? Bool,
+          loaded == true
+        else {
+          return
+        }
 
-        self.setNowPlayingInfo(with: book)
-      }
+        if self.interfaceController?.topTemplate == self.interfaceController?.rootTemplate {
+          self.loadRecentItems()
+          self.setRootTemplateRecentItems()
+          self.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
+        } else {
+          self.needsReload = true
+        }
+
+        self.setupNowPlayingTemplate()
+      })
       .store(in: &disposeBag)
-  }
 
-  func createTabItem(for indexPath: IndexPath) -> MPContentItem {
-    let tab = self.tabs[indexPath[IndexGuide.tab.content]]
-    let item = MPContentItem(identifier: tab.identifier)
-    item.title = tab.title
-    item.isContainer = true
-    item.isPlayable = false
-    if let tabImage = UIImage(systemName: tab.imageName) {
-      item.artwork = MPMediaItemArtwork(boundsSize: tabImage.size, requestHandler: { _ -> UIImage in
-        tabImage
+    NotificationCenter.default.publisher(for: .chapterChange, object: nil)
+      .delay(for: .seconds(0.1), scheduler: RunLoop.main, options: .none)
+      .sink(receiveValue: { [weak self] _ in
+        self?.setupNowPlayingTemplate()
       })
-    }
+      .store(in: &disposeBag)
 
-    return item
-  }
+    self.boostVolumeItem.handler = { [weak self] (_, completion) in
+      let flag = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
 
-  func populateCachedData(at indexPath: IndexPath) -> Int {
-    var mutableIndexPath = indexPath
-    let sourceIndex = mutableIndexPath.removeFirst()
+      NotificationCenter.default.post(
+        name: .messageReceived,
+        object: self,
+        userInfo: [
+          "command": Command.boostVolume.rawValue,
+          "isOn": "\(!flag)"
+        ]
+      )
 
-    let baseIndex = IndexPath(index: sourceIndex)
+      let boostTitle = !flag
+      ? "\("settings_boostvolume_title".localized): \("active_title".localized)"
+      : "\("settings_boostvolume_title".localized): \("sleep_off_title".localized)"
 
-    guard let items = self.cachedDataStore[baseIndex]
-            ?? self.getSourceItems(for: sourceIndex) else {
-      return 0
-    }
-
-    if mutableIndexPath.isEmpty {
-      self.cachedDataStore[indexPath] = items
-      return items.count
-    }
-
-    let item = self.getItem(from: items, and: mutableIndexPath)
-
-    if item.type == .folder,
-       let folderItems = self.libraryService.fetchContents(at: item.relativePath, limit: nil, offset: nil) {
-      let folderItems = folderItems.map({ SimpleLibraryItem(from: $0,
-                                                            themeAccent: themeAccent) })
-      self.cachedDataStore[indexPath] = folderItems
-      return folderItems.count
-    } else {
-      return 0
+      self?.boostVolumeItem.setText(boostTitle)
+      completion()
     }
   }
 
-  func numberOfChildItems(at indexPath: IndexPath) -> Int {
-    if indexPath.indices.isEmpty {
-      return 2
+  func loadRecentItems() {
+    if let recentBooks = mainCoordinator.libraryService.getLastPlayedItems(limit: 20) {
+      recentItems = recentBooks.compactMap({ try? mainCoordinator.playbackService.getPlayableItem(from: $0) })
     }
-
-    if let items = self.cachedDataStore[indexPath] {
-      return items.count
-    }
-
-    return self.populateCachedData(at: indexPath)
   }
 
-  func contentItem(at indexPath: IndexPath) -> MPContentItem? {
-    // Populate tabs
-    if indexPath.indices.count == IndexGuide.tab.count {
-      return self.createTabItem(for: indexPath)
+  func setupNowPlayingTemplate() {
+    let prevButton = self.getPreviousChapterButton()
+
+    let nextButton = self.getNextChapterButton()
+
+    let controlsButton = CPNowPlayingPlaybackRateButton { [weak self] _ in
+      self?.showPlaybackControlsTemplate()
     }
 
-    var mutableIndexPath = indexPath
-    let index = mutableIndexPath.removeLast()
+    let chaptersButton = CPNowPlayingImageButton(image: UIImage(systemName: "list.bullet")!) { [weak self] _ in
+      self?.showChapterListTemplate()
+    }
 
-    guard let items = self.cachedDataStore[mutableIndexPath] else { return nil }
+    let bookmarksButton = CPNowPlayingImageButton(image: UIImage(named: "toolbarIconBookmark")!) { [weak self] _ in
+      guard
+        let self = self,
+        let currentItem = self.mainCoordinator.playerManager.currentItem
+      else { return }
 
-    let libraryItem = items[index]
+      let bookmark = self.mainCoordinator.libraryService.createBookmark(
+        at: currentItem.currentTime,
+        relativePath: currentItem.relativePath,
+        type: .user
+      )
 
-    let item = MPContentItem(identifier: libraryItem.relativePath)
-    item.title = libraryItem.title
-    item.playbackProgress = Float(libraryItem.progress)
+      let formattedTime = TimeParser.formatTime(bookmark.time)
 
-    ArtworkService.retrieveImageFromCache(for: libraryItem.relativePath) { result in
-      let image: UIImage
+      let alertTitle = String.localizedStringWithFormat("bookmark_created_title".localized, formattedTime)
+      let okAction = CPAlertAction(title: "ok_button".localized, style: .default) { _ in
+        self.interfaceController?.dismissTemplate(animated: true, completion: nil)
+      }
+      let alertTemplate = CPAlertTemplate(titleVariants: [alertTitle], actions: [okAction])
 
-      switch result {
-      case .success(let value):
-        image = value.image
-      case .failure:
-        image = self.defaultArtwork
+      self.interfaceController?.presentTemplate(alertTemplate, animated: true, completion: nil)
+    }
+
+    CPNowPlayingTemplate.shared.updateNowPlayingButtons([prevButton, controlsButton, bookmarksButton, chaptersButton, nextButton])
+  }
+
+  func handleItemSelection(_ item: CPSelectableListItem) {
+    if let listTemplate = self.interfaceController?.rootTemplate as? CPListTemplate,
+       let indexPath = listTemplate.indexPath(for: item) {
+      let selectedItem = recentItems[indexPath.row]
+      NotificationCenter.default.post(
+        name: .messageReceived,
+        object: self,
+        userInfo: [
+          "command": Command.play.rawValue,
+          "identifier": selectedItem.relativePath
+        ]
+      )
+    }
+    self.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
+  }
+
+  func setRootTemplateRecentItems() {
+    let items = self.recentItems.map({ playableItem -> CPListItem in
+      let item = CPListItem(
+        text: playableItem.title,
+        detailText: playableItem.author,
+        image: UIImage(contentsOfFile: ArtworkService.getCachedImageURL(for: playableItem.relativePath).path)
+      )
+      item.playbackProgress = CGFloat(playableItem.progressPercentage)
+      item.handler = { [weak self] (item, completion) in
+        self?.handleItemSelection(item)
+        completion()
       }
 
-      item.artwork = MPMediaItemArtwork(boundsSize: image.size,
-                                        requestHandler: { (_) -> UIImage in
-        image
-      })
-    }
-
-    item.subtitle = libraryItem.details
-
-    switch libraryItem.type {
-    case .book, .bound:
-      item.isContainer = false
-      item.isPlayable = true
-    case .folder:
-      item.isContainer = indexPath[0] != IndexGuide.tab.recentlyPlayed
-      item.isPlayable = indexPath[0] == IndexGuide.tab.recentlyPlayed
-    }
-
-    return item
-  }
-
-  func playableContentManager(_ contentManager: MPPlayableContentManager, initiatePlaybackOfContentItemAt indexPath: IndexPath, completionHandler: @escaping (Error?) -> Void) {
-    var mutableIndexPath = indexPath
-    let itemIndex = mutableIndexPath.removeLast()
-
-    guard let items = self.cachedDataStore[mutableIndexPath] else {
-      completionHandler(BookPlayerError.runtimeError("carplay_library_error".localized))
-      return
-    }
-
-    let libraryItem = items[itemIndex]
-
-    let message: [AnyHashable: Any] = ["command": "play",
-                                       "identifier": libraryItem.relativePath]
-
-    NotificationCenter.default.post(name: .messageReceived, object: nil, userInfo: message)
-
-    // Hack to show the now-playing-view on simulator
-    // It has side effects on the initial state of the buttons of that view
-    // But it's meant for development use only
-    #if targetEnvironment(simulator)
-    DispatchQueue.main.async {
-      UIApplication.shared.endReceivingRemoteControlEvents()
-      UIApplication.shared.beginReceivingRemoteControlEvents()
-    }
-    #endif
-
-    completionHandler(nil)
-  }
-
-  func childItemsDisplayPlaybackProgress(at indexPath: IndexPath) -> Bool {
-    return true
-  }
-
-  private func getItem(from items: [SimpleLibraryItem],
-                       and indexPath: IndexPath) -> SimpleLibraryItem {
-    var mutableIndexPath = indexPath
-    let index = mutableIndexPath.removeFirst()
-    let item = items[index]
-
-    guard !mutableIndexPath.isEmpty,
-          item.type == .folder,
-          let folderItems = self.libraryService.fetchContents(at: item.relativePath, limit: nil, offset: nil) else {
       return item
-    }
+    })
 
-    let simpleItems = folderItems.map({ SimpleLibraryItem(from: $0,
-                                                          themeAccent: themeAccent) })
-    return getItem(from: simpleItems, and: mutableIndexPath)
+    items.first?.isPlaying = true
+
+    let section = CPListSection(items: items)
+    let listTemplate = CPListTemplate(title: "recent_title".localized, sections: [section])
+
+    self.interfaceController?.setRootTemplate(listTemplate, animated: false, completion: nil)
   }
 
-  private func getSourceItems(for index: Int) -> [SimpleLibraryItem]? {
-    // Recently played items or library items
-    return (index == IndexGuide.tab.recentlyPlayed
-            ? self.libraryService.getLastPlayedItems(limit: 20) ?? []
-            : self.libraryService.fetchContents(at: nil, limit: nil, offset: nil) ?? [])
-      .map({ SimpleLibraryItem(from: $0,
-                               themeAccent: themeAccent)
-      })
-  }
-
-  func setNowPlayingInfo(with book: Book) {
-    var identifiers = [book.identifier!]
-
-    if let folder = book.folder {
-      identifiers.append(folder.identifier)
-    }
-
-    self.cachedDataStore = [:]
-
-    MPPlayableContentManager.shared().nowPlayingIdentifiers = identifiers
-    MPPlayableContentManager.shared().reloadData()
+  func formatSpeed(_ speed: Float) -> String {
+    return (speed.truncatingRemainder(dividingBy: 1) == 0 ? "\(Int(speed))" : "\(speed)") + "×"
   }
 }
 
-extension CarPlayManager: Themeable {
-  func applyTheme(_ theme: SimpleTheme) {
-    self.themeAccent = theme.linkColor
-    self.defaultArtwork = ArtworkService.generateDefaultArtwork(from: theme.linkColor)!
-    MPPlayableContentManager.shared().reloadData()
+// MARK: - Skip Chapter buttons
+
+extension CarPlayManager {
+  func hasChapter(before chapter: PlayableChapter?) -> Bool {
+    guard let chapter = chapter else { return false }
+    return self.mainCoordinator.playerManager.currentItem?.hasChapter(before: chapter) ?? false
+  }
+
+  func hasChapter(after chapter: PlayableChapter?) -> Bool {
+    guard let chapter = chapter else { return false }
+    return self.mainCoordinator.playerManager.currentItem?.hasChapter(after: chapter) ?? false
+  }
+
+  func getPreviousChapterButton() -> CPNowPlayingImageButton {
+    let prevChapterImageName = self.hasChapter(before: self.mainCoordinator.playerManager.currentItem?.currentChapter)
+    ? "chevron.left"
+    : "chevron.left.2"
+
+    return CPNowPlayingImageButton(image: UIImage(systemName: prevChapterImageName)!) { [weak self] _ in
+      if let currentChapter = self?.mainCoordinator.playerManager.currentItem?.currentChapter,
+         let previousChapter = self?.mainCoordinator.playerManager.currentItem?.previousChapter(before: currentChapter) {
+        self?.mainCoordinator.playerManager.jumpTo(previousChapter.start + 0.5, recordBookmark: false)
+      } else {
+        self?.mainCoordinator.playerManager.playPreviousItem()
+      }
+    }
+  }
+
+  func getNextChapterButton() -> CPNowPlayingImageButton {
+    let nextChapterImageName = self.hasChapter(after: self.mainCoordinator.playerManager.currentItem?.currentChapter)
+    ? "chevron.right"
+    : "chevron.right.2"
+
+    return CPNowPlayingImageButton(image: UIImage(systemName: nextChapterImageName)!) { [weak self] _ in
+      if let currentChapter = self?.mainCoordinator.playerManager.currentItem?.currentChapter,
+         let nextChapter = self?.mainCoordinator.playerManager.currentItem?.nextChapter(after: currentChapter) {
+        self?.mainCoordinator.playerManager.jumpTo(nextChapter.start + 0.5, recordBookmark: false)
+      } else {
+        self?.mainCoordinator.playerManager.playNextItem(autoPlayed: false)
+      }
+    }
+  }
+}
+
+// MARK: - Chapter List Template
+
+extension CarPlayManager {
+  func showChapterListTemplate() {
+    guard
+      let chapters = self.mainCoordinator.playerManager.currentItem?.chapters
+    else { return }
+
+    let chapterItems = chapters.enumerated().map({ [weak self] (index, chapter) -> CPListItem in
+      let chapterTitle = chapter.title == ""
+      ? String.localizedStringWithFormat("chapter_number_title".localized, index + 1)
+      : chapter.title
+
+      let chapterDetail = String.localizedStringWithFormat("chapters_item_description".localized, TimeParser.formatTime(chapter.start), TimeParser.formatTime(chapter.duration))
+
+      let item = CPListItem(text: chapterTitle, detailText: chapterDetail)
+
+      if let currentChapter = self?.mainCoordinator.playerManager.currentItem?.currentChapter,
+         currentChapter.index == chapter.index {
+        item.isPlaying = true
+      }
+
+      item.handler = { [weak self] (_, completion) in
+        NotificationCenter.default.post(
+          name: .messageReceived,
+          object: self,
+          userInfo: [
+            "command": Command.chapter.rawValue,
+            "start": "\(chapter.start)"
+          ]
+        )
+        completion()
+        self?.interfaceController?.popTemplate(animated: true, completion: nil)
+      }
+      return item
+    })
+
+    let section = CPListSection(items: chapterItems)
+
+    let listTemplate = CPListTemplate(title: "chapters_title".localized, sections: [section])
+
+    self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
+  }
+}
+
+// MARK: - Playback Controls
+
+extension CarPlayManager {
+  func showPlaybackControlsTemplate() {
+    let boostTitle = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+    ? "\("settings_boostvolume_title".localized): \("active_title".localized)"
+    : "\("settings_boostvolume_title".localized): \("sleep_off_title".localized)"
+
+    boostVolumeItem.setText(boostTitle)
+
+    let section1 = CPListSection(items: [boostVolumeItem])
+
+    let currentSpeed = mainCoordinator.playerManager.getCurrentSpeed()
+    let formattedSpeed = formatSpeed(currentSpeed)
+
+    let speedItems = self.getSpeedOptions()
+      .map({ interval -> CPListItem in
+        let item = CPListItem(text: formatSpeed(interval), detailText: nil)
+        item.handler = { [weak self] (_, completion) in
+          let roundedValue = round(interval * 100) / 100.0
+
+          NotificationCenter.default.post(
+            name: .messageReceived,
+            object: self,
+            userInfo: [
+              "command": Command.speed.rawValue,
+              "rate": "\(roundedValue)"
+            ]
+          )
+
+          self?.interfaceController?.popTemplate(animated: true, completion: nil)
+          completion()
+        }
+        return item
+      })
+
+    let section2 = CPListSection(items: speedItems, header: "\("player_speed_title".localized): \(formattedSpeed)", sectionIndexTitle: nil)
+
+    let listTemplate = CPListTemplate(title: "settings_controls_title".localized, sections: [section1, section2])
+
+    self.interfaceController?.pushTemplate(listTemplate, animated: true, completion: nil)
+  }
+
+  public func getSpeedOptions() -> [Float] {
+    return [
+      0.5, 0.6, 0.7, 0.8, 0.9,
+      1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+      2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
+      3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9,
+      4.0
+    ]
+  }
+}
+
+extension CarPlayManager: CPInterfaceControllerDelegate {
+  func templateDidAppear(_ aTemplate: CPTemplate, animated: Bool) {
+    if aTemplate == self.interfaceController?.rootTemplate,
+       self.needsReload {
+      self.needsReload = false
+      self.loadRecentItems()
+      self.setRootTemplateRecentItems()
+    }
   }
 }

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -18,7 +18,7 @@ class CarPlayManager: NSObject {
   private var disposeBag = Set<AnyCancellable>()
   /// Reference for updating boost volume title
   let boostVolumeItem = CPListItem(text: "", detailText: nil)
-  ///
+  /// Refresh flag in case the root template is not visible
   var needsReload = false
 
   override init() {


### PR DESCRIPTION
## Purpose

Adopt iOS 14 CarPlay APIs

## Related tasks

* #738 
* #509 
* #501 
* #481 
* https://linear.app/bookplayer/issue/BKPLY-86/rewrite-carplay-with-ios-14-apis

## Approach

- Rewrite CarPlayManager to adopt new CarPlay's template API
- Use `.messageReceived` events to route common actions like item/chapter selection and player setup

## Things to be aware of / Things to focus on

- We can't upload this to TestFlight until Apple approves the new app entitlements for the iOS 14 CarPlay APIs

## Screenshots

https://user-images.githubusercontent.com/14112819/160850700-96ec282a-55b9-4385-b3d4-7cc553f84312.mov
