### PR TITLE
[Storage management] Links to stored books with unicode characters not being found

### DIFF
--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -95,6 +95,8 @@ class StorageViewModelMissingFileTests: XCTestCase {
                            path: self.directoryURL.path,
                            size: 10,
                            showWarning: true)
+    // Trigger library creation for this test
+    XCTAssertTrue(self.viewModel.library.items?.array.isEmpty ?? false)
     try self.viewModel.handleFix(for: item)
 
     let expectation = XCTestExpectation(description: "Items load expectation")

--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -19,6 +19,30 @@ class StorageViewModelMissingFileTests: XCTestCase {
   var directoryURL: URL!
   let testPath = "/dev/null"
 
+  func testSetupItem(in folder: String, filename: String) {
+    let bookContents = "bookcontents".data(using: .utf8)!
+    let documentsURL = DataManager.getDocumentsFolderURL()
+
+    self.directoryURL = try! FileManager.default.url(
+      for: .itemReplacementDirectory,
+         in: .userDomainMask,
+         appropriateFor: documentsURL,
+         create: true
+    )
+
+    let folderURL = try! DataTestUtils.generateTestFolder(name: folder, destinationFolder: self.directoryURL)
+
+    // Add test file to the Processed folder
+    _ = DataTestUtils.generateTestFile(name: filename,
+                                       contents: bookContents,
+                                       destinationFolder: folderURL)
+
+    let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: self.testPath))
+    let libraryService = LibraryService(dataManager: dataManager)
+    self.viewModel = StorageViewModel(libraryService: libraryService,
+                                      folderURL: self.directoryURL)
+  }
+
   func testSetup(with filename: String) {
     let bookContents = "bookcontents".data(using: .utf8)!
 
@@ -89,5 +113,41 @@ class StorageViewModelMissingFileTests: XCTestCase {
 
     let brokenItems = self.viewModel.getBrokenItems()
     XCTAssert(brokenItems.isEmpty)
+  }
+
+  func testUnicodeMissingItem() throws {
+    let folderName = "Maigretův první případ"
+    let bookName = "idyllica_04_herrick_64kb.mp3"
+
+    self.testSetupItem(in: folderName, filename: bookName)
+    self.subscription?.cancel()
+
+    let expectation = XCTestExpectation(description: "Items load expectation")
+
+    var loadedFileURL: URL!
+    self.subscription = self.viewModel.observeFiles()
+      .sink { optionalItems in
+        guard let item = optionalItems?.first else { return }
+        loadedFileURL = item.fileURL
+        expectation.fulfill()
+      }
+
+    wait(for: [expectation], timeout: 5.0)
+
+    // Manual recreation of folder and book inside library
+    let folder = try self.viewModel.libraryService.createFolder(with: folderName, inside: nil)
+    let book = self.viewModel.libraryService.createBook(from: loadedFileURL)
+    folder.insert(item: book)
+    self.viewModel.library.insert(item: folder)
+
+    let currentRelativePath = self.viewModel.getRelativePath(of: loadedFileURL, baseURL: self.directoryURL)
+
+    // manually fetched book should be nil
+    let fetchedBook = self.viewModel.libraryService.getItem(
+      with: currentRelativePath
+    ) as? Book
+
+    XCTAssert(fetchedBook == nil)
+    XCTAssertFalse(self.viewModel.shouldShowWarning(for: "Maigretův první případ/idyllica_04_herrick_64kb.mp3", book: nil))
   }
 }

--- a/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Library+CoreDataClass.swift
@@ -16,6 +16,22 @@ public class Library: NSManagedObject, Codable {
         return self.items?.array as? [LibraryItem] ?? []
     }
 
+  public func bookExists(with relativePath: String) -> Bool {
+    guard let items = self.items?.array as? [LibraryItem] else {
+      return false
+    }
+
+    return items.contains { item in
+      if let book = item as? Book {
+        return book.relativePath == relativePath
+      } else if let folder = item as? Folder {
+        return folder.getItem(with: relativePath) != nil
+      }
+
+      return false
+    }
+  }
+
     public func itemIndex(with relativePath: String) -> Int? {
         guard let items = self.items?.array as? [LibraryItem] else {
             return nil


### PR DESCRIPTION
## Bugfix

File URLs come with unicode characters percent encoded, while stored books have their unicode as scalars, making the core data fetch requests fail

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/790

## Approach

Double check as a last resort within the library object if the item exists or not

## Things to be aware of / Things to focus on

This PR also includes reloading the library list to avoid issues like loading an extra page
