### PR TITLE
[BKPLY-108] Playback streaming QA

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -209,39 +209,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     guard let item = item else { return }
 
-    var subscription: AnyCancellable?
+    playerManager?.load(item, autoplay: autoplay)
 
-    subscription = NotificationCenter.default.publisher(for: .bookReady, object: nil)
-      .sink(receiveValue: { [weak self, showPlayer, autoplay, alertPresenter] notification in
-        alertPresenter.stopLoader()
-        guard
-          let userInfo = notification.userInfo,
-          let loaded = userInfo["loaded"] as? Bool,
-          loaded == true
-        else {
-          subscription?.cancel()
-          return
-        }
-
-        showPlayer?()
-
-        if autoplay {
-          self?.playerManager?.play()
-        }
-
-        subscription?.cancel()
-      })
-
-    alertPresenter.showLoader()
-
-    Task { [unowned self] in
-      do {
-        try await self.playerManager?.load(item)
-      } catch {
-        alertPresenter.stopLoader()
-        alertPresenter.showAlert("error_title".localized, message: error.localizedDescription, completion: nil)
-      }
-    }
+    showPlayer?()
   }
 
   @objc func messageReceived(_ notification: Notification) {

--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -32,7 +32,7 @@ final class ImportManager {
     // Avoid processing the creation of the Processed and Inbox folder
     if fileUrl.lastPathComponent == DataManager.processedFolderName
         || fileUrl.lastPathComponent == "Inbox" { return }
-    
+
     self.files.value.insert(fileUrl)
   }
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -461,12 +461,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     socketService.sendEvent(
       .timeUpdate,
       payload: [
-        "speed": currentSpeed,
         "currentTime": currentItem.currentTime,
         "percentCompleted": currentItem.percentCompleted,
-        "isFinished": currentItem.isFinished,
         "relativePath": currentItem.relativePath,
-        "duration": currentItem.duration,
         "lastPlayDateTimestamp": Date().timeIntervalSince1970,
       ]
     )

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -21,7 +21,7 @@ public protocol PlayerManagerProtocol: NSObjectProtocol {
   var boostVolume: Bool { get set }
   var isPlaying: Bool { get }
 
-  func load(_ item: PlayableItem) async throws
+  func load(_ item: PlayableItem, autoplay: Bool)
   func hasLoadedBook() -> Bool
 
   func playPreviousItem()
@@ -58,7 +58,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   private var isPlayingSubscription: AnyCancellable?
   private var periodicTimeObserver: Any?
   /// Flag determining if it should resume playback after finishing up loading an item
-  private var playbackQueued: Bool?
+  @Published private var playbackQueued: Bool?
   private var hasObserverRegistered = false
   private var observeStatus: Bool = false {
     didSet {
@@ -75,6 +75,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   }
 
   private var playerItem: AVPlayerItem?
+  private var loadChapterTask: Task<(), Never>?
   @Published var currentItem: PlayableItem?
   @Published var currentSpeed: Float = 1.0
 
@@ -187,7 +188,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     self.playerItem?.audioTimePitchAlgorithm = .timeDomain
   }
 
-  func load(_ item: PlayableItem) async throws {
+  func load(_ item: PlayableItem, autoplay: Bool) {
     // Recover in case of failure
     if self.audioPlayer.status == .failed {
       if let observer = self.periodicTimeObserver {
@@ -213,12 +214,27 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       NotificationCenter.default.post(name: .chapterChange, object: nil, userInfo: nil)
     }
 
-    try await loadChapterMetadata(item.currentChapter)
+    loadChapterMetadata(item.currentChapter, autoplay: autoplay)
   }
 
-  func loadChapterMetadata(_ chapter: PlayableChapter) async throws {
-    try await self.loadPlayerItem(for: chapter)
-    self.loadChapterOperation(chapter)
+  func loadChapterMetadata(_ chapter: PlayableChapter, autoplay: Bool? = nil) {
+    if let autoplay {
+      playbackQueued = autoplay
+    }
+
+    loadChapterTask = Task { [unowned self] in
+      do {
+        try await self.loadPlayerItem(for: chapter)
+        self.loadChapterOperation(chapter)
+      } catch {
+        self.playbackQueued = nil
+        /// Only show the alert if the user didn't manually cancel
+        if !Task.isCancelled {
+          self.showErrorAlert(error.localizedDescription)
+        }
+        return
+      }
+    }
   }
 
   func loadChapterOperation(_ chapter: PlayableChapter) {
@@ -236,10 +252,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       }
 
       self.audioPlayer.replaceCurrentItem(with: nil)
-      /// Load up info after the item is ready for playback
-      if !self.isPlaying {
-        self.observeStatus = true
-      }
+      self.observeStatus = true
       self.audioPlayer.replaceCurrentItem(with: playerItem)
 
       // Update UI on main thread
@@ -291,11 +304,13 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
   // Called every second by the timer
   func updateTime() {
-    guard let currentItem = self.currentItem,
-          let playerItem = self.playerItem,
-          playerItem.status == .readyToPlay else {
-            return
-          }
+    guard
+      let currentItem,
+      let playerItem,
+      playerItem.status == .readyToPlay
+    else {
+      return
+    }
 
     var currentTime = CMTimeGetSeconds(self.audioPlayer.currentTime())
 
@@ -348,11 +363,14 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   }
 
   func isPlayingPublisher() -> AnyPublisher<Bool, Never> {
-    return self.audioPlayer.publisher(for: \.timeControlStatus)
-      .map({ timeControlStatus in
-        return timeControlStatus == .playing
-      })
-      .eraseToAnyPublisher()
+    return Publishers.CombineLatest(
+      audioPlayer.publisher(for: \.timeControlStatus),
+      $playbackQueued
+    )
+    .map({ (timeControlStatus, playbackQueued) in
+      return timeControlStatus == .playing || playbackQueued == true
+    })
+    .eraseToAnyPublisher()
   }
 
   var boostVolume: Bool = false {
@@ -444,8 +462,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       .timeUpdate,
       payload: [
         "speed": currentSpeed,
-        "currentTime": currentTimeInContext,
-        "percentCompleted": itemProgress,
+        "currentTime": currentItem.currentTime,
+        "percentCompleted": currentItem.percentCompleted,
         "isFinished": currentItem.isFinished,
         "relativePath": currentItem.relativePath,
         "duration": currentItem.duration,
@@ -496,16 +514,7 @@ extension PlayerManager {
       // If chapters are different, and it's a bound book,
       // load the new chapter
       if currentItem.isBoundBook {
-        Task { [unowned self] in
-          do {
-            try await self.loadChapterMetadata(chapterAfterSkip)
-          } catch {
-            await SceneDelegate.shared?.coordinator.getMainCoordinator()?
-              .getTopController()?
-              .showAlert("error_title".localized, message: error.localizedDescription)
-            return
-          }
-        }
+        loadChapterMetadata(chapterAfterSkip)
         return
       }
     }
@@ -535,13 +544,27 @@ extension PlayerManager {
 
 extension PlayerManager {
   func play() {
-    guard let currentItem = self.currentItem,
-          let playerItem = self.playerItem else { return }
+    /// Ignore play commands if there's no item loaded
+    guard let currentItem else { return }
+
+    guard let playerItem else {
+      /// Check if the playbable item is in the process of being set
+      if observeStatus == false {
+        load(currentItem, autoplay: true)
+      }
+      return
+    }
 
     guard playerItem.status == .readyToPlay else {
-      // queue playback
-      self.playbackQueued = true
-      self.observeStatus = true
+      /// Try to reload the item if it failed to load previously
+      if playerItem.status == .failed {
+        load(currentItem, autoplay: true)
+      } else {
+        // queue playback
+        self.playbackQueued = true
+        self.observeStatus = true
+      }
+
       return
     }
 
@@ -622,9 +645,9 @@ extension PlayerManager {
 
     guard item.status == .readyToPlay else {
       if item.status == .failed {
-        SceneDelegate.shared?.coordinator.getMainCoordinator()?
-          .getTopController()?
-          .showAlert("error_title".localized, message: item.error?.localizedDescription)
+        playbackQueued = nil
+        observeStatus = false
+        showErrorAlert(item.error?.localizedDescription)
       }
       return
     }
@@ -653,6 +676,8 @@ extension PlayerManager {
       self?.bindPauseObserver()
       // Set pause state on player and control center
       self?.audioPlayer.pause()
+      self?.playbackQueued = nil
+      self?.loadChapterTask?.cancel()
       self?.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
       self?.setNowPlayingBookTime()
       MPNowPlayingInfoCenter.default().nowPlayingInfo = self?.nowPlayingInfo
@@ -671,7 +696,7 @@ extension PlayerManager {
   // Toggle play/pause of book
   func playPause() {
     // Pause player if it's playing
-    if self.audioPlayer.timeControlStatus == .playing {
+    if self.audioPlayer.timeControlStatus == .playing || playbackQueued == true {
       self.pause(fade: false)
     } else {
       self.play()
@@ -687,11 +712,13 @@ extension PlayerManager {
   }
 
   private func stopPlayback() {
-    self.observeStatus = false
+    observeStatus = false
+    playbackQueued = nil
 
-    self.audioPlayer.pause()
+    audioPlayer.pause()
+    loadChapterTask?.cancel()
 
-    self.userActivityManager.stopPlaybackActivity()
+    userActivityManager.stopPlaybackActivity()
   }
 
   func markAsCompleted(_ flag: Bool) {
@@ -719,7 +746,7 @@ extension PlayerManager {
       )
     else { return }
 
-    self.playItem(previousBook)
+    load(previousBook, autoplay: true)
   }
 
   func playNextItem(autoPlayed: Bool = false) {
@@ -748,40 +775,7 @@ extension PlayerManager {
       updatePlaybackTime(item: nextBook, time: 0)
     }
 
-    self.playItem(nextBook)
-  }
-
-  func playItem(_ item: PlayableItem) {
-    var subscription: AnyCancellable?
-
-    subscription = NotificationCenter.default.publisher(for: .bookReady, object: nil)
-      .sink(receiveValue: { [weak self] notification in
-        guard let self = self,
-              let userInfo = notification.userInfo,
-              let loaded = userInfo["loaded"] as? Bool,
-              loaded == true else {
-                subscription?.cancel()
-                return
-              }
-
-        // Resume playback if it's paused
-        if !self.isPlaying {
-          self.play()
-        }
-
-        subscription?.cancel()
-      })
-
-    Task { [unowned self] in
-      do {
-        try await self.load(item)
-      } catch {
-        await SceneDelegate.shared?.coordinator.getMainCoordinator()?
-          .getTopController()?
-          .showAlert("error_title".localized, message: error.localizedDescription)
-        return
-      }
-    }
+    load(nextBook, autoplay: true)
   }
 
   @objc
@@ -802,36 +796,11 @@ extension PlayerManager {
       self.playNextItem(autoPlayed: true)
       return
     } else if currentItem.isBoundBook {
-      var subscription: AnyCancellable?
-
-      subscription = NotificationCenter.default.publisher(for: .bookReady, object: nil)
-        .sink(receiveValue: { [weak self] notification in
-          guard let self = self,
-                let userInfo = notification.userInfo,
-                let loaded = userInfo["loaded"] as? Bool,
-                loaded == true else {
-            subscription?.cancel()
-            return
-          }
-
-          self.play()
-
-          subscription?.cancel()
-        })
-
       updatePlaybackTime(item: currentItem, time: currentItem.currentTime)
       /// Load next chapter
       guard let nextChapter = self.playbackService.getNextChapter(from: currentItem) else { return }
       currentItem.currentChapter = nextChapter
-      Task { [unowned self] in
-        do {
-          try await self.loadChapterMetadata(nextChapter)
-        } catch {
-          await SceneDelegate.shared?.coordinator.getMainCoordinator()?
-            .getTopController()?
-            .showAlert("error_title".localized, message: error.localizedDescription)
-        }
-      }
+      loadChapterMetadata(nextChapter, autoplay: true)
     }
   }
 
@@ -861,5 +830,15 @@ extension PlayerManager {
     else { return }
 
     libraryService.addNote(type.getNote() ?? "", bookmark: bookmark)
+  }
+}
+
+extension PlayerManager {
+  private func showErrorAlert(_ message: String?) {
+    DispatchQueue.main.async {
+      SceneDelegate.shared?.coordinator.getMainCoordinator()?
+        .getTopController()?
+        .showAlert("error_title".localized, message: message)
+    }
   }
 }

--- a/BookPlayer/Profile/CompleteAccount Screen/CompleteAccountViewModel.swift
+++ b/BookPlayer/Profile/CompleteAccount Screen/CompleteAccountViewModel.swift
@@ -71,21 +71,22 @@ class CompleteAccountViewModel: BaseViewModel<CompleteAccountCoordinator> {
   }
 
   func handleRestorePurchases() {
-    Task { @MainActor [weak self, accountService] in
-      self?.coordinator.showLoader()
+    Task { @MainActor [weak self] in
+      guard let self = self else { return }
+      self.coordinator.showLoader()
 
       do {
-        let customerInfo = try await accountService.restorePurchases()
+        let customerInfo = try await self.accountService.restorePurchases()
 
         if customerInfo.activeSubscriptions.isEmpty {
           throw AccountError.inactiveSubscription
         }
 
-        self?.coordinator.stopLoader()
-        self?.onTransition?(.success)
+        self.coordinator.stopLoader()
+        self.onTransition?(.success)
       } catch {
-        self?.coordinator.stopLoader()
-        self?.coordinator.showError(error)
+        self.coordinator.stopLoader()
+        self.coordinator.showError(error)
       }
     }
   }

--- a/BookPlayer/Profile/CompleteAccount Screen/CompleteAccountViewModel.swift
+++ b/BookPlayer/Profile/CompleteAccount Screen/CompleteAccountViewModel.swift
@@ -52,20 +52,22 @@ class CompleteAccountViewModel: BaseViewModel<CompleteAccountCoordinator> {
       let selectedOption = pricingViewModel.selected
     else { return }
 
-    Task { @MainActor [weak self, accountService] in
-      self?.coordinator.showLoader()
+    Task { @MainActor [weak self] in
+      guard let self = self else { return }
+
+      self.coordinator.showLoader()
 
       do {
-        let userCancelled = try await accountService.subscribe(option: selectedOption)
+        let userCancelled = try await self.accountService.subscribe(option: selectedOption)
 
-        self?.coordinator.stopLoader()
+        self.coordinator.stopLoader()
         if !userCancelled {
-          self?.onTransition?(.success)
+          self.onTransition?(.success)
         }
 
       } catch {
-        self?.coordinator.stopLoader()
-        self?.coordinator.showError(error)
+        self.coordinator.stopLoader()
+        self.coordinator.showError(error)
       }
     }
   }

--- a/BookPlayerTests/Mocks/PlayerManagerMock.swift
+++ b/BookPlayerTests/Mocks/PlayerManagerMock.swift
@@ -37,7 +37,7 @@ class PlayerManagerMock: NSObject, PlayerManagerProtocol {
 
   func stop() {}
 
-  func load(_ item: PlayableItem) {
+  func load(_ item: PlayableItem, autoplay: Bool) {
     NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["loaded": true])
   }
 

--- a/Shared/BookPlayerError.swift
+++ b/Shared/BookPlayerError.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum BookPlayerError: Error {
   case runtimeError(String)
   case networkError(String)
+  case cancelledTask
   case emptyResponse
 }
 
@@ -23,6 +24,8 @@ extension BookPlayerError: LocalizedError {
       return "Empty network response"
     case .networkError(let message):
       return message
+    case .cancelledTask:
+      return "Concurrent task was cancelled"
     }
   }
 }

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -46,7 +46,7 @@ public class CommandParser {
       guard !DataManager.isURLInProcessedFolder(url) else {
         return nil
       }
-      
+
       return Action(command: .fileImport, parameters: [URLQueryItem(name: "url", value: url.path)])
     }
 

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -65,7 +65,7 @@ public class DataManager {
 
     return sharedFolderURL
   }
-  
+
   public class func isURLInProcessedFolder(_ url: URL) -> Bool {
     let absoluteUrl = url.resolvingSymlinksInPath().absoluteString
     let processedFolderUrl = getProcessedFolderURL().absoluteString

--- a/Shared/Extensions/URL+BookPlayer.swift
+++ b/Shared/Extensions/URL+BookPlayer.swift
@@ -18,7 +18,7 @@ public extension URL {
     var isDirectoryFolder: Bool {
         return (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
-    
+
   // Disable file protection for file and descendants if it's a directory
   func disableFileProtection() {
     try? (self as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -46,7 +46,7 @@ extension LibraryService: LibrarySyncProtocol {
       localItem.lastPlayDate = nil
     }
 
-    dataManager.saveContext()
+    dataManager.saveSyncContext()
   }
 
   public func addBook(from item: SyncableItem, parentFolder: String?) {


### PR DESCRIPTION
## Purpose

- `currentTime` and `percentCompleted` are being updated based on the chapter context
- If streaming fails to load, there's no straightway to retry the stream


## Approach

- Rework the `PlayerManager` to queue playback internally when loading a new item
- Retry loading the item after a play action, if the `currentItem` fails to load
- Show the player screen before loading the new playback item
- Remove unnecessary values from the socket payload

## Things to be aware of / Things to focus on

- There's probably a better way to let the user know that the player is loading a stream, right now the only feedback is the play button displaying the pause button, but depending on the internet connection, this may take some time until playback is resumed
