### PR TITLE
Fix playback stopping after chapter end

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -395,7 +395,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
 extension PlayerManager {
   func jumpToChapter(_ chapter: PlayableChapter) {
-    jumpTo(chapter.start, recordBookmark: false)
+    jumpTo(chapter.start + 0.5, recordBookmark: false)
   }
 
   func initializeChapterTime(_ time: Double) {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -161,15 +161,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
       self?.setNowPlayingBookTitle(chapter: chapter)
       NotificationCenter.default.post(name: .chapterChange, object: nil, userInfo: nil)
-
-      // avoid loading the same item if it's already loaded
-      if let playingURL = (self?.audioPlayer.currentItem?.asset as? AVURLAsset)?.url,
-         chapter.fileURL == playingURL {
-        return
-      }
-
-      self?.loadChapter(chapter)
     }
+
+    loadChapter(item.currentChapter)
   }
 
   func loadChapter(_ chapter: PlayableChapter) {
@@ -233,7 +227,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
           // add 1 second as a finished threshold
           if currentItem.currentTime > 0.0 {
             let time = (currentItem.currentTime + 1) >= currentItem.duration ? 0 : currentItem.currentTime
-            self.jumpTo(time, recordBookmark: false)
+            self.initializeChapterTime(time)
           }
 
           self.libraryService.updateBookLastPlayDate(at: currentItem.relativePath, date: Date())
@@ -262,6 +256,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
     if currentItem.isBoundBook {
       currentTime += currentItem.currentChapter.start
+    } else if currentTime >= currentItem.currentChapter.end || currentTime < currentItem.currentChapter.start,
+              let newChapter = currentItem.getChapter(at: currentTime) {
+      currentItem.currentChapter = newChapter
     }
 
     self.playbackService.updatePlaybackTime(item: currentItem, time: currentTime)
@@ -398,7 +395,24 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
 extension PlayerManager {
   func jumpToChapter(_ chapter: PlayableChapter) {
-    jumpTo(chapter.start + 0.5, recordBookmark: false)
+    jumpTo(chapter.start, recordBookmark: false)
+  }
+
+  func initializeChapterTime(_ time: Double) {
+    guard let currentItem = self.currentItem else { return }
+
+    if !self.isPlaying {
+      UserDefaults.standard.set(Date(), forKey: "\(Constants.UserDefaults.lastPauseTime)_\(currentItem.relativePath)")
+    }
+
+    let boundedTime = min(max(time, 0), currentItem.duration)
+
+    self.playbackService.updatePlaybackTime(item: currentItem, time: boundedTime)
+
+    let newTime = currentItem.isBoundBook
+    ? currentItem.getChapterTime(in: currentItem.currentChapter, for: boundedTime)
+    : boundedTime
+    self.audioPlayer.seek(to: CMTime(seconds: newTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
   }
 
   func jumpTo(_ time: Double, recordBookmark: Bool = true) {
@@ -420,19 +434,20 @@ extension PlayerManager {
 
     let chapterBeforeSkip = currentItem.currentChapter
     self.playbackService.updatePlaybackTime(item: currentItem, time: boundedTime)
-    let chapterAfterSkip = currentItem.currentChapter
-
-    // If chapters are different, and it's a bound book, do nothing else,
-    // the player is loading the new chapter
-    if chapterBeforeSkip != chapterAfterSkip,
-       currentItem.isBoundBook {
-      return
+    if let chapterAfterSkip = currentItem.getChapter(at: boundedTime),
+       chapterBeforeSkip != chapterAfterSkip {
+      currentItem.currentChapter = chapterAfterSkip
+      // If chapters are different, and it's a bound book,
+      // load the new chapter
+      if currentItem.isBoundBook {
+        loadChapter(chapterAfterSkip)
+        return
+      }
     }
 
     let newTime = currentItem.isBoundBook
-    ? currentItem.getChapterTime(from: boundedTime)
+    ? currentItem.getChapterTime(in: currentItem.currentChapter, for: boundedTime)
     : boundedTime
-
     self.audioPlayer.seek(to: CMTime(seconds: newTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
   }
 
@@ -716,27 +731,29 @@ extension PlayerManager {
 
       self.playNextItem(autoPlayed: true)
       return
-    } else {
-      if currentItem.isBoundBook {
-        var subscription: AnyCancellable?
+    } else if currentItem.isBoundBook {
+      var subscription: AnyCancellable?
 
-        subscription = NotificationCenter.default.publisher(for: .bookReady, object: nil)
-          .sink(receiveValue: { [weak self] notification in
-            guard let self = self,
-                  let userInfo = notification.userInfo,
-                  let loaded = userInfo["loaded"] as? Bool,
-                  loaded == true else {
-                    subscription?.cancel()
-                    return
-                  }
-
-            self.play()
-
+      subscription = NotificationCenter.default.publisher(for: .bookReady, object: nil)
+        .sink(receiveValue: { [weak self] notification in
+          guard let self = self,
+                let userInfo = notification.userInfo,
+                let loaded = userInfo["loaded"] as? Bool,
+                loaded == true else {
             subscription?.cancel()
-          })
+            return
+          }
 
-        self.playbackService.updatePlaybackTime(item: currentItem, time: currentItem.currentTime)
-      }
+          self.play()
+
+          subscription?.cancel()
+        })
+
+      self.playbackService.updatePlaybackTime(item: currentItem, time: currentItem.currentTime)
+      /// Load next chapter
+      guard let nextChapter = self.playbackService.getNextChapter(from: currentItem) else { return }
+      currentItem.currentChapter = nextChapter
+      loadChapter(nextChapter)
     }
   }
 }

--- a/BookPlayer/Services/BookmarksActivityItemProvider.swift
+++ b/BookPlayer/Services/BookmarksActivityItemProvider.swift
@@ -45,7 +45,7 @@ final class BookmarksActivityItemProvider: UIActivityItemProvider {
 
     for bookmark in bookmarks {
       guard let chapter = currentItem.getChapter(at: bookmark.time) else { continue }
-      let chapterTime = currentItem.getChapterTime(from: bookmark.time)
+      let chapterTime = currentItem.getChapterTime(in: chapter, for: bookmark.time)
       let formattedTime = TimeParser.formatTime(chapterTime)
 
       fileContents += String.localizedStringWithFormat("chapter_number_title".localized, chapter.index)

--- a/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyPlaybackServiceMock.swift
@@ -17,6 +17,10 @@ class EmptyPlaybackServiceMock: PlaybackServiceProtocol {
     return nil
   }
 
+  func getNextChapter(from item: PlayableItem) -> PlayableChapter? {
+    return nil
+  }
+
   func getPlayableItem(
     after relativePath: String,
     parentFolder: String?,

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -67,13 +67,10 @@ public final class PlayableItem: NSObject, Identifiable {
 
     super.init()
 
-    self.currentChapter = chapters[0]
-    self.updateCurrentChapter()
+    self.currentChapter = self.getChapter(at: self.currentTime) ?? chapters[0]
   }
 
-  public func getChapterTime(from globalTime: TimeInterval) -> TimeInterval {
-    guard let chapter = self.getChapter(at: globalTime) else { return globalTime }
-
+  public func getChapterTime(in chapter: PlayableChapter, for globalTime: TimeInterval) -> TimeInterval {
     return globalTime - chapter.start
   }
 
@@ -84,13 +81,6 @@ public final class PlayableItem: NSObject, Identifiable {
     }
 
     return self.chapters.first { globalTime < $0.end && $0.start <= globalTime }
-  }
-
-  public func updateCurrentChapter() {
-    guard let chapter = self.getChapter(at: self.currentTime),
-          chapter != self.currentChapter else { return }
-
-    self.currentChapter = chapter
   }
 
   public func currentTimeInContext(_ prefersChapterContext: Bool) -> TimeInterval {

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -19,6 +19,7 @@ public protocol PlaybackServiceProtocol {
   ) -> PlayableItem?
   func getFirstPlayableItem(in folder: Folder, isUnfinished: Bool?) throws -> PlayableItem?
   func getPlayableItem(from item: LibraryItem) throws -> PlayableItem?
+  func getNextChapter(from item: PlayableItem) -> PlayableChapter?
 }
 
 public final class PlaybackService: PlaybackServiceProtocol {
@@ -32,10 +33,13 @@ public final class PlaybackService: PlaybackServiceProtocol {
     item.currentTime = time
     item.percentCompleted = round((item.currentTime / item.duration) * 100)
     self.libraryService.updatePlaybackTime(relativePath: item.relativePath, time: time)
+  }
 
-    if let currentChapter = item.currentChapter,
-       item.currentTime >= currentChapter.end || item.currentTime < currentChapter.start {
-      item.updateCurrentChapter()
+  public func getNextChapter(from item: PlayableItem) -> PlayableChapter? {
+    if item.chapters.last == item.currentChapter {
+      return nil
+    } else {
+      return item.nextChapter(after: item.currentChapter)
     }
   }
 


### PR DESCRIPTION
## Bugfix

- Playback would stop after an mp3 chapter finishes in a mp3 volume

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/844

## Approach

- Update the currentChapter manually, and wait for the player to report the callback when the files is finished
- Add new `initializeChapterTime` to be used after the chapter is finished loading
