### PR TITLE
Fix setting MPNowPlayingInfoPropertyPlaybackProgress property

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -352,6 +352,10 @@
 		9FA334C327C2833B0064E8EA /* ResizeableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA334C227C2833B0064E8EA /* ResizeableImageView.swift */; };
 		9FA334C527C285650064E8EA /* ChapterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA334C427C285650064E8EA /* ChapterListView.swift */; };
 		9FA334C727C28D650064E8EA /* PlaybackControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA334C627C28D650064E8EA /* PlaybackControlsView.swift */; };
+		9FB7C48D2835A2C1003B917E /* PlayerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C48C2835A2C1003B917E /* PlayerManagerTests.swift */; };
+		9FB7C48F2835A4C9003B917E /* EmptyLibraryServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C48E2835A4C9003B917E /* EmptyLibraryServiceMock.swift */; };
+		9FB7C4912835A5A3003B917E /* EmptyPlaybackServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C4902835A5A3003B917E /* EmptyPlaybackServiceMock.swift */; };
+		9FB7C4932835A617003B917E /* EmptySpeedServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C4922835A617003B917E /* EmptySpeedServiceMock.swift */; };
 		9FE07E1B27C522DE007591F7 /* ContainerItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE07E1A27C522DE007591F7 /* ContainerItemListView.swift */; };
 		C30B66AE20E2D8CF00FC0030 /* ArtworkControl.xib in Resources */ = {isa = PBXBuildFile; fileRef = C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */; };
 		C318D3AD208CF624000666F8 /* PlayerJumpIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C318D3AC208CF624000666F8 /* PlayerJumpIcon.swift */; };
@@ -848,6 +852,10 @@
 		9FA334C227C2833B0064E8EA /* ResizeableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeableImageView.swift; sourceTree = "<group>"; };
 		9FA334C427C285650064E8EA /* ChapterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterListView.swift; sourceTree = "<group>"; };
 		9FA334C627C28D650064E8EA /* PlaybackControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackControlsView.swift; sourceTree = "<group>"; };
+		9FB7C48C2835A2C1003B917E /* PlayerManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerManagerTests.swift; sourceTree = "<group>"; };
+		9FB7C48E2835A4C9003B917E /* EmptyLibraryServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyLibraryServiceMock.swift; sourceTree = "<group>"; };
+		9FB7C4902835A5A3003B917E /* EmptyPlaybackServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPlaybackServiceMock.swift; sourceTree = "<group>"; };
+		9FB7C4922835A617003B917E /* EmptySpeedServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySpeedServiceMock.swift; sourceTree = "<group>"; };
 		9FE07E1A27C522DE007591F7 /* ContainerItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerItemListView.swift; sourceTree = "<group>"; };
 		C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BookPlayer.swift"; sourceTree = "<group>"; };
 		C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ArtworkControl.xib; sourceTree = "<group>"; };
@@ -1207,6 +1215,7 @@
 				416A9D4A2743D51E00463621 /* StorageViewModelTests.swift */,
 				62AAE2242749283F001EB9FF /* MiniPlayerViewModelTests.swift */,
 				9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */,
+				9FB7C48C2835A2C1003B917E /* PlayerManagerTests.swift */,
 				6279361D272D0CF50097837D /* Coordinators */,
 				418B6D141D2707F800F974FB /* Info.plist */,
 			);
