### PR TITLE
Suggest folder name same as imported zip archive

### DIFF
--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -14,7 +14,7 @@ import UniformTypeIdentifiers
 enum ItemListActionRoutes {
   case downloadBook(_ url: URL)
   case newImportOperation(_ operation: ImportOperation)
-  case importOperationFinished(_ urls: [URL])
+  case importOperationFinished(_ urls: [URL], _ suggestedFolderName: String?)
   case reloadItems(_ pageSizePadding: Int)
 }
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -135,7 +135,7 @@ class LibraryListCoordinator: ItemListCoordinator {
 
       operation.completionBlock = {
         DispatchQueue.main.async {
-          coordinator.onAction?(.importOperationFinished(operation.processedFiles))
+          coordinator.onAction?(.importOperationFinished(operation.processedFiles, operation.suggestedFolderName))
         }
       }
 

--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -20,6 +20,7 @@ public class ImportOperation: Operation {
   public let files: [URL]
   public let libraryService: LibraryServiceProtocol
   public var processedFiles = [URL]()
+  public var suggestedFolderName: String?
 
   private let lockQueue = DispatchQueue(label: "com.bookplayer.asyncoperation", attributes: .concurrent)
 
@@ -102,6 +103,8 @@ public class ImportOperation: Operation {
   }
 
   func handleZip(file: URL, remainingFiles: [URL]) {
+    self.suggestedFolderName = file.deletingPathExtension().lastPathComponent
+    
     // Unzip to temporary directory
     let documentsURL = DataManager.getDocumentsFolderURL()
 

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -293,9 +293,9 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, ItemListVi
       case .newImportOperation(let operation):
         let loadingTitle = String.localizedStringWithFormat("import_processing_description".localized, operation.files.count)
         self?.showLoadView(true, title: loadingTitle)
-      case .importOperationFinished(let files):
+      case .importOperationFinished(let files, let suggestedFolderName):
         self?.showLoadView(false)
-        self?.viewModel.handleOperationCompletion(files)
+        self?.viewModel.handleOperationCompletion(files, suggestedFolderName: suggestedFolderName)
       case .downloadBook(let url):
         self?.showLoadView(true, title: "downloading_file_title".localized, subtitle: "\("progress_title".localized) 0%")
         self?.viewModel.handleDownload(url)

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -969,7 +969,7 @@ extension ItemListViewModel {
     self.coordinator.getMainCoordinator()?.getLibraryCoordinator()?.processFiles(urls: urls)
   }
 
-  func handleOperationCompletion(_ files: [URL]) {
+  func handleOperationCompletion(_ files: [URL], suggestedFolderName: String?) {
     guard !files.isEmpty else { return }
 
     let processedItems = libraryService.insertItems(from: files)
@@ -997,14 +997,24 @@ extension ItemListViewModel {
       parentFolder: folderRelativePath
     )?.filter({ $0.type == .folder }) ?? []
 
-    showOperationCompletedAlert(with: itemIdentifiers, availableFolders: availableFolders)
+    showOperationCompletedAlert(
+      with: itemIdentifiers,
+      availableFolders: availableFolders,
+      suggestedFolderName: suggestedFolderName
+    )
   }
 
-  func showOperationCompletedAlert(with items: [String], availableFolders: [SimpleLibraryItem]) {
+  func showOperationCompletedAlert(
+    with items: [String],
+    availableFolders: [SimpleLibraryItem],
+    suggestedFolderName: String?
+  ) {
     let hasParentFolder = folderRelativePath != nil
 
     var firstTitle: String?
-    if let relativePath = items.first {
+    if let suggestedFolderName {
+      firstTitle = suggestedFolderName
+    } else if let relativePath = items.first {
       firstTitle = libraryService.getItemProperty(#keyPath(LibraryItem.title), relativePath: relativePath) as? String
     }
 


### PR DESCRIPTION
## Purpose

When importing zip archive, and then selecting import into New Folder, app suggests folder name same as first file in the archive. This PR changes the behaviour and now suggested folder name is the same as imported archive file name (without extension).


## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/394

## Approach

1. Capture `suggestedFolderName` in `ImportOperation`
2. Pass it to `ItemListViewModel` which shows finished import Alert with suggested folder name
