### PR TITLE
Fix playback starting ahead of chapter start on Volumes

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		9FB7C4912835A5A3003B917E /* EmptyPlaybackServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C4902835A5A3003B917E /* EmptyPlaybackServiceMock.swift */; };
 		9FB7C4932835A617003B917E /* EmptySpeedServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C4922835A617003B917E /* EmptySpeedServiceMock.swift */; };
 		9FE07E1B27C522DE007591F7 /* ContainerItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE07E1A27C522DE007591F7 /* ContainerItemListView.swift */; };
+		9FFCC08F289418CA00F4952E /* SimpleChapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFCC08E289418CA00F4952E /* SimpleChapter.swift */; };
+		9FFCC090289418CA00F4952E /* SimpleChapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFCC08E289418CA00F4952E /* SimpleChapter.swift */; };
 		C30B66AE20E2D8CF00FC0030 /* ArtworkControl.xib in Resources */ = {isa = PBXBuildFile; fileRef = C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */; };
 		C318D3AD208CF624000666F8 /* PlayerJumpIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C318D3AC208CF624000666F8 /* PlayerJumpIcon.swift */; };
 		C318DDBC20A48D4700C3A17B /* BPMarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C318DDBB20A48D4700C3A17B /* BPMarqueeLabel.swift */; };
@@ -865,6 +867,7 @@
 		9FB7C4902835A5A3003B917E /* EmptyPlaybackServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPlaybackServiceMock.swift; sourceTree = "<group>"; };
 		9FB7C4922835A617003B917E /* EmptySpeedServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySpeedServiceMock.swift; sourceTree = "<group>"; };
 		9FE07E1A27C522DE007591F7 /* ContainerItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerItemListView.swift; sourceTree = "<group>"; };
+		9FFCC08E289418CA00F4952E /* SimpleChapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleChapter.swift; sourceTree = "<group>"; };
 		C30B085E209654E3003F325B /* UIColor+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BookPlayer.swift"; sourceTree = "<group>"; };
 		C30B66AD20E2D8CF00FC0030 /* ArtworkControl.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ArtworkControl.xib; sourceTree = "<group>"; };
 		C30CD2A0209791FA00258B09 /* UIColor+Sweetercolor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Sweetercolor.swift"; sourceTree = "<group>"; };
@@ -1475,6 +1478,7 @@
 			isa = PBXGroup;
 			children = (
 				41188D3026ED715D0017124E /* SimpleLibraryItem.swift */,
+				9FFCC08E289418CA00F4952E /* SimpleChapter.swift */,
 				41546FF226F559CE00825180 /* SimpleItemType.swift */,
 				412AB73B2702BDED00969618 /* SimpleTheme.swift */,
 				41546FF026F54F0600825180 /* PlaybackState.swift */,
@@ -2339,6 +2343,7 @@
 				4140EA71227289A20009F794 /* UIColor+BookPlayer.swift in Sources */,
 				4138CE1726E584B60014F11E /* BookmarkType.swift in Sources */,
 				5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
+				9FFCC090289418CA00F4952E /* SimpleChapter.swift in Sources */,
 				419BD5992443FD04001E50A0 /* Intents.intentdefinition in Sources */,
 				62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */,
 				62CADBAF2725FE2C00A4A98F /* ArtworkService.swift in Sources */,
@@ -2572,6 +2577,7 @@
 				41A1B11F226F88C500EA0400 /* Chapter+CoreDataClass.swift in Sources */,
 				4138CE1626E584B60014F11E /* BookmarkType.swift in Sources */,
 				412AB7092701421600969618 /* ManualOrderMigrationUtils.swift in Sources */,
+				9FFCC08F289418CA00F4952E /* SimpleChapter.swift in Sources */,
 				416AAC3423F515AF005AD04F /* String+BookPlayer.swift in Sources */,
 				62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */,
 				41A1B126226F88C500EA0400 /* LibraryItem+CoreDataProperties.swift in Sources */,

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -54,7 +54,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
 
     if let currentChapter = self.playerManager.currentItem?.currentChapter,
        let previousChapter = self.playerManager.currentItem?.previousChapter(before: currentChapter) {
-      self.playerManager.jumpTo(previousChapter.start + 0.5, recordBookmark: false)
+      self.playerManager.jumpTo(previousChapter.start, recordBookmark: false)
     } else {
       self.playerManager.playPreviousItem()
     }
