### PR TITLE
New setting for restarting autoplayed finished books

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Settings";
 "settings_title" = "Settings";
 "settings_autoplay_title" = "AutoPlay Library";
-"settings_autoplay_description" = "After finishing an audiobook, playback will resume with all items in the library that are not completed, including items in folders.";
+"settings_autoplay_description" = "After finishing an audiobook, playback will resume with all items in the library, including items in folders.";
 "settings_smartrewind_title" = "Smart Rewind";
 "settings_smartrewind_description" = "Rewind 30 seconds after being paused for 10 minutes.";
 "settings_boostvolume_title" = "Boost Volume";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Use Chapter Context";
 "settings_progresslabels_description" = "Toggle between displaying the remaining time, total duration and progress of either the chapter or the book in the player screen";
 "settings_playerinterface_list_description" = "Adjust what the list button in the player screen opens";
+"settings_autoplay_section_title" = "AUTOPLAY";
+"settings_autoplay_restart_title" = "Restart finished books";

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -185,6 +185,10 @@ class DataInitializerCoordinator {
     if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayEnabled.rawValue) == nil {
       UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
     }
+    // Set autoplay finished enabled as default
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
+    }
 
     let libraryService = LibraryService(dataManager: dataManager)
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -650,14 +650,24 @@ extension PlayerManager {
       return
     }
 
+    let restartFinished = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
+
     guard
       let currentItem = self.currentItem,
       let nextBook = self.playbackService.getPlayableItem(
         after: currentItem.relativePath,
         parentFolder: currentItem.parentFolder,
-        autoplayed: autoPlayed
+        autoplayed: autoPlayed,
+        restartFinished: restartFinished
       )
     else { return }
+
+    /// If autoplaying a finished book and restart is enabled, set currentTime to 0
+    if autoPlayed,
+       nextBook.isFinished,
+       restartFinished {
+      self.playbackService.updatePlaybackTime(item: nextBook, time: 0)
+    }
 
     self.playItem(nextBook)
   }

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21179.7" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nNa-3d-7ZC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21223" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nNa-3d-7ZC">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21169.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21204"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -157,10 +157,10 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection footerTitle="Continue playback with all items in the Library that are not completed, including files in playlists." id="xgC-Yo-CeI">
+                            <tableViewSection headerTitle="AUTOPLAY" footerTitle="Continue playback with all items in the Library that are not completed, including files in playlists." id="xgC-Yo-CeI">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="mZC-FQ-bJv" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="518" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="545.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mZC-FQ-bJv" id="d1P-2x-oKv">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -194,12 +194,47 @@
                                             <outlet property="customLabel" destination="CmE-t6-YbE" id="fVM-Th-JnE"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="43C-Ha-Yxc" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="589.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="43C-Ha-Yxc" id="brU-gK-EvR">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Dwy-AZ-0Mo">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="49" id="eOa-gm-OpN"/>
+                                                    </constraints>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Restart finished books" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wzg-bn-V3w" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="11.5" width="286" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_autoplay_restart_title"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Dwy-AZ-0Mo" firstAttribute="leading" secondItem="wzg-bn-V3w" secondAttribute="trailing" constant="8" id="1Nx-Pn-gde"/>
+                                                <constraint firstItem="wzg-bn-V3w" firstAttribute="centerY" secondItem="brU-gK-EvR" secondAttribute="centerY" id="Gse-vP-63G"/>
+                                                <constraint firstItem="Dwy-AZ-0Mo" firstAttribute="centerY" secondItem="brU-gK-EvR" secondAttribute="centerY" id="WSG-6k-yZr"/>
+                                                <constraint firstItem="wzg-bn-V3w" firstAttribute="leading" secondItem="brU-gK-EvR" secondAttribute="leading" constant="16" id="XO9-C0-2mT"/>
+                                                <constraint firstAttribute="trailing" secondItem="Dwy-AZ-0Mo" secondAttribute="trailing" constant="16" id="rCE-BC-7lH"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="customLabel" destination="wzg-bn-V3w" id="RKD-Yc-z6O"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection footerTitle="Prevent the device from locking when on the Player screen. " id="ol9-Yg-Kce">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="CAX-9V-L9h" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="626" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="697.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CAX-9V-L9h" id="Fmf-ga-zlY">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -234,7 +269,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="AuQ-P2-doo" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="670" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="741.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AuQ-P2-doo" id="3Hy-3P-G22">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -273,7 +308,7 @@
                             <tableViewSection headerTitle="Siri Shortcut" id="V2g-SX-Hc4">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="3Hf-KW-kuZ" style="IBUITableViewCellStyleDefault" id="uAD-fX-V6A" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="798" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="869.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uAD-fX-V6A" id="TYe-ak-jZf">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
