### PR TITLE
[BKPLY] Fix import crash and delete bug

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -16,7 +16,6 @@ class FolderListCoordinator: ItemListCoordinator {
     navigationController: UINavigationController,
     folderRelativePath: String,
     playerManager: PlayerManagerProtocol,
-    importManager: ImportManager,
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol
   ) {
@@ -25,7 +24,6 @@ class FolderListCoordinator: ItemListCoordinator {
     super.init(
       navigationController: navigationController,
       playerManager: playerManager,
-      importManager: importManager,
       libraryService: libraryService,
       playbackService: playbackService
     )

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -336,8 +336,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     let selectedItems = items.compactMap({ self.libraryService.getItem(with: $0.relativePath )})
 
     do {
-      let library = self.libraryService.getLibrary()
-      try self.libraryService.delete(selectedItems, library: library, mode: mode)
+      try self.libraryService.delete(selectedItems, mode: mode)
     } catch {
       self.coordinator.showAlert("error_title".localized, message: error.localizedDescription)
     }
@@ -445,7 +444,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
   }
 
   func handleNewFiles(_ urls: [URL]) {
-    self.coordinator.processFiles(urls: urls)
+    self.coordinator.getMainCoordinator()?.getLibraryCoordinator()?.processFiles(urls: urls)
   }
 
   func showSortOptions() {

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -34,7 +34,6 @@ class LibraryListCoordinatorTests: XCTestCase {
   func testInitialState() {
     XCTAssert(self.libraryListCoordinator.childCoordinators.isEmpty)
     XCTAssert(self.libraryListCoordinator.shouldShowImportScreen())
-    XCTAssert(self.libraryListCoordinator.shouldHandleImport())
   }
 
   func testDocumentPickerDelegate() {
@@ -48,8 +47,7 @@ class LibraryListCoordinatorTests: XCTestCase {
 
     self.libraryListCoordinator.showFolder(folder.relativePath)
     XCTAssert(self.libraryListCoordinator.childCoordinators.first is ItemListCoordinator)
-    XCTAssertFalse(self.libraryListCoordinator.shouldShowImportScreen())
-    XCTAssertFalse(self.libraryListCoordinator.shouldHandleImport())
+    XCTAssertTrue(self.libraryListCoordinator.shouldShowImportScreen())
   }
 
   func testShowPlayer() {
@@ -106,7 +104,6 @@ class FolderListCoordinatorTests: XCTestCase {
       navigationController: UINavigationController(),
       folderRelativePath: folder.relativePath,
       playerManager: PlayerManagerMock(),
-      importManager: ImportManager(libraryService: libraryService),
       libraryService: libraryService,
       playbackService: PlaybackService(libraryService: libraryService)
     )

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -933,11 +933,11 @@ class ModifyLibraryTests: LibraryServiceTests {
     try self.sut.moveItems([folder], inside: folder2.relativePath, moveFiles: true)
     try self.sut.moveItems([folder2], inside: nil, moveFiles: true)
 
-    try self.sut.delete([folder2], library: library, mode: .shallow)
+    try self.sut.delete([folder2], mode: .shallow)
 
     XCTAssert((library.items?.array as? [LibraryItem])?.first == folder)
 
-    try self.sut.delete([folder], library: library, mode: .shallow)
+    try self.sut.delete([folder], mode: .shallow)
 
     XCTAssert((library.items?.array as? [LibraryItem])?.first == book1)
   }
@@ -957,12 +957,12 @@ class ModifyLibraryTests: LibraryServiceTests {
     try self.sut.moveItems([book4], inside: folder2.relativePath, moveFiles: true)
     try self.sut.moveItems([folder2], inside: nil, moveFiles: true)
 
-    try self.sut.delete([folder2], library: library, mode: .shallow)
+    try self.sut.delete([folder2], mode: .shallow)
 
     XCTAssert((library.items?.array as? [LibraryItem])?.first == book1)
     XCTAssert((library.items?.array as? [LibraryItem])?.last == book4)
 
-    try self.sut.delete([folder], library: library, mode: .shallow)
+    try self.sut.delete([folder], mode: .shallow)
 
     XCTAssert(library.items?.array is [Book])
     XCTAssert(library.items?.count == 4)
@@ -980,12 +980,12 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     XCTAssert(folder2.items?.count == 1)
 
-    try self.sut.delete([folder], library: library, mode: .deep)
+    try self.sut.delete([folder], mode: .deep)
 
     XCTAssert(folder2.items?.count == 0)
     XCTAssert(library.items?.count == 1)
 
-    try self.sut.delete([folder2], library: library, mode: .deep)
+    try self.sut.delete([folder2], mode: .deep)
 
     XCTAssert(library.items?.count == 0)
   }
@@ -1010,12 +1010,12 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     XCTAssert(folder2.items?.count == 2)
 
-    try self.sut.delete([folder], library: library, mode: .deep)
+    try self.sut.delete([folder], mode: .deep)
 
     XCTAssert(folder2.items?.count == 1)
     XCTAssert(library.items?.count == 2)
 
-    try self.sut.delete([folder2], library: library, mode: .deep)
+    try self.sut.delete([folder2], mode: .deep)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert((library.items?.array as? [LibraryItem])?.first == book1)


### PR DESCRIPTION
## Bugfix

- There is a crash whenever two import screens get presented at once, this could happen when importing files from within a folder, and the crash is due to the import triggering the start of the operation twice
- Complete deletion of subfolders is only deleting the first level of items, while leaving the rest existing in the DB

## Related tasks

https://linear.app/bookplayer/issue/BKPLY-90/fix-import-crash

## Approach

- Remove logic about handling import operations from the item list coordinator, and move it to the library coordinator which should be unique
- Rewrite delete functions, they were written when nested folders weren't supported, so it didn't really delete items after the first subfolders, and would leave those core data objects w/o being connected to the library
