### PR TITLE
[Part 2] Performance improvements: CoreData

### DIFF
--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -374,7 +374,7 @@ public final class LibraryService: LibraryServiceProtocol {
     item.currentTime = time
     item.percentCompleted = round((item.currentTime / item.duration) * 100)
 
-    self.dataManager.saveContext()
+    self.dataManager.scheduleSaveContext()
   }
 
   public func updateBookSpeed(at relativePath: String, speed: Float) {
@@ -483,7 +483,7 @@ public final class LibraryService: LibraryServiceProtocol {
 
   public func recordTime(_ playbackRecord: PlaybackRecord) {
     playbackRecord.time += 1
-    self.dataManager.saveContext()
+    self.dataManager.scheduleSaveContext()
   }
 
   // MARK: - Bookmarks


### PR DESCRIPTION
## Purpose

CoreData is saving the context a lot of times in a second if playback rate is greater than 1x

## Approach

Schedule a save `DispatchWorkItem` 2 seconds after it's requested, and discard the other save events if there's already one scheduled. This shouldn't affect the data, since all the changes are live in the context when the save is executed