### PR TITLE
#867 - Prevent importing files that are already in the library

### DIFF
--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -43,6 +43,10 @@ public class CommandParser {
 
   public class func parse(_ url: URL) -> Action? {
     if url.isFileURL {
+      guard !url.absoluteString.contains(DataManager.getProcessedFolderURL().absoluteString) else {
+        return nil
+      }
+      
       return Action(command: .fileImport, parameters: [URLQueryItem(name: "url", value: url.path)])
     }
 


### PR DESCRIPTION
## Bugfix

When user taps on the audio file in the Processed folder, and then Cancel, file is deleted as part of the clean-up process. If user taps on Import, library ends up with duplicate file.

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/867

## Approach

In `CommandParser.parse` function add another check if file is in the Processed folder. If it is, stop import process (silently ignore)