@@ -65,7 +65,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
 
     if let currentChapter = self.playerManager.currentItem?.currentChapter,
        let nextChapter = self.playerManager.currentItem?.nextChapter(after: currentChapter) {
-      self.playerManager.jumpTo(nextChapter.start + 0.5, recordBookmark: false)
+      self.playerManager.jumpTo(nextChapter.start, recordBookmark: false)
     } else {
       self.playerManager.playNextItem(autoPlayed: false)
     }

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -250,7 +250,7 @@ extension CarPlayManager {
 
       if let currentChapter = playerManager.currentItem?.currentChapter,
          let previousChapter = playerManager.currentItem?.previousChapter(before: currentChapter) {
-        playerManager.jumpTo(previousChapter.start + 0.5, recordBookmark: false)
+        playerManager.jumpTo(previousChapter.start, recordBookmark: false)
       } else {
         playerManager.playPreviousItem()
       }
@@ -267,7 +267,7 @@ extension CarPlayManager {
 
       if let currentChapter = playerManager.currentItem?.currentChapter,
          let nextChapter = playerManager.currentItem?.nextChapter(after: currentChapter) {
-        playerManager.jumpTo(nextChapter.start + 0.5, recordBookmark: false)
+        playerManager.jumpTo(nextChapter.start, recordBookmark: false)
       } else {
         playerManager.playNextItem(autoPlayed: false)
       }

--- a/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
@@ -39,7 +39,7 @@ class EmptyLibraryServiceMock: LibraryServiceProtocol {
     return Book()
   }
 
-  func getChapters(from relativePath: String) -> [Chapter]? {
+  func getChapters(from relativePath: String) -> [SimpleChapter]? {
     return nil
   }
 

--- a/BookPlayerTests/PlayableItemTests.swift
+++ b/BookPlayerTests/PlayableItemTests.swift
@@ -42,7 +42,7 @@ class PlayableItemTests: XCTestCase {
       relativePath: "",
       percentCompleted: 10,
       isFinished: false,
-      useChapterTimeContext: false
+      isBoundBook: false
     )
   }
 

--- a/BookPlayerTests/PlayerManagerTests.swift
+++ b/BookPlayerTests/PlayerManagerTests.swift
@@ -54,7 +54,7 @@ class PlayerManagerTests: XCTestCase {
       relativePath: "",
       percentCompleted: 10,
       isFinished: false,
-      useChapterTimeContext: false
+      isBoundBook: false
     )
   }
 

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1209,6 +1209,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     ]
 
     book.chapters = NSOrderedSet(array: chapters)
+    self.sut.dataManager.saveContext()
 
     let fetchedChapters = self.sut.getChapters(from: book.relativePath)
 

--- a/BookPlayerTests/Support/StubFactory.swift
+++ b/BookPlayerTests/Support/StubFactory.swift
@@ -53,7 +53,9 @@ class StubFactory {
     // swiftlint:disable:next force_cast
     let chapter = NSEntityDescription.insertNewObject(forEntityName: "Chapter", into: dataManager.getContext()) as! Chapter
     chapter.index = index
+    chapter.start = 0
     chapter.duration = 0
+    chapter.title = "test"
     return chapter
   }
 

