### PR TITLE
#646 Download books from url on Library screen

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -482,6 +482,13 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
             }
           ),
           BPActionItem(
+            // TODO: translate string for download button
+            title: "download_button".localized,
+            handler: { [weak self] in
+              self?.showDownloadFromUrlAlert()
+            }
+          ),
+          BPActionItem(
             title: "create_playlist_button".localized,
             handler: { [weak self] in
               self?.showCreateFolderAlert(
@@ -856,6 +863,29 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
             title: "create_button".localized,
             inputHandler: { [items, type, weak self] title in
               self?.createFolder(with: title, items: items, type: type)
+            }
+          ),
+          BPActionItem.cancelAction
+        ]
+      )
+    ))
+  }
+  
+  func showDownloadFromUrlAlert() {
+    sendEvent(.showAlert(
+      content: BPAlertContent(
+        // TODO: Translate title
+        title: "download_from_url_title".localized,
+        style: .alert,
+        textInputPlaceholder: "",
+        actionItems: [
+          BPActionItem(
+            // TODO: translate button
+            title: "download_button".localized,
+            inputHandler: { [weak self] url in
+              if let bookUrl = URL(string: url) {
+                self?.handleDownload(bookUrl)
+              }
             }
           ),
           BPActionItem.cancelAction


### PR DESCRIPTION
## Purpose

Add an option to "Add" action sheet on Library screen to download books from URLs. 

## Related tasks

[- Links to related tasks being addressed in this PR](https://github.com/TortugaPower/BookPlayer/issues/646)

## Approach

New action (in `ItemListViewModel.showAddActions()`) displays an alert with text field where user can enter or paste book URL and proceed to download (new function `ItemListViewModel.showDownloadFromUrlAlert()') 

## Things to be aware of / Things to focus on

- There are several **TODO** placeholders for new strings that must be translated
- Potentially, update "Add" action sheet header to include description of download option

## Screenshots

![image](https://user-images.githubusercontent.com/1176284/229748767-ea46d702-93c4-47c3-b4d8-e023f10d368b.png)


![image](https://user-images.githubusercontent.com/1176284/229749012-b878c204-91b8-452f-a453-ddba6bf7724a.png)