@@ -293,7 +328,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="BsZ-qn-RYs" style="IBUITableViewCellStyleDefault" id="eGV-vo-55W" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="842" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="913.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eGV-vo-55W" id="fIX-20-CXK">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
@@ -317,7 +352,7 @@
                             <tableViewSection headerTitle="ICLOUD BACKUPS" id="Ih3-au-VR8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="geY-VJ-JHG" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="942" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1013.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="geY-VJ-JHG" id="zPn-MZ-SwT">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -356,7 +391,7 @@
                             <tableViewSection headerTitle="Support" id="HHg-sB-jse">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ClD-F6-XBV" detailTextLabel="p5a-8D-TIK" rowHeight="50" style="IBUITableViewCellStyleSubtitle" id="ml3-w4-0Kh" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1042" width="375" height="50"/>
+                                        <rect key="frame" x="0.0" y="1113.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ml3-w4-0Kh" id="iby-ep-R6R">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -390,7 +425,7 @@
                                         </accessibility>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="nCM-M8-bSw" detailTextLabel="6ow-P5-iYK" rowHeight="50" style="IBUITableViewCellStyleSubtitle" id="SPt-vd-9qJ" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1092" width="375" height="50"/>
+                                        <rect key="frame" x="0.0" y="1163.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SPt-vd-9qJ" id="IOg-0m-vsn">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -421,7 +456,7 @@
                                         </accessibility>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="MVf-CT-ocr" rowHeight="50" style="IBUITableViewCellStyleDefault" id="g64-9I-V0m" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1142" width="375" height="50"/>
+                                        <rect key="frame" x="0.0" y="1213.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="g64-9I-V0m" id="f9T-VJ-ed5">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -451,7 +486,7 @@
                             <tableViewSection id="7d8-SQ-Lj5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="f5k-Kh-fBQ" style="IBUITableViewCellStyleDefault" id="03X-zP-RZe" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1228" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1299.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="03X-zP-RZe" id="IIp-cC-U1k">
                                             <rect key="frame" x="0.0" y="0.0" width="356.5" height="44"/>
@@ -494,6 +529,7 @@
                         <outlet property="autolockDisabledOnlyWhenPoweredLabel" destination="ZUk-YK-XeG" id="2hI-Ie-TKo"/>
                         <outlet property="autolockDisabledOnlyWhenPoweredSwitch" destination="NMd-BM-Aab" id="FuE-ky-W4F"/>
                         <outlet property="autoplayLibrarySwitch" destination="U00-rk-lxZ" id="HCv-jo-TbM"/>
+                        <outlet property="autoplayRestartSwitch" destination="Dwy-AZ-0Mo" id="gkj-22-udL"/>
                         <outlet property="disableAutolockSwitch" destination="BlM-8p-0Ka" id="Fbl-zc-kUw"/>
                         <outlet property="iCloudBackupsSwitch" destination="ssf-Q5-vn2" id="pjG-GZ-NHe"/>
                         <outlet property="themeLabel" destination="CVc-ad-1rf" id="I40-1O-6rO"/>
@@ -645,7 +681,7 @@
             <objects>
                 <navigationController storyboardIdentifier="PlusNavigationController" id="d6y-ya-0pE" customClass="PlusNavigationController" customModule="BookPlayer" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="v1q-oa-GaA">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -661,11 +697,11 @@
             <objects>
                 <viewController storyboardIdentifier="PlusViewController" title="BookPlayer Plus" id="AQw-yJ-pXJ" customClass="PlusViewController" customModule="BookPlayer" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BG4-7I-rMx">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="824"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="836"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MvT-oX-RXS">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="824"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="836"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="grA-HN-IYo">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="835"/>

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -22,6 +22,7 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
                               MFMailComposeViewControllerDelegate,
                               Storyboarded {
   @IBOutlet weak var autoplayLibrarySwitch: UISwitch!
+  @IBOutlet weak var autoplayRestartSwitch: UISwitch!
   @IBOutlet weak var disableAutolockSwitch: UISwitch!
   @IBOutlet weak var autolockDisabledOnlyWhenPoweredSwitch: UISwitch!
   @IBOutlet weak var iCloudBackupsSwitch: UISwitch!
@@ -90,13 +91,19 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
 
   func setupSwitchValues() {
     self.autoplayLibrarySwitch.addTarget(self, action: #selector(self.autoplayToggleDidChange), for: .valueChanged)
+    self.autoplayRestartSwitch.addTarget(self, action: #selector(self.autoplayRestartToggleDidChange), for: .valueChanged)
     self.disableAutolockSwitch.addTarget(self, action: #selector(self.disableAutolockDidChange), for: .valueChanged)
     self.autolockDisabledOnlyWhenPoweredSwitch.addTarget(self, action: #selector(self.autolockOnlyWhenPoweredDidChange), for: .valueChanged)
     self.iCloudBackupsSwitch.addTarget(self, action: #selector(self.iCloudBackupsDidChange), for: .valueChanged)
 
     // Set initial switch positions
     self.iCloudBackupsSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.iCloudBackupsEnabled.rawValue), animated: false)
-    self.autoplayLibrarySwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled.rawValue), animated: false)
+    let isAutoplayEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
+    self.autoplayLibrarySwitch.setOn(isAutoplayEnabled, animated: false)
+    autoplayRestartSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue), animated: false)
+    if !isAutoplayEnabled {
+      autoplayRestartSwitch.isEnabled = false
+    }
     self.disableAutolockSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue), animated: false)
     self.autolockDisabledOnlyWhenPoweredSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue), animated: false)
     self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue)