@@ -1516,6 +1525,9 @@
 			isa = PBXGroup;
 			children = (
 				62AAE22627492896001EB9FF /* PlayerManagerMock.swift */,
+				9FB7C48E2835A4C9003B917E /* EmptyLibraryServiceMock.swift */,
+				9FB7C4902835A5A3003B917E /* EmptyPlaybackServiceMock.swift */,
+				9FB7C4922835A617003B917E /* EmptySpeedServiceMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2505,9 +2517,11 @@
 				4137BBD6272DF693009ED9FE /* SettingsCoordinatorTests.swift in Sources */,
 				69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */,
 				62AAE2252749283F001EB9FF /* MiniPlayerViewModelTests.swift in Sources */,
+				9FB7C48F2835A4C9003B917E /* EmptyLibraryServiceMock.swift in Sources */,
 				41C2340C27324AB7006BC7B8 /* ItemListViewModelTests.swift in Sources */,
 				41A1B140226FEF9600EA0400 /* FolderTests.swift in Sources */,
 				41A1B13F226FEF9300EA0400 /* DataManagerTests.swift in Sources */,
+				9FB7C48D2835A2C1003B917E /* PlayerManagerTests.swift in Sources */,
 				4137BBD4272DF540009ED9FE /* PlayerCoordinatorTests.swift in Sources */,
 				416A9D4B2743D51E00463621 /* StorageViewModelTests.swift in Sources */,
 				4137BBD2272DED79009ED9FE /* ItemListCoordinatorTests.swift in Sources */,
@@ -2518,6 +2532,8 @@
 				6279361F272D0D110097837D /* MainCoordinatorTests.swift in Sources */,
 				4197FAFA267E38D900811CC8 /* LibraryTests.swift in Sources */,
 				4137BBD0272DEBEC009ED9FE /* LoadingCoordinatorTests.swift in Sources */,
+				9FB7C4912835A5A3003B917E /* EmptyPlaybackServiceMock.swift in Sources */,
+				9FB7C4932835A617003B917E /* EmptySpeedServiceMock.swift in Sources */,
 				41A1B13E226FEF8000EA0400 /* DataTestUtils.swift in Sources */,
 				9F8A9A5E27AC3F8C0093AA1C /* PlayableItemTests.swift in Sources */,
 				4163E313214AC43000072AA2 /* ImportOperationTests.swift in Sources */,

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -74,7 +74,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   @Published var currentItem: PlayableItem?
   @Published var currentSpeed: Float = 1.0
 
-  private var nowPlayingInfo = [String: Any]()
+  var nowPlayingInfo = [String: Any]()
 
   private let queue = OperationQueue()
 
@@ -238,7 +238,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   }
 
   // Called every second by the timer
-  func updateTime(includeItem: Bool = false) {
+  func updateTime() {
     guard let currentItem = self.currentItem,
           let playerItem = self.playerItem,
           playerItem.status == .readyToPlay else {
@@ -363,10 +363,27 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     // 1x is needed because of how the control center behaves when decrementing time
     self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
     self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTimeInContext
-    self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = prefersRemainingTime
-    ? (abs(maxTimeInContext) + currentTimeInContext)
-    : maxTimeInContext
-    self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] = currentTimeInContext / maxTimeInContext
+
+    let playbackDuration: TimeInterval
+    let itemProgress: TimeInterval
+
+    if prefersRemainingTime {
+      playbackDuration = (abs(maxTimeInContext) + currentTimeInContext)
+
+      let realMaxTime = currentItem.maxTimeInContext(
+        prefersChapterContext: prefersChapterContext,
+        prefersRemainingTime: false,
+        at: self.currentSpeed
+      )
+
+      itemProgress = currentTimeInContext / realMaxTime
+    } else {
+      playbackDuration = maxTimeInContext
+      itemProgress = currentTimeInContext / maxTimeInContext
+    }
+
+    self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = playbackDuration
+    self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] = itemProgress
   }
 }
 

--- a/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
@@ -1,0 +1,139 @@
+//
+//  EmptyLibraryServiceMock.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 18/5/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+
+/// Empty class meant to be subclassed to adjust service for test conditions
+class EmptyLibraryServiceMock: LibraryServiceProtocol {
+  func getLibrary() -> Library {
+    return Library()
+  }
+
+  func getLibraryLastItem() throws -> LibraryItem? {
+    return nil
+  }
+
+  func getLibraryCurrentTheme() throws -> Theme? {
+    return nil
+  }
+
+  func getTheme(with title: String) -> Theme? {
+    return nil
+  }
+
+  func setLibraryTheme(with title: String) {}
+
+  func setLibraryLastBook(with relativePath: String?) {}
+
+  func createTheme(params: [String: Any]) -> Theme {
+    return Theme()
+  }
+
+  func createBook(from url: URL) -> Book {
+    return Book()
+  }
+
+  func getChapters(from relativePath: String) -> [Chapter]? {
+    return nil
+  }
+
+  func getItem(with relativePath: String) -> LibraryItem? {
+    return nil
+  }
+
+  func findBooks(containing fileURL: URL) -> [Book]? {
+    return nil
+  }
+
+  func getLastPlayedItems(limit: Int?) -> [LibraryItem]? {
+    return nil
+  }
+
+  func updateFolder(at relativePath: String, type: FolderType) throws {}
+
+  func findFolder(with fileURL: URL) -> Folder? {
+    return nil
+  }
+
+  func findFolder(with relativePath: String) -> Folder? {
+    return nil
+  }
+
+  func hasLibraryLinked(item: LibraryItem) -> Bool {
+    return false
+  }
+
+  func createFolder(with title: String, inside relativePath: String?) throws -> Folder {
+    return Folder()
+  }
+
+  func fetchContents(at relativePath: String?, limit: Int?, offset: Int?) -> [LibraryItem]? {
+    return nil
+  }
+
+  func getMaxItemsCount(at relativePath: String?) -> Int {
+    return 0
+  }
+
+  func replaceOrderedItems(_ items: NSOrderedSet, at relativePath: String?) {}
+
+  func reorderItem(at relativePath: String, inside folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) {}
+
+  func updatePlaybackTime(relativePath: String, time: Double) {}
+
+  func updateBookSpeed(at relativePath: String, speed: Float) {}
+
+  func getItemSpeed(at relativePath: String) -> Float {
+    return 1
+  }
+
+  func updateBookLastPlayDate(at relativePath: String, date: Date) {}
+
+  func markAsFinished(flag: Bool, relativePath: String) {}
+
+  func jumpToStart(relativePath: String) {}
+
+  func getCurrentPlaybackRecord() -> PlaybackRecord {
+    return PlaybackRecord()
+  }
+
+  func getPlaybackRecords(from startDate: Date, to endDate: Date) -> [PlaybackRecord]? {
+    return nil
+  }
+
+  func recordTime(_ playbackRecord: PlaybackRecord) {}
+
+  func getBookmarks(of type: BookmarkType, relativePath: String) -> [Bookmark]? {
+    return nil
+  }
+
+  func getBookmark(at time: Double, relativePath: String, type: BookmarkType) -> Bookmark? {
+    return nil
+  }
+
+  func createBookmark(at time: Double, relativePath: String, type: BookmarkType) -> Bookmark {
+    return Bookmark()
+  }
+
+  func addNote(_ note: String, bookmark: Bookmark) {}
+
+  func deleteBookmark(_ bookmark: Bookmark) {}
+
+  func renameItem(at relativePath: String, with newTitle: String) {}
+
+  func insertItems(from files: [URL], into folder: Folder?, library: Library, processedItems: [LibraryItem]?) -> [LibraryItem] {
+    return []
+  }
+
+  func handleDirectory(item: URL, folder: Folder, library: Library) {}
+
+  func moveItems(_ items: [LibraryItem], inside relativePath: String?, moveFiles: Bool) throws {}
+
+  func delete(_ items: [LibraryItem], mode: DeleteMode) throws {}
+}

