### PR TITLE
[BKPLY-91] Fix alerts not having the proper color scheme

### DIFF
--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -9,6 +9,7 @@
 import BookPlayerKit
 import DeviceKit
 import MediaPlayer
+import Themeable
 import UIKit
 
 class MainCoordinator: Coordinator {
@@ -44,6 +45,8 @@ class MainCoordinator: Coordinator {
     ThemeManager.shared.libraryService = libraryService
 
     super.init(navigationController: navigationController, flowType: .modal)
+
+    setUpTheming()
   }
 
   override func start() {
@@ -119,5 +122,14 @@ class MainCoordinator: Coordinator {
     }
 
     return getPresentingController(coordinator: lastCoordinator)
+  }
+}
+
+extension MainCoordinator: Themeable {
+  func applyTheme(_ theme: SimpleTheme) {
+    // This fixes native components like alerts having the proper color theme
+    SceneDelegate.shared?.window?.overrideUserInterfaceStyle = theme.useDarkVariant
+    ? .dark
+    : .light
   }
 }


### PR DESCRIPTION
## Bugfix

If the OS is set to light mode, and the app is set to a dark theme, the alerts will have a light theme instead of a dark theme

## Related tasks

https://linear.app/bookplayer/issue/BKPLY-91/adapt-action-alert-sheets-to-dark-mode

## Approach

Conform the MainCoordinator to the Themeable protocol, to update the `overrideUserInterfaceStyle ` property from the window of the scene delegate

## Screenshots

<img width="409" alt="Screen Shot 2022-05-11 at 12 45 28" src="https://user-images.githubusercontent.com/14112819/168176308-c90965ca-0b48-4c7a-af0c-cd9a4b79fa38.png">

