### PR TITLE
fix off-center progressslider thumbnail

### DIFF
--- a/BookPlayer/Player/Player Screen/Views/ProgressSlider.swift
+++ b/BookPlayer/Player/Player Screen/Views/ProgressSlider.swift
@@ -92,7 +92,12 @@ class ProgressSlider: UISlider {
         minColor.set()
         UIBezierPath(rect: progressRect).fill()
     }
-
+  
+  override func thumbRect(forBounds bounds: CGRect, trackRect rect: CGRect, value: Float) -> CGRect {
+    let originalRect = super.thumbRect(forBounds: bounds, trackRect: rect, value: value)
+    return originalRect.offsetBy(dx: 0, dy: 1)
+  }
+  
   public func setProgress(_ value: Float) {
     self.value = value
     self.setNeedsDisplay()


### PR DESCRIPTION
## Bugfix

- fix misaligned `ProgressSlider` thumbnail on `PlayerViewController` screen

## Related tasks

- https://github.com/TortugaPower/BookPlayer/issues/773

## Approach

- override `thumbRect` function of `UISlider` and set appropriate thumbnail offset


## Screenshots

Slider before the fix:
![Simulator Screenshot - iPhone 14 Pro - 2023-03-28 at 20 24 15](https://user-images.githubusercontent.com/1176284/228333333-72252f40-e28c-4f62-a295-b16050517fda.png)


Slider after fix (1px difference):
![Simulator Screenshot - iPhone 14 Pro - 2023-03-28 at 20 23 40](https://user-images.githubusercontent.com/1176284/228333439-1b7e8b82-a030-48a3-9b6c-495939765b88.png)

