### PR TITLE
Fix issues in Themes screen

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Adjust what the list button in the player screen opens";
 "settings_autoplay_section_title" = "AUTOPLAY";
 "settings_autoplay_restart_title" = "Restart finished books";
+"settings_theme_autobrightness" = "Select the dark variation of a theme if the screen brightness falls below the set threshold.";

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -1596,7 +1596,7 @@
                                                 <color key="textColor" red="0.59229660034179688" green="0.58781206607818604" blue="0.61176860332489014" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                                 <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="theme_dark_title"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_theme_autobrightness"/>
                                                 </userDefinedRuntimeAttributes>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="THEMES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PSZ-lE-AzA" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "اضبط ما يفتحه زر القائمة في شاشة المشغل";
 "settings_autoplay_section_title" = "تشغيل تلقائي";
 "settings_autoplay_restart_title" = "أعد تشغيل الكتب المنتهية";
+"settings_theme_autobrightness" = "حدد التباين الداكن للسمة إذا انخفض سطوع الشاشة عن الحد المعين.";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Upravte, co otevře tlačítko seznamu na obrazovce přehrávače";
 "settings_autoplay_section_title" = "AUTOMATICKÉ PŘEHRÁVÁNÍ";
 "settings_autoplay_restart_title" = "Restartujte hotové knihy";
+"settings_theme_autobrightness" = "Vyberte tmavou variantu motivu, pokud jas obrazovky klesne pod nastavenou prahovou hodnotu.";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Juster, hvad listeknappen på afspillerskærmen åbner";
 "settings_autoplay_section_title" = "AUTOMATISK AFSPILNING";
 "settings_autoplay_restart_title" = "Genstart færdige bøger";
+"settings_theme_autobrightness" = "Vælg den mørke variant af et tema, hvis skærmens lysstyrke falder under den indstillede tærskel.";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Anpassen, was die Taste „Liste“ auf dem Wiedergabebildschirm öffnet";
 "settings_autoplay_section_title" = "AUTOMATISCHES ABSPIELEN";
 "settings_autoplay_restart_title" = "Fertige Bücher neu starten";
+"settings_theme_autobrightness" = "Wählen Sie die dunkle Variante eines Themas, wenn die Bildschirmhelligkeit unter den eingestellten Schwellenwert fällt.";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Adjust what the list button in the player screen opens";
 "settings_autoplay_section_title" = "AUTOPLAY";
 "settings_autoplay_restart_title" = "Restart finished books";
+"settings_theme_autobrightness" = "Select the dark variation of a theme if the screen brightness falls below the set threshold.";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Ajusta lo que el botón de lista abre en la pantalla del reproductor";
 "settings_autoplay_section_title" = "AUTO-REPRODUCCIÓN";
 "settings_autoplay_restart_title" = "Reiniciar libros terminados";
+"settings_theme_autobrightness" = "Seleccione la variación oscura de un tema si el brillo de la pantalla cae por debajo del umbral establecido.";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Säädä, mitä luettelopainike avautuu soittimen näytössä";
 "settings_autoplay_section_title" = "AUTOMAATTINEN TOISTO";
 "settings_autoplay_restart_title" = "Käynnistä valmiit kirjat uudelleen";
+"settings_theme_autobrightness" = "Valitse teeman tumma muunnelma, jos näytön kirkkaus alittaa asetetun kynnyksen.";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Ajustez ce que le bouton de liste dans l'écran du lecteur ouvre";
 "settings_autoplay_section_title" = "LECTURE AUTOMATIQUE";
 "settings_autoplay_restart_title" = "Redémarrez les livres terminés";
+"settings_theme_autobrightness" = "Sélectionnez la variation sombre d'un thème si la luminosité de l'écran tombe en dessous du seuil défini.";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "A lejátszó képernyőn mi nyíljon meg a lista gomb megnyomására";
 "settings_autoplay_section_title" = "AUTOMATIKUS LEJÁTSZÁS";
 "settings_autoplay_restart_title" = "Indítsa újra a kész könyveket";