@@ -109,6 +116,11 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
 
     @objc func autoplayToggleDidChange() {
         UserDefaults.standard.set(self.autoplayLibrarySwitch.isOn, forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
+      self.autoplayRestartSwitch.isEnabled = autoplayLibrarySwitch.isOn
+    }
+
+    @objc func autoplayRestartToggleDidChange() {
+      UserDefaults.standard.set(self.autoplayRestartSwitch.isOn, forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
     }
 
     @objc func disableAutolockDidChange() {

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "الاعدادات";
 "settings_title" = "الاعدادات";
 "settings_autoplay_title" = "مكتبة التشغيل التلقائي";
-"settings_autoplay_description" = "بعد الانتهاء من كتاب صوتي ، سيستأنف التشغيل مع جميع العناصر الموجودة في المكتبة التي لم تكتمل ، بما في ذلك العناصر الموجودة في المجلدات.";
+"settings_autoplay_description" = "بعد الانتهاء من كتاب صوتي ، سيستأنف التشغيل مع جميع العناصر الموجودة في المكتبة ، بما في ذلك العناصر الموجودة في المجلدات.";
 "settings_smartrewind_title" = "إعادة الإرجاع الذكية";
 "settings_smartrewind_description" = "الترجيع 30 ثانية بعد توقف لمدة 10 دقائق.";
 "settings_boostvolume_title" = "زيادة مستوى الصوت";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "استخدم سياق الفصل";
 "settings_progresslabels_description" = "قم بالتبديل بين عرض الوقت المتبقي والمدة الإجمالية والتقدم في الفصل أو الكتاب في شاشة المشغل";
 "settings_playerinterface_list_description" = "اضبط ما يفتحه زر القائمة في شاشة المشغل";
+"settings_autoplay_section_title" = "تشغيل تلقائي";
+"settings_autoplay_restart_title" = "أعد تشغيل الكتب المنتهية";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Nastavení";
 "settings_title" = "Nastavení";
 "settings_autoplay_title" = "Knihovna automatického přehrávání";
-"settings_autoplay_description" = "Po dokončení audioknihy se přehrávání obnoví se všemi položkami v knihovně, které nejsou dokončeny, včetně položek ve složkách.";
+"settings_autoplay_description" = "Po dokončení audioknihy se přehrávání obnoví se všemi položkami v knihovně, včetně položek ve složkách.";
 "settings_smartrewind_title" = "Chytré přetáčení";
 "settings_smartrewind_description" = "Po přerušení poslechu na 10 minut dojde k přetočení zpět o 30 sekund.";
 "settings_boostvolume_title" = "Zvýšení hlasitosti";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Použijte kontext kapitoly";
 "settings_progresslabels_description" = "Přepínání mezi zobrazením zbývajícího času, celkové doby trvání a průběhu kapitoly nebo knihy na obrazovce přehrávače";
 "settings_playerinterface_list_description" = "Upravte, co otevře tlačítko seznamu na obrazovce přehrávače";
+"settings_autoplay_section_title" = "AUTOMATICKÉ PŘEHRÁVÁNÍ";
+"settings_autoplay_restart_title" = "Restartujte hotové knihy";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Indstillinger";
 "settings_title" = "Indstillinger";
 "settings_autoplay_title" = "AutoPlay Bibliotek";
-"settings_autoplay_description" = "Når du har afsluttet en lydbog, genoptages afspilningen med alle elementer i biblioteket, der ikke er afsluttet, inklusive elementer i mapper.";
+"settings_autoplay_description" = "Når du har afsluttet en lydbog, genoptages afspilningen med alle elementer i biblioteket, inklusive elementer i mapper.";
 "settings_smartrewind_title" = "Smart Tilbagespolning";
 "settings_smartrewind_description" = "Spol 30 sekunder tilbage, efter at du har sat bogen på pause i 10 minutter.";
 "settings_boostvolume_title" = "Boost lydstyrken";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Brug kapitelkontekst";
 "settings_progresslabels_description" = "Skift mellem at vise den resterende tid, den samlede varighed og fremskridt for enten kapitlet eller bogen på afspillerskærmen";
 "settings_playerinterface_list_description" = "Juster, hvad listeknappen på afspillerskærmen åbner";
+"settings_autoplay_section_title" = "AUTOMATISK AFSPILNING";
+"settings_autoplay_restart_title" = "Genstart færdige bøger";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Einstellungen";
 "settings_title" = "Einstellungen";
 "settings_autoplay_title" = "Kontinuierliche Wiedergabe";
-"settings_autoplay_description" = "Nach Beenden eines Hörbuchs wird die Wiedergabe mit allen Elementen in der Bibliothek fortgesetzt, die noch nicht abgeschlossen sind, einschließlich Dateien in Wiedergabelisten.";
+"settings_autoplay_description" = "Nach Beendigung eines Hörbuchs wird die Wiedergabe mit allen Elementen in der Bibliothek fortgesetzt, einschließlich Elementen in Ordnern.";
 "settings_smartrewind_title" = "Intelligentes Zurückspulen";
 "settings_smartrewind_description" = "30 Sekunden zurückspulen, nachdem die Wiedergabe für 10 Minuten oder länger angehalten wurde.";
 "settings_boostvolume_title" = "Lautstärke erhöhen";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Kapitelkontext verwenden";
 "settings_progresslabels_description" = "Zwischen der Anzeige der verbleibenden Zeit, der Gesamtdauer und des Kapitel- oder Buchfortschritts auf dem Wiedergabebildschirm umschalten.";
 "settings_playerinterface_list_description" = "Anpassen, was die Taste „Liste“ auf dem Wiedergabebildschirm öffnet";
+"settings_autoplay_section_title" = "AUTOMATISCHES ABSPIELEN";
+"settings_autoplay_restart_title" = "Fertige Bücher neu starten";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Settings";
 "settings_title" = "Settings";
 "settings_autoplay_title" = "AutoPlay Library";
-"settings_autoplay_description" = "After finishing an audiobook, playback will resume with all items in the library that are not completed, including items in folders.";
+"settings_autoplay_description" = "After finishing an audiobook, playback will resume with all items in the library, including items in folders.";
 "settings_smartrewind_title" = "Smart Rewind";
 "settings_smartrewind_description" = "Rewind 30 seconds after being paused for 10 minutes.";
 "settings_boostvolume_title" = "Boost Volume";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Use Chapter Context";
 "settings_progresslabels_description" = "Toggle between displaying the remaining time, total duration and progress of either the chapter or the book in the player screen";
 "settings_playerinterface_list_description" = "Adjust what the list button in the player screen opens";
+"settings_autoplay_section_title" = "AUTOPLAY";
+"settings_autoplay_restart_title" = "Restart finished books";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Ajustes";
 "settings_title" = "Ajustes";
 "settings_autoplay_title" = "Reproducción Automática de la Biblioteca";
-"settings_autoplay_description" = "Después de terminar un audiolibro, la reproducción se reanudará con todos los elementos de la biblioteca que no estén completos, incluidos los elementos de las carpetas.";
+"settings_autoplay_description" = "Después de terminar un audiolibro, la reproducción se reanudará con todos los elementos de la biblioteca, incluidos los elementos de las carpetas.";
 "settings_smartrewind_title" = "Rebobinado Inteligente";
 "settings_smartrewind_description" = "Retrocede 30 segundos después de estar en pausa durante 10 minutos.";
 "settings_boostvolume_title" = "Aumentar el volumen";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Usar el contexto del capítulo";
 "settings_progresslabels_description" = "Alterna entre mostrar el tiempo restante, la duración total y el progreso del capítulo o del libro en la pantalla del reproductor";
 "settings_playerinterface_list_description" = "Ajusta lo que el botón de lista abre en la pantalla del reproductor";
+"settings_autoplay_section_title" = "AUTO-REPRODUCCIÓN";
+"settings_autoplay_restart_title" = "Reiniciar libros terminados";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Asetukset";
 "settings_title" = "Asetukset";
 "settings_autoplay_title" = "Kirjaston automaattitoisto";
-"settings_autoplay_description" = "Kun äänikirja on valmis, toisto jatkuu kaikilla kirjaston kohteilla, joita ei ole vielä valmisteltu, mukaan lukien kansioiden kohteet.";
+"settings_autoplay_description" = "Kun äänikirja on valmis, toisto jatkuu kaikilla kirjaston kohteilla, mukaan lukien kansioissa olevat kohteet.";
 "settings_smartrewind_title" = "Älykäs taaksepäinkelaus";
 "settings_smartrewind_description" = "Kelaa taaksepäin 30 sekuntia 10 minuutin tauon jälkeen.";
 "settings_boostvolume_title" = "Lisää äänenvoimakkuutta";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Käytä luvun kontekstia";
 "settings_progresslabels_description" = "Vaihda jäljellä olevan ajan, kokonaiskeston ja joko luvun tai kirjan edistymisen näyttämisen välillä soittimen näytössä";
 "settings_playerinterface_list_description" = "Säädä, mitä luettelopainike avautuu soittimen näytössä";
+"settings_autoplay_section_title" = "AUTOMAATTINEN TOISTO";
+"settings_autoplay_restart_title" = "Käynnistä valmiit kirjat uudelleen";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Réglages";
 "settings_title" = "Réglages";
 "settings_autoplay_title" = "Lecture auto. de la Bibliothèque";
-"settings_autoplay_description" = "Après avoir terminé un livre audio, la lecture reprendra avec tous les éléments de la bibliothèque qui ne sont pas terminés, y compris les éléments des dossiers.";
+"settings_autoplay_description" = "Après avoir terminé un livre audio, la lecture reprendra avec tous les éléments de la bibliothèque, y compris les éléments des dossiers.";
 "settings_smartrewind_title" = "Rembobinage intelligent";
 "settings_smartrewind_description" = "Rembobine 30 secondes après avoir été mis en pause pendant 10 minutes.";
 "settings_boostvolume_title" = "Augmenter le volume";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Utiliser le contexte du chapitre";
 "settings_progresslabels_description" = "Basculer entre l'affichage du temps restant, de la durée totale et de la progression du chapitre ou du livre sur l'écran du lecteur";
 "settings_playerinterface_list_description" = "Ajustez ce que le bouton de liste dans l'écran du lecteur ouvre";
+"settings_autoplay_section_title" = "LECTURE AUTOMATIQUE";
+"settings_autoplay_restart_title" = "Redémarrez les livres terminés";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Beállítások";
 "settings_title" = "Beállítások";
 "settings_autoplay_title" = "Könyvtárak automatikus lejátszása";
-"settings_autoplay_description" = "A hangoskönyv befejezése után a lejátszás folytatódik a könyvtárban lévő összes, még nem befejezett elemmel, beleértve a mappákban lévő elemeket is.";
+"settings_autoplay_description" = "A hangoskönyv befejezése után a lejátszás folytatódik a könyvtár összes elemével, beleértve a mappákban lévő elemeket is.";
 "settings_smartrewind_title" = "Okos visszatekerés";
 "settings_smartrewind_description" = "Tekerjen vissza 30 másodpercet, ha 10 percig szüneteltette.";
 "settings_boostvolume_title" = "Hangerő növelése";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Fejezet kontextus használata";
 "settings_progresslabels_description" = "Váltás a hátralévő idő, a teljes időtartam és a fejezet vagy a teljes könyv előrehaladásának megjelenítése között a lejátszó képernyőn";
 "settings_playerinterface_list_description" = "A lejátszó képernyőn mi nyíljon meg a lista gomb megnyomására";
+"settings_autoplay_section_title" = "AUTOMATIKUS LEJÁTSZÁS";
+"settings_autoplay_restart_title" = "Indítsa újra a kész könyveket";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Impostazioni";
 "settings_title" = "Impostazioni";
 "settings_autoplay_title" = "Riproduci Automaticamente la Libreria";
-"settings_autoplay_description" = "Dopo aver terminato un audiolibro, la riproduzione riprenderà con tutti gli elementi della libreria che non sono stati completati, inclusi gli elementi nelle cartelle.";
+"settings_autoplay_description" = "Dopo aver terminato un audiolibro, la riproduzione riprenderà con tutti gli elementi nella libreria, inclusi gli elementi nelle cartelle.";
 "settings_smartrewind_title" = "Riavvolgimento intelligente";
 "settings_smartrewind_description" = "Riavvolgi 30 secondi dopo essere stato in pausa per 10 minuti.";
 "settings_boostvolume_title" = "Aumenta il volume massimo";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Usa il contesto del capitolo";
 "settings_progresslabels_description" = "Alterna tra la visualizzazione del tempo rimanente, la durata totale e l'avanzamento del capitolo o del libro nella schermata del lettore";
 "settings_playerinterface_list_description" = "Regola ciò che si apre il pulsante elenco nella schermata del lettore";
+"settings_autoplay_section_title" = "RIPRODUZIONE AUTOMATICA";
+"settings_autoplay_restart_title" = "Riavvia i libri finiti";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Ustawienia";
 "settings_title" = "Ustawienia";
 "settings_autoplay_title" = "Automatyczne odtwarzanie Biblioteki";
-"settings_autoplay_description" = "Po ukończeniu książki audio odtwarzanie zostanie wznowione ze wszystkimi niezakończonymi elementami w bibliotece, w tym z elementami w folderach.";
+"settings_autoplay_description" = "Po ukończeniu książki audio odtwarzanie zostanie wznowione ze wszystkimi elementami w bibliotece, w tym elementami w folderach.";
 "settings_smartrewind_title" = "Inteligentne Cofanie";
 "settings_smartrewind_description" = "Cofnij o 30 sekund po 10 minutowej pauzie.";
 "settings_boostvolume_title" = "Zwiększ głośność";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Użyj kontekstu rozdziału";
 "settings_progresslabels_description" = "Przełącz między wyświetlaniem pozostałego czasu, całkowitego czasu trwania i postępu rozdziału lub książki na ekranie odtwarzacza";
 "settings_playerinterface_list_description" = "Dostosuj, co otwiera przycisk listy na ekranie odtwarzacza";
+"settings_autoplay_section_title" = "AUTOMATYCZNE ODTWARZANIE";
+"settings_autoplay_restart_title" = "Uruchom ponownie ukończone książki";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Configurações";
 "settings_title" = "Configurações";
 "settings_autoplay_title" = "Reprodução automática da Biblioteca";
-"settings_autoplay_description" = "Depois de terminar um audiolivro, a reprodução será retomada com todos os itens da biblioteca que não foram concluídos, incluindo itens em pastas.";
+"settings_autoplay_description" = "Depois de terminar um audiolivro, a reprodução será retomada com todos os itens da biblioteca, incluindo itens nas pastas.";
 "settings_smartrewind_title" = "Retrocesso Inteligente";
 "settings_smartrewind_description" = "Retroceda 30 segundos após ser pausado por 10 minutos.";
 "settings_boostvolume_title" = "Aumentar volume";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Usar Contexto do Capítulo";
 "settings_progresslabels_description" = "Alterne entre a exibição do tempo restante, duração total e progresso do capítulo ou do livro na tela de reprodução";
 "settings_playerinterface_list_description" = "Ajuste o que o botão de lista na tela de reprodução abre";
+"settings_autoplay_section_title" = "REPRODUÇÃO AUTOMÁTICA";
+"settings_autoplay_restart_title" = "Reiniciar livros concluídos";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "settings_button" = "Setări";
 "settings_title" = "Setări";
 "settings_autoplay_title" = "Bibliotecă redare automată";
-"settings_autoplay_description" = "După terminarea unei cărți audio, redarea se va relua cu toate elementele din bibliotecă care nu sunt finalizate, inclusiv articolele din foldere.";
+"settings_autoplay_description" = "După terminarea unei cărți audio, redarea se va relua cu toate elementele din bibliotecă, inclusiv cele din foldere.";
 "settings_smartrewind_title" = "Derulare inteligentă înapoi";
 "settings_smartrewind_description" = "Derulați 30 de secunde înapoi după ce a fost o pauza de 10 minute.";
 "settings_boostvolume_title" = "Creșterea volumului";
@@ -209,3 +209,5 @@
 "settings_chaptercontext_title" = "Utilizați contextul capitolului";
 "settings_progresslabels_description" = "Comutați între afișarea timpului rămas, a duratei totale și a progresului fie al capitolului, fie al cărții în ecranul playerului";
 "settings_playerinterface_list_description" = "Ajustați ce se deschide butonul de listă din ecranul playerului";
+"settings_autoplay_section_title" = "REDARE AUTOMATA";
+"settings_autoplay_restart_title" = "Reporniți cărțile terminate";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Настройки";
 "settings_title" = "Настройки";
 "settings_autoplay_title" = "Автовоспроизведение библиотеки";
-"settings_autoplay_description" = "После завершения аудиокниги воспроизведение возобновится со всеми незавершенными элементами в библиотеке, включая элементы в папках.";
+"settings_autoplay_description" = "После завершения аудиокниги воспроизведение возобновится со всеми элементами в библиотеке, включая элементы в папках.";
 "settings_smartrewind_title" = "Умная перемотка";
 "settings_smartrewind_description" = "Перемотка назад на 30 секунд после 10-минутного перерыва.";
 "settings_boostvolume_title" = "Увеличить громкость";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Использовать контекст главы";
 "settings_progresslabels_description" = "Переключение между отображением оставшегося времени, общей продолжительности и хода выполнения главы или книги на экране проигрывателя.";
 "settings_playerinterface_list_description" = "Отрегулируйте, что открывает кнопка списка на экране плеера";
+"settings_autoplay_section_title" = "АВТОВОСПРОИЗВЕДЕНИЕ";
+"settings_autoplay_restart_title" = "Перезапустить готовые книги";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Nastavenia";
 "settings_title" = "Nastavenia";
 "settings_autoplay_title" = "Knižnica automatického prehrávania";
-"settings_autoplay_description" = "Po dokončení audioknihy sa prehrávanie obnoví so všetkými položkami v knižnici, ktoré nie sú dokončené, vrátane položiek v priečinkoch.";
+"settings_autoplay_description" = "Po dokončení audioknihy sa prehrávanie obnoví so všetkými položkami v knižnici vrátane položiek v priečinkoch.";
 "settings_smartrewind_title" = "Inteligentné pretáčanie";
 "settings_smartrewind_description" = "Po prerušení počúvania na 10 minút dôjde k pretočeniu späť o 30 sekúnd.";
 "settings_boostvolume_title" = "Zvýšenie hlasitosti";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Kontext kapitoly";
 "settings_progresslabels_description" = "Prepínanie medzi zobrazením zostávajúceho času, celkového trvania a priebehu spracovania kapitoly alebo knihy na obrazovke prehrávača";
 "settings_playerinterface_list_description" = "Úprava správania sa tlačidla zoznamu na obrazovke prehrávača";
+"settings_autoplay_section_title" = "AUTOHRA";
+"settings_autoplay_restart_title" = "Reštartujte hotové knihy";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Inställningar";
 "settings_title" = "Inställningar";
 "settings_autoplay_title" = "Automatisk Uppspelning";
-"settings_autoplay_description" = "När du har avslutat en ljudbok kommer uppspelningen att återupptas med alla objekt i biblioteket som inte är färdiga, inklusive objekt i mappar.";
+"settings_autoplay_description" = "När du har avslutat en ljudbok kommer uppspelningen att återupptas med alla objekt i biblioteket, inklusive objekt i mappar.";
 "settings_smartrewind_title" = "Automatisk Tillbakaspolning";
 "settings_smartrewind_description" = "Spola tillbaka 30 sekunder efter appen varit pausad i 10 minuter.";
 "settings_boostvolume_title" = "Öka volymen";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Använd Kapitelkontext";
 "settings_progresslabels_description" = "Välj mellan att visa återstående tid, total längd och spelläge relaterat till antingen kapitlet eller boken i spelaren";
 "settings_playerinterface_list_description" = "Välj vad listknappen på spelarkontrollen öppnar";
+"settings_autoplay_section_title" = "AUTOSPELA";
+"settings_autoplay_restart_title" = "Starta om färdiga böcker";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Ayarlar";
 "settings_title" = "Ayarlar";
 "settings_autoplay_title" = "Kitaplığı Otomatik Oynat";
-"settings_autoplay_description" = "Bir sesli kitabı bitirdikten sonra, klasörlerdeki öğeler de dahil olmak üzere kitaplıktaki tamamlanmamış tüm öğelerle oynatma devam edecektir.";
+"settings_autoplay_description" = "Bir sesli kitabı bitirdikten sonra, klasörlerdeki öğeler de dahil olmak üzere kitaplıktaki tüm öğelerle oynatma devam edecektir.";
 "settings_smartrewind_title" = "Akıllı Geri Sarma";
 "settings_smartrewind_description" = "10 dakika duraklatıldıktan sonra 30 saniye geri sarın.";
 "settings_boostvolume_title" = "Sesi Güçlendir";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Bölüm İçeriğini Kullan";
 "settings_progresslabels_description" = "Oynatıcı ekranında bölümün veya kitabın kalan süresini, toplam süresini ve ilerlemesini görüntüleme arasında geçiş yapın";
 "settings_playerinterface_list_description" = "Oynatıcı ekranındaki liste düğmesinin ne açacağını ayarlayın";
+"settings_autoplay_section_title" = "OTOMATİK OYNATMA";
+"settings_autoplay_restart_title" = "Biten kitapları yeniden başlat";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "Налаштування";
 "settings_title" = "Налаштування";
 "settings_autoplay_title" = "Автовідтворення бібліотеки";
-"settings_autoplay_description" = "Після завершення аудіокниги відтворення відновиться з усіма елементами в бібліотеці, які не були завершені, включно з елементами в папках.";
+"settings_autoplay_description" = "Після завершення аудіокниги відтворення відновиться з усіма елементами в бібліотеці, включно з елементами в папках.";
 "settings_smartrewind_title" = "Розумне відмотування";
 "settings_smartrewind_description" = "Повернутись на 30 секунд назад після паузи на 10 хвилин.";
 "settings_boostvolume_title" = "Збільшення гучності";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "Використовуйте контекст розділу";
 "settings_progresslabels_description" = "Перемикання між відображенням часу, що залишився, загальної тривалості та прогресу розділу або книги на екрані програвача";
 "settings_playerinterface_list_description" = "Налаштувати що відкриватиме кнопка списку на екрані програвача";
+"settings_autoplay_section_title" = "АВТОМАТИЧНЕ ВІДТВОРЕННЯ";
+"settings_autoplay_restart_title" = "Перезапустіть готові книги";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "settings_button" = "设置";
 "settings_title" = "设置";
 "settings_autoplay_title" = "自动播放有声书库";
-"settings_autoplay_description" = "完成有声读物后，将继续播放库中所有未完成的项目，包括文件夹中的项目。";
+"settings_autoplay_description" = "完成有声读物后，将继续播放库中的所有项目，包括文件夹中的项目。";
 "settings_smartrewind_title" = "智能倒带";
 "settings_smartrewind_description" = "暂停 10 分钟后倒带 30 秒。";
 "settings_boostvolume_title" = "提高音量";
@@ -217,3 +217,5 @@
 "settings_chaptercontext_title" = "使用章节上下文";
 "settings_progresslabels_description" = "在播放器屏幕中显示章节或书籍的剩余时间、总持续时间和进度之间切换";
 "settings_playerinterface_list_description" = "调整播放器屏幕中的列表按钮打开的内容";
+"settings_autoplay_section_title" = "自动播放";
+"settings_autoplay_restart_title" = "重新启动完成的书籍";

--- a/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
@@ -17,7 +17,12 @@ class EmptyPlaybackServiceMock: PlaybackServiceProtocol {
     return nil
   }
 
-  func getPlayableItem(after relativePath: String, parentFolder: String?, autoplayed: Bool) -> PlayableItem? {
+  func getPlayableItem(
+    after relativePath: String,
+    parentFolder: String?,
+    autoplayed: Bool,
+    restartFinished: Bool
+  ) -> PlayableItem? {
     return nil
   }
 

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -25,6 +25,7 @@ public enum Constants {
         case boostVolumeEnabled = "userSettingsBoostVolume"
         case globalSpeedEnabled = "userSettingsGlobalSpeed"
         case autoplayEnabled = "userSettingsAutoplay"
+        case autoplayRestartEnabled = "userSettingsAutoplayRestart"
         case iCloudBackupsEnabled = "userSettingsiCloudBackupsEnabled"
         case autolockDisabled = "userSettingsDisableAutolock"
         case autolockDisabledOnlyWhenPowered = "userSettingsAutolockOnlyWhenPowered"

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -11,7 +11,12 @@ import Foundation
 public protocol PlaybackServiceProtocol {
   func updatePlaybackTime(item: PlayableItem, time: Double)
   func getPlayableItem(before relativePath: String, parentFolder: String?) -> PlayableItem?
-  func getPlayableItem(after relativePath: String, parentFolder: String?, autoplayed: Bool) -> PlayableItem?
+  func getPlayableItem(
+    after relativePath: String,
+    parentFolder: String?,
+    autoplayed: Bool,
+    restartFinished: Bool
+  ) -> PlayableItem?
   func getFirstPlayableItem(in folder: Folder, isUnfinished: Bool?) throws -> PlayableItem?
   func getPlayableItem(from item: LibraryItem) throws -> PlayableItem?
 }
@@ -73,7 +78,12 @@ public final class PlaybackService: PlaybackServiceProtocol {
     return try? getPlayableItem(from: previousItem)
   }
 
-  public func getPlayableItem(after relativePath: String, parentFolder: String?, autoplayed: Bool) -> PlayableItem? {
+  public func getPlayableItem(
+    after relativePath: String,
+    parentFolder: String?,
+    autoplayed: Bool,
+    restartFinished: Bool
+  ) -> PlayableItem? {
     guard
       let orderRank = self.libraryService.getItemProperty(
         #keyPath(LibraryItem.orderRank),
@@ -83,7 +93,8 @@ public final class PlaybackService: PlaybackServiceProtocol {
 
     var isUnfinished: Bool?
 
-    if autoplayed == true {
+    if autoplayed == true,
+       !restartFinished {
       isUnfinished = true
     }
 
@@ -102,7 +113,8 @@ public final class PlaybackService: PlaybackServiceProtocol {
         return getPlayableItem(
           after: parentFolderPath,
           parentFolder: containerPathForParentFolder,
-          autoplayed: autoplayed
+          autoplayed: autoplayed,
+          restartFinished: restartFinished
         )
       }
 


### PR DESCRIPTION
## Purpose

Add new setting to restart finished books when they are autoplayed. This behavior was the automatic one before v4.6.2, but it was a bug introduced around v3.x.x, since the intention before was that only books that weren't finished would autoplay. 

This setting (defaults to On) brings back this behavior, and allows users to disable it if they wish

## Approach

- Add new constant for user defaults
- Add new toggle in settings screen
- Update playback service to consider this new flag when item is autoplayed
- Update player manager to restart item if the item is autoplayed and the flag is enabled

## Screenshots

![IMG_2A495A7D2DC8-1](https://user-images.githubusercontent.com/14112819/185928978-a7d57c51-3e0c-4d9b-aba6-c58073a68eba.jpeg)