--- a/BookPlayerWatch Extension/ItemList/ItemCellView.swift
+++ b/BookPlayerWatch Extension/ItemList/ItemCellView.swift
@@ -37,7 +37,7 @@ struct ItemCellView_Previews: PreviewProvider {
         relativePath: "book 1",
         percentCompleted: 0,
         isFinished: false,
-        useChapterTimeContext: false
+        isBoundBook: false
       ))
     }
   }

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -22,7 +22,7 @@ public final class PlayableItem: NSObject, Identifiable {
   @objc dynamic public var percentCompleted: Double
   public var isFinished: Bool
   // This property is explicitly set for bound books, for seeking purposes
-  public let useChapterTimeContext: Bool
+  public let isBoundBook: Bool
 
   @Published public var currentChapter: PlayableChapter!
 
@@ -37,7 +37,7 @@ public final class PlayableItem: NSObject, Identifiable {
   }
 
   enum CodingKeys: String, CodingKey {
-    case title, author, chapters, currentTime, duration, relativePath, percentCompleted, isFinished, useChapterTimeContext
+    case title, author, chapters, currentTime, duration, relativePath, percentCompleted, isFinished, isBoundBook
   }
 
   public init(
@@ -49,7 +49,7 @@ public final class PlayableItem: NSObject, Identifiable {
     relativePath: String,
     percentCompleted: Double,
     isFinished: Bool,
-    useChapterTimeContext: Bool
+    isBoundBook: Bool
   ) {
     self.title = title
     self.author = author
@@ -59,7 +59,7 @@ public final class PlayableItem: NSObject, Identifiable {
     self.relativePath = relativePath
     self.percentCompleted = percentCompleted
     self.isFinished = isFinished
-    self.useChapterTimeContext = useChapterTimeContext
+    self.isBoundBook = isBoundBook
 
     super.init()
 
@@ -79,7 +79,7 @@ public final class PlayableItem: NSObject, Identifiable {
       return lastChapter
     }
 
-    return self.chapters.first { $0.start <= globalTime && $0.end > globalTime }
+    return self.chapters.first { globalTime < $0.end && $0.start <= globalTime }
   }
 
   public func updateCurrentChapter() {
@@ -201,7 +201,7 @@ extension PlayableItem: Codable {
     try container.encode(self.relativePath, forKey: .relativePath)
     try container.encode(self.percentCompleted, forKey: .percentCompleted)
     try container.encode(self.isFinished, forKey: .isFinished)
-    try container.encode(self.useChapterTimeContext, forKey: .useChapterTimeContext)
+    try container.encode(self.isBoundBook, forKey: .isBoundBook)
   }
 
   public convenience init(from decoder: Decoder) throws {
@@ -215,7 +215,7 @@ extension PlayableItem: Codable {
       relativePath: try values.decode(String.self, forKey: .relativePath),
       percentCompleted: try values.decode(Double.self, forKey: .percentCompleted),
       isFinished: try values.decode(Bool.self, forKey: .isFinished),
-      useChapterTimeContext: try values.decode(Bool.self, forKey: .useChapterTimeContext)
+      isBoundBook: try values.decode(Bool.self, forKey: .isBoundBook)
     )
   }
 }

--- a/Shared/CoreData/Lightweight-Models/SimpleChapter.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleChapter.swift
@@ -1,0 +1,16 @@
+//
+//  SimpleChapter.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 29/7/22.
+//  Copyright © 2022 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+public struct SimpleChapter {
+  public let title: String
+  public let start: Double
+  public let duration: Double
+  public let index: Int16
+}

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -90,7 +90,7 @@ public final class PlaybackService: PlaybackServiceProtocol {
       relativePath: book.relativePath,
       percentCompleted: book.percentCompleted,
       isFinished: book.isFinished,
-      useChapterTimeContext: false
+      isBoundBook: false
     )
   }
 
@@ -150,7 +150,7 @@ public final class PlaybackService: PlaybackServiceProtocol {
       relativePath: folder.relativePath,
       percentCompleted: folder.percentCompleted,
       isFinished: folder.isFinished,
-      useChapterTimeContext: true
+      isBoundBook: true
     )
   }
 


### PR DESCRIPTION
## Purpose

There's a problem when a new chapter starts for volume books, it's minor on most books (as it usually chops off the 'Chapter' word read at the start), but annoying nonetheless 

## Approach

- Limit the threshold +0.5 to only be used for m4b books, as this is the source of mp3s starting ahead of time
- Fix updating the UI when playback is paused
- Refactor loading Chapter core data object directly into SimpleChapter object to avoid extra loads