+"settings_theme_autobrightness" = "Válassza ki a téma sötét változatát, ha a képernyő fényereje a beállított küszöb alá esik.";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Regola ciò che si apre il pulsante elenco nella schermata del lettore";
 "settings_autoplay_section_title" = "RIPRODUZIONE AUTOMATICA";
 "settings_autoplay_restart_title" = "Riavvia i libri finiti";
+"settings_theme_autobrightness" = "Seleziona la variazione scura di un tema se la luminosità dello schermo scende al di sotto della soglia impostata.";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Dostosuj, co otwiera przycisk listy na ekranie odtwarzacza";
 "settings_autoplay_section_title" = "AUTOMATYCZNE ODTWARZANIE";
 "settings_autoplay_restart_title" = "Uruchom ponownie ukończone książki";
+"settings_theme_autobrightness" = "Wybierz ciemną odmianę motywu, jeśli jasność ekranu spadnie poniżej ustawionego progu.";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Ajuste o que o botão de lista na tela de reprodução abre";
 "settings_autoplay_section_title" = "REPRODUÇÃO AUTOMÁTICA";
 "settings_autoplay_restart_title" = "Reiniciar livros concluídos";
+"settings_theme_autobrightness" = "Selecione a variação escura de um tema se o brilho da tela ficar abaixo do limite definido.";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -211,3 +211,4 @@
 "settings_playerinterface_list_description" = "Ajustați ce se deschide butonul de listă din ecranul playerului";
 "settings_autoplay_section_title" = "REDARE AUTOMATA";
 "settings_autoplay_restart_title" = "Reporniți cărțile terminate";
+"settings_theme_autobrightness" = "Selectați variația întunecată a unei teme dacă luminozitatea ecranului scade sub pragul setat.";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Отрегулируйте, что открывает кнопка списка на экране плеера";
 "settings_autoplay_section_title" = "АВТОВОСПРОИЗВЕДЕНИЕ";
 "settings_autoplay_restart_title" = "Перезапустить готовые книги";
+"settings_theme_autobrightness" = "Выбирайте темную вариацию темы, если яркость экрана падает ниже установленного порога.";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Úprava správania sa tlačidla zoznamu na obrazovke prehrávača";
 "settings_autoplay_section_title" = "AUTOHRA";
 "settings_autoplay_restart_title" = "Reštartujte hotové knihy";
+"settings_theme_autobrightness" = "Vyberte tmavú variáciu témy, ak jas obrazovky klesne pod nastavenú hranicu.";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Välj vad listknappen på spelarkontrollen öppnar";
 "settings_autoplay_section_title" = "AUTOSPELA";
 "settings_autoplay_restart_title" = "Starta om färdiga böcker";
+"settings_theme_autobrightness" = "Välj den mörka varianten av ett tema om skärmens ljusstyrka faller under den inställda tröskeln.";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Oynatıcı ekranındaki liste düğmesinin ne açacağını ayarlayın";
 "settings_autoplay_section_title" = "OTOMATİK OYNATMA";
 "settings_autoplay_restart_title" = "Biten kitapları yeniden başlat";
+"settings_theme_autobrightness" = "Ekran parlaklığı ayarlanan eşiğin altına düşerse bir temanın koyu varyasyonunu seçin.";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "Налаштувати що відкриватиме кнопка списку на екрані програвача";
 "settings_autoplay_section_title" = "АВТОМАТИЧНЕ ВІДТВОРЕННЯ";
 "settings_autoplay_restart_title" = "Перезапустіть готові книги";
+"settings_theme_autobrightness" = "Виберіть темний варіант теми, якщо яскравість екрана падає нижче встановленого порогу.";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -219,3 +219,4 @@
 "settings_playerinterface_list_description" = "调整播放器屏幕中的列表按钮打开的内容";
 "settings_autoplay_section_title" = "自动播放";
 "settings_autoplay_restart_title" = "重新启动完成的书籍";
+"settings_theme_autobrightness" = "如果屏幕亮度低于设置的阈值，请选择主题的暗色变化。";


### PR DESCRIPTION
## Bugfix

- Layout for custom themes table sometimes is cut off. One way to reproduce this, is by setting the text font to a larger size in the phone settings
- Add missing translation for auto brightness description