### PR TITLE
#867 - Prevent importing files that are already in the library

### DIFF
--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -31,8 +31,7 @@ final class ImportManager {
   public func process(_ fileUrl: URL) {
     // Avoid processing the creation of the Processed and Inbox folder
     if fileUrl.lastPathComponent == DataManager.processedFolderName
-        || fileUrl.lastPathComponent == "Inbox"
-        || fileUrl.isInProcessedFolder { return }
+        || fileUrl.lastPathComponent == "Inbox" { return }
     
     self.files.value.insert(fileUrl)
   }
@@ -44,7 +43,7 @@ final class ImportManager {
   }
 
   public func removeFile(_ item: URL, updateCollection: Bool = true) throws {
-    if FileManager.default.fileExists(atPath: item.path) && !item.isInProcessedFolder {
+    if FileManager.default.fileExists(atPath: item.path) {
       try FileManager.default.removeItem(at: item)
     }
 

--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -31,8 +31,9 @@ final class ImportManager {
   public func process(_ fileUrl: URL) {
     // Avoid processing the creation of the Processed and Inbox folder
     if fileUrl.lastPathComponent == DataManager.processedFolderName
-        || fileUrl.lastPathComponent == "Inbox" { return }
-
+        || fileUrl.lastPathComponent == "Inbox"
+        || fileUrl.isInProcessedFolder { return }
+    
     self.files.value.insert(fileUrl)
   }
 
@@ -43,7 +44,7 @@ final class ImportManager {
   }
 
   public func removeFile(_ item: URL, updateCollection: Bool = true) throws {
-    if FileManager.default.fileExists(atPath: item.path) {
+    if FileManager.default.fileExists(atPath: item.path) && !item.isInProcessedFolder {
       try FileManager.default.removeItem(at: item)
     }
 

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -43,7 +43,7 @@ public class CommandParser {
 
   public class func parse(_ url: URL) -> Action? {
     if url.isFileURL {
-      guard !url.absoluteString.contains(DataManager.getProcessedFolderURL().absoluteString) else {
+      guard !url.isInProcessedFolder else {
         return nil
       }
       

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -43,7 +43,7 @@ public class CommandParser {
 
   public class func parse(_ url: URL) -> Action? {
     if url.isFileURL {
-      guard !url.isInProcessedFolder else {
+      guard !DataManager.isURLInProcessedFolder(url) else {
         return nil
       }
       

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -43,6 +43,10 @@ public class CommandParser {
 
   public class func parse(_ url: URL) -> Action? {
     if url.isFileURL {
+      guard !url.absoluteString.contains(DataManager.getProcessedFolderURL().absoluteString) else {
+        return nil
+      }
+      
       return Action(command: .fileImport, parameters: [URLQueryItem(name: "url", value: url.path)])
     }
 

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -65,6 +65,12 @@ public class DataManager {
 
     return sharedFolderURL
   }
+  
+  public class func isURLInProcessedFolder(_ url: URL) -> Bool {
+    let absoluteUrl = url.resolvingSymlinksInPath().absoluteString
+    let processedFolderUrl = getProcessedFolderURL().absoluteString
+    return absoluteUrl.contains(processedFolderUrl)
+  }
 
   public func getContext() -> NSManagedObjectContext {
     return self.coreDataStack.managedContext

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -13,12 +13,6 @@ public extension URL {
         return (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
     
-    var isInProcessedFolder: Bool {
-        let absoluteUrl = resolvingSymlinksInPath().absoluteString
-        let processedFolderUrl = DataManager.getProcessedFolderURL().absoluteString
-        return absoluteUrl.contains(processedFolderUrl)
-    }
-
   // Disable file protection for file and descendants if it's a directory
   func disableFileProtection() {
     try? (self as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -14,7 +14,9 @@ public extension URL {
     }
     
     var isInProcessedFolder: Bool {
-        return absoluteString.contains(DataManager.getProcessedFolderURL().absoluteString)
+        let absoluteUrl = resolvingSymlinksInPath().absoluteString
+        let processedFolderUrl = DataManager.getProcessedFolderURL().absoluteString
+        return absoluteUrl.contains(processedFolderUrl)
     }
 
   // Disable file protection for file and descendants if it's a directory

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -12,6 +12,10 @@ public extension URL {
     var isDirectoryFolder: Bool {
         return (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
+    
+    var isInProcessedFolder: Bool {
+        return absoluteString.contains(DataManager.getProcessedFolderURL().absoluteString)
+    }
 
   // Disable file protection for file and descendants if it's a directory
   func disableFileProtection() {


### PR DESCRIPTION
## Bugfix

When user taps on the audio file in the Processed folder, and then Cancel, file is deleted as part of the clean-up process. If user taps on Import, library ends up with duplicate file.

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/867

## Approach

In `CommandParser.parse` function add another check if file is in the Processed folder. If it is, stop import process (silently ignore). Additional check when creating import operation in `ImportManager` in order not to duplicate files; and when cleaning up after the cancelled operation in order not to delete files from Processed folder.