--- a/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
@@ -1,0 +1,27 @@
+//
+//  EmptyPlaybackServiceMock.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 18/5/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+
+/// Empty class meant to be subclassed to adjust service for test conditions
+class EmptyPlaybackServiceMock: PlaybackServiceProtocol {
+  func updatePlaybackTime(item: PlayableItem, time: Double) {}
+
+  func getPlayableItem(before relativePath: String) -> PlayableItem? {
+    return nil
+  }
+
+  func getPlayableItem(after relativePath: String, autoplayed: Bool) -> PlayableItem? {
+    return nil
+  }
+
+  func getPlayableItem(from item: LibraryItem) throws -> PlayableItem? {
+    return nil
+  }
+}

--- a/BookPlayerTests/Mocks/EmptySpeedServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptySpeedServiceMock.swift
@@ -1,0 +1,21 @@
+//
+//  EmptySpeedServiceMock.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 18/5/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+
+@testable import BookPlayer
+
+/// Empty class meant to be subclassed to adjust service for test conditions
+class EmptySpeedServiceMock: SpeedServiceProtocol {
+  func setSpeed(_ newValue: Float, relativePath: String?) {}
+
+  func getSpeed(relativePath: String?) -> Float {
+    return 1
+  }
+}

--- a/BookPlayerTests/PlayableItemTests.swift
+++ b/BookPlayerTests/PlayableItemTests.swift
@@ -16,10 +16,6 @@ import XCTest
 class PlayableItemTests: XCTestCase {
   var sut: PlayableItem!
 
-  private func generatePlayableItem() {
-
-  }
-
   override func setUp() {
     let testChapter = PlayableChapter(
       title: "test chapter",

--- a/BookPlayerTests/PlayerManagerTests.swift
+++ b/BookPlayerTests/PlayerManagerTests.swift
@@ -1,0 +1,160 @@
+//
+//  PlayerManagerTests.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 18/5/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import Combine
+import XCTest
+
+class PlayerManagerTests: XCTestCase {
+  var sut: PlayerManager!
+
+  override func setUp() {
+    // Clean up stored configs
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    self.sut = PlayerManager(
+      libraryService: EmptyLibraryServiceMock(),
+      playbackService: EmptyPlaybackServiceMock(),
+      speedService: EmptySpeedServiceMock()
+    )
+  }
+
+  private func generatePlayableItem() -> PlayableItem {
+    let testChapter = PlayableChapter(
+      title: "test chapter 1",
+      author: "test author chapter",
+      start: 0,
+      duration: 50,
+      relativePath: "",
+      index: 0
+    )
+    let testChapter2 = PlayableChapter(
+      title: "test chapter 2",
+      author: "test author chapter 2",
+      start: 51,
+      duration: 100,
+      relativePath: "",
+      index: 1
+    )
+    return PlayableItem(
+      title: "test book",
+      author: "test author",
+      chapters: [testChapter, testChapter2],
+      currentTime: 0,
+      duration: 100,
+      relativePath: "",
+      percentCompleted: 10,
+      isFinished: false,
+      useChapterTimeContext: false
+    )
+  }
+
+  func testUpdatingEmptyNowPlayingBookTime() {
+    self.sut.setNowPlayingBookTime()
+
+    XCTAssertNil(self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate])
+    XCTAssertNil(self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime])
+    XCTAssertNil(self.sut.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration])
+    XCTAssertNil(self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress])
+  }
+
+  func testUpdatingGlobalNowPlayingBookTime() {
+    // playback speed shouldn't affect duration time set
+    self.sut.setSpeed(2)
+    // mocked playable item
+    let playableItem = generatePlayableItem()
+    playableItem.currentTime = 20
+
+    self.sut.currentItem = playableItem
+    self.sut.setNowPlayingBookTime()
+
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] as? Double) == 1)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double) == 20)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] as? Double) == 100)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] as? Double) == 0.2)
+  }
+
+  func testUpdatingGlobalRemainingNowPlayingBookTime() {
+    // playback speed should affect duration time set
+    self.sut.setSpeed(2)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    // mocked playable item
+    let playableItem = generatePlayableItem()
+    playableItem.currentTime = 20
+
+    self.sut.currentItem = playableItem
+    self.sut.setNowPlayingBookTime()
+
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] as? Double) == 1)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double) == 20)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] as? Double) == 60)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] as? Double) == 0.2)
+  }
+
+  func testUpdatingChapterNowPlayingBookTime() {
+    // playback speed shouldn't affect duration time set
+    self.sut.setSpeed(2)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    // mocked playable item
+    let playableItem = generatePlayableItem()
+    playableItem.currentTime = 10
+
+    self.sut.currentItem = playableItem
+    self.sut.setNowPlayingBookTime()
+
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] as? Double) == 1)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double) == 10)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] as? Double) == 50)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] as? Double) == 0.20)
+  }
+
+  func testUpdatingChapterRemainingNowPlayingBookTime() {
+    // playback speed should affect duration time set
+    self.sut.setSpeed(2)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    // mocked playable item
+    let playableItem = generatePlayableItem()
+    playableItem.currentTime = 10
+
+    self.sut.currentItem = playableItem
+    self.sut.setNowPlayingBookTime()
+
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] as? Double) == 1)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] as? Double) == 10)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] as? Double) == 30)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] as? Double) == 0.20)
+  }
+
+  func testUpdatingEmptyNowPlayingBookTitle() {
+    let playableItem = generatePlayableItem()
+    let chapter = playableItem.chapters.first!
+
+    self.sut.setNowPlayingBookTitle(chapter: chapter)
+
+    XCTAssertNil(self.sut.nowPlayingInfo[MPMediaItemPropertyTitle])
+    XCTAssertNil(self.sut.nowPlayingInfo[MPMediaItemPropertyArtist])
+    XCTAssertNil(self.sut.nowPlayingInfo[MPMediaItemPropertyAlbumTitle])
+  }
+
+  func testUpdatingNowPlayingBookTitle() {
+    let playableItem = generatePlayableItem()
+    let chapter = playableItem.chapters.first!
+
+    self.sut.currentItem = playableItem
+    self.sut.setNowPlayingBookTitle(chapter: chapter)
+
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyTitle] as? String) == chapter.title)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyArtist] as? String) == playableItem.title)
+    XCTAssertTrue((self.sut.nowPlayingInfo[MPMediaItemPropertyAlbumTitle] as? String) == playableItem.author)
+  }
+}

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -21,6 +21,7 @@ public final class PlayableItem: NSObject, Identifiable {
   @objc dynamic public let relativePath: String
   @objc dynamic public var percentCompleted: Double
   public var isFinished: Bool
+  // This property is explicitly set for bound books, for seeking purposes
   public let useChapterTimeContext: Bool
 
   @Published public var currentChapter: PlayableChapter!


### PR DESCRIPTION
## Bugfix

`MPNowPlayingInfoPropertyPlaybackProgress` is being set wrong when the app shows the remaining time

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/782

## Approach

- Use the real max time of the book when calculating the current progress
- Add tests

## Things to be aware of / Things to focus on

It turns out that `MPNowPlayingInfoPropertyPlaybackProgress` is not taken into account when the OS sets the progress bar in the control center, as mentioned in #782, when the remaining time is being shown, we need to have the same value for duration inside the app and for the flag `MPMediaItemPropertyPlaybackDuration`, which skews the progress in the control center
