### PR TITLE
Handle syncing item when it's created or imported

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -74,7 +74,6 @@ class FolderListCoordinator: ItemListCoordinator {
     Task { [weak self] in
       guard
         let self = self,
-        UserDefaults.standard.bool(forKey: Constants.UserDefaults.completedLibrarySync.rawValue) == true,
         let (newItems, _) = try await self.syncService.syncListContents(at: self.folderRelativePath)
       else { return }
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -217,8 +217,7 @@ class LibraryListCoordinator: ItemListCoordinator {
   override func syncList() {
     Task { [weak self] in
       guard
-        let self = self,
-        UserDefaults.standard.bool(forKey: Constants.UserDefaults.completedLibrarySync.rawValue) == true
+        let self = self
       else { return }
 
       guard let (newItems, lastPlayed) = try await self.syncService.syncListContents(at: nil) else { return }

--- a/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
+++ b/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
@@ -82,6 +82,7 @@ struct ItemDetailsForm_Previews: PreviewProvider {
         item: SimpleLibraryItem(
           title: "title",
           details: "details",
+          speed: 1,
           currentTime: 0,
           duration: 100,
           percentCompleted: 1,

--- a/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsView.swift
+++ b/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsView.swift
@@ -29,6 +29,7 @@ struct ItemDetailsView_Previews: PreviewProvider {
         item: SimpleLibraryItem(
           title: "title",
           details: "details",
+          speed: 1,
           currentTime: 0,
           duration: 100,
           percentCompleted: 1,

--- a/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
+++ b/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
@@ -63,10 +63,10 @@ class ProfileViewModel: BaseViewModel<ProfileCoordinator>, ProfileViewModelProto
   }
 
   func bindObservers() {
-    UserDefaults.standard.publisher(for: \.userSettingsCompletedLibrarySync)
+    UserDefaults.standard.publisher(for: \.userSettingsHasQueuedJobs)
       .receive(on: DispatchQueue.main)
       .sink(receiveValue: { [weak self] completedSync in
-        self?.isSyncButtonDisabled = !completedSync
+        self?.isSyncButtonDisabled = completedSync
       })
       .store(in: &disposeBag)
 

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -70,7 +70,7 @@ final class StorageViewModel: BaseViewModel<StorageCoordinator>, ObservableObjec
   }
 
   func getRelativePath(of fileURL: URL, baseURL: URL) -> String {
-    return String(fileURL.relativePath(to: baseURL).dropFirst())
+    return fileURL.relativePath(to: baseURL)
   }
 
   func shouldShowWarning(for relativePath: String) -> Bool {

--- a/BookPlayer/Utils/Extensions/UserDefaults+BookPlayer.swift
+++ b/BookPlayer/Utils/Extensions/UserDefaults+BookPlayer.swift
@@ -14,7 +14,7 @@ extension UserDefaults {
     return string(forKey: Constants.UserDefaults.appIcon.rawValue)
   }
 
-  @objc dynamic var userSettingsCompletedLibrarySync: Bool {
-    return bool(forKey: Constants.UserDefaults.completedLibrarySync.rawValue)
+  @objc dynamic var userSettingsHasQueuedJobs: Bool {
+    return bool(forKey: Constants.UserDefaults.hasQueuedJobs.rawValue)
   }
 }

--- a/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
+++ b/BookPlayerTests/Mocks/EmptyLibraryServiceMock.swift
@@ -58,7 +58,7 @@ class EmptyLibraryServiceMock: LibraryServiceProtocol {
     return nil
   }
 
-  func insertItems(from files: [URL]) -> [String] {
+  func insertItems(from files: [URL]) -> [SimpleLibraryItem] {
     return []
   }
 
@@ -144,6 +144,7 @@ class EmptyLibraryServiceMock: LibraryServiceProtocol {
     return SimpleLibraryItem(
       title: "",
       details: "",
+      speed: 1,
       currentTime: 0,
       duration: 0,
       percentCompleted: 0,

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -12,7 +12,7 @@ public enum Constants {
         case donationMade = "userSettingsDonationMade"
         case showPlayer = "userSettingsShowPlayer"
         case lastSyncTimestamp = "lastSyncTimestamp"
-        case completedLibrarySync = "userSettingsCompletedLibrarySync"
+        case hasQueuedJobs = "userSettingsHasQueuedJobs"
 
         // User preferences
         case themeBrightnessEnabled = "userSettingsBrightnessEnabled"

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -14,6 +14,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
   }
   public let title: String
   public let details: String
+  public let speed: Double
   public let currentTime: Double
   public let duration: Double
   public let durationFormatted: String
@@ -46,6 +47,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
   static var fetchRequestProperties = [
     "title",
     "details",
+    "speed",
     "currentTime",
     "duration",
     "percentCompleted",
@@ -68,6 +70,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
   public init(
     title: String,
     details: String,
+    speed: Double,
     currentTime: Double,
     duration: Double,
     percentCompleted: Double,
@@ -81,6 +84,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
   ) {
     self.title = title
     self.details = details
+    self.speed = speed
     self.currentTime = currentTime
     self.duration = duration
     self.durationFormatted = TimeParser.formatTotalDuration(duration)
@@ -99,6 +103,7 @@ extension SimpleLibraryItem {
   public init(from item: LibraryItem) {
     self.title = item.title
     self.details = item.details
+    self.speed = Double(item.speed)
     self.currentTime = item.currentTime
     self.duration = item.duration
     self.durationFormatted = TimeParser.formatTotalDuration(item.duration)

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -6,7 +6,13 @@ public extension URL {
     }
 
     func relativePath(to baseURL: URL) -> String {
-        return self.path.components(separatedBy: baseURL.path).last ?? ""
+      let lastPath = self.path.components(separatedBy: baseURL.path).last ?? ""
+      if !lastPath.isEmpty,
+         lastPath.first == "/" {
+        return String(lastPath.dropFirst())
+      } else {
+        return lastPath
+      }
     }
 
     var isDirectoryFolder: Bool {

--- a/Shared/Services/Sync/LibraryItemSyncJob.swift
+++ b/Shared/Services/Sync/LibraryItemSyncJob.swift
@@ -117,6 +117,9 @@ class LibraryItemSyncJob: Job, BPLogger {
         parameters: nil,
         useKeychain: false
       )
+
+      /// Clean up hard link
+      try FileManager.default.removeItem(at: fileURL)
       callback.done(.success)
       return
     }

--- a/Shared/Services/Sync/LibraryItemSyncJob.swift
+++ b/Shared/Services/Sync/LibraryItemSyncJob.swift
@@ -53,7 +53,16 @@ class LibraryItemSyncJob: Job, BPLogger {
       do {
         switch self.jobType {
         case .upload:
-          try await self.handleUploadJob(callback: callback)
+          guard
+            let rawType = parameters["type"] as? Int16,
+            let type = SimpleItemType(rawValue: rawType)
+          else {
+            throw BookPlayerError.runtimeError("Missing parameters for uploading")
+          }
+          try await self.handleUploadJob(
+            type: type,
+            callback: callback
+          )
         case .update:
           let _: UploadItemResponse = try await self.provider.request(.update(params: self.parameters))
           callback.done(.success)
@@ -79,7 +88,10 @@ class LibraryItemSyncJob: Job, BPLogger {
     }
   }
 
-  func handleUploadJob(callback: SwiftQueue.JobResult) async throws {
+  func handleUploadJob(
+    type: SimpleItemType,
+    callback: SwiftQueue.JobResult
+  ) async throws {
     let response: UploadItemResponse = try await self.provider.request(.upload(params: self.parameters))
 
     guard let remoteURL = response.content.url else {
@@ -88,19 +100,17 @@ class LibraryItemSyncJob: Job, BPLogger {
       return
     }
 
-    let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(self.relativePath)
-
-    var isDirectory: ObjCBool = false
+    let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(self.relativePath)
 
     guard
-      FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory)
+      FileManager.default.fileExists(atPath: fileURL.path)
     else {
       /// Uploaded metadata will not have a backing file, but we'll have a backup of item data
       callback.done(.success)
       return
     }
 
-    guard isDirectory.boolValue == false else {
+    guard type == .book else {
       let _: Empty = try await self.client.request(
         url: remoteURL,
         method: .put,
@@ -163,9 +173,9 @@ class LibraryItemSyncJob: Job, BPLogger {
   func onRemove(result: SwiftQueue.JobCompletion) {
     switch result {
     case .success:
-      Self.logger.trace("Finished upload for: \(self.relativePath)")
+      Self.logger.trace("Finished \(self.jobType.rawValue) for: \(self.relativePath)")
     case .fail(let error):
-      Self.logger.error("Upload error for \(self.relativePath): \(error.localizedDescription)")
+      Self.logger.error("Error on jobType \(self.jobType.rawValue) for \(self.relativePath): \(error.localizedDescription)")
     }
   }
 }

--- a/Shared/Services/Sync/Model/SyncableItem.swift
+++ b/Shared/Services/Sync/Model/SyncableItem.swift
@@ -70,3 +70,20 @@ extension SyncableItem: Decodable {
     self.type = try container.decode(SimpleItemType.self, forKey: .type)
   }
 }
+
+extension SyncableItem {
+  public init(from item: SimpleLibraryItem) {
+    self.relativePath = item.relativePath
+    self.originalFileName = item.originalFileName
+    self.title = item.title
+    self.details = item.details
+    self.speed = item.speed
+    self.currentTime = item.currentTime
+    self.duration = item.duration
+    self.percentCompleted = item.percentCompleted
+    self.isFinished = item.isFinished
+    self.orderRank = Int(item.orderRank)
+    self.lastPlayDateTimestamp = item.lastPlayDate?.timeIntervalSince1970
+    self.type = item.type
+  }
+}


### PR DESCRIPTION
## Purpose

- Sync item when imported, or when a folder is created

## Approach

- Create an upload job for each imported item
- Create a hard link to the file, so it doesn't matter where the files ends up moving, we have a reference to it in a temporal folder
- Clean up the hard link
- Rework the `completedLibrarySync` flag to another that denotes if there are pending tasks to be executed

## Things to be aware of / Things to focus on

Uploading files on background needs more testing
