### PR TITLE
Add restore-purchase button to Themes and Icons screen

### DIFF
--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -113,7 +113,14 @@ class SettingsCoordinator: Coordinator {
 
   func showIcons() {
     let viewModel = IconsViewModel(accountService: self.accountService)
-    viewModel.coordinator = self
+
+    viewModel.onTransition = { [weak self] routes in
+      switch routes {
+      case .showPro:
+        self?.showPro()
+      }
+    }
+
     let vc = IconsViewController.instantiate(from: .Settings)
     vc.viewModel = viewModel
     vc.navigationItem.largeTitleDisplayMode = .never

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -94,7 +94,14 @@ class SettingsCoordinator: Coordinator {
 
   func showThemes() {
     let viewModel = ThemesViewModel(accountService: self.accountService)
-    viewModel.coordinator = self
+
+    viewModel.onTransition = { [weak self] routes in
+      switch routes {
+      case .showPro:
+        self?.showPro()
+      }
+    }
+
     let vc = ThemesViewController.instantiate(from: .Settings)
     vc.viewModel = viewModel
     vc.navigationItem.largeTitleDisplayMode = .never

--- a/BookPlayer/Settings/Icons Screen/IconsViewController.swift
+++ b/BookPlayer/Settings/Icons Screen/IconsViewController.swift
@@ -33,6 +33,12 @@ class IconsViewController: UIViewController, Storyboarded {
       target: self,
       action: #selector(self.didPressClose)
     )
+    self.navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "restore_title".localized,
+      style: .plain,
+      target: self,
+      action: #selector(self.didPressRestore)
+    )
 
     self.icons = self.getIcons()
 
@@ -44,6 +50,32 @@ class IconsViewController: UIViewController, Storyboarded {
 
     self.bannerView.showPlus = { [weak self] in
       self?.viewModel.showPro()
+    }
+
+    bindDataItems()
+  }
+
+  func bindDataItems() {
+    self.viewModel.observeEvents()
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] event in
+        switch event {
+        case .showAlert(let content):
+          self?.showAlert(content)
+        case .showLoader(let flag):
+          self?.showLoader(flag)
+        case .donationMade:
+          self?.donationMade()
+        }
+      }
+      .store(in: &disposeBag)
+  }
+
+  func showLoader(_ flag: Bool) {
+    if flag {
+      LoadingUtils.loadAndBlock(in: self)
+    } else {
+      LoadingUtils.stopLoading(in: self)
     }
   }
 
@@ -66,11 +98,17 @@ class IconsViewController: UIViewController, Storyboarded {
     self.dismiss(animated: true, completion: nil)
   }
 
-    @objc func donationMade() {
-        self.bannerView.isHidden = true
-        self.bannerHeightConstraint.constant = 0
-        self.tableView.reloadData()
+  @objc func didPressRestore() {
+    viewModel.handleRestorePurchases()
+  }
+
+  @objc func donationMade() {
+    if self.viewModel.hasSubscription {
+      self.bannerView.isHidden = true
+      self.bannerHeightConstraint.constant = 0
     }
+    self.tableView.reloadData()
+  }
 
     func getIcons() -> [Icon] {
         guard

--- a/BookPlayer/Settings/Icons Screen/IconsViewModel.swift
+++ b/BookPlayer/Settings/Icons Screen/IconsViewModel.swift
@@ -10,7 +10,18 @@ import BookPlayerKit
 import Combine
 
 final class IconsViewModel {
-  weak var coordinator: SettingsCoordinator!
+  /// Available routes for this screen
+  enum Routes {
+    case showPro
+  }
+
+  /// Events that the screen can handle
+  enum Events {
+    case showAlert(content: BPAlertContent)
+    case showLoader(Bool)
+    case donationMade
+  }
+
   let accountService: AccountServiceProtocol
 
   @Published var account: Account?
@@ -18,6 +29,11 @@ final class IconsViewModel {
   var hasSubscription: Bool {
     return account?.hasSubscription == true
   }
+
+  /// Callback to handle actions on this screen
+  public var onTransition: Transition<Routes>?
+  /// Events publisher
+  private var eventsPublisher = InterfaceUpdater<IconsViewModel.Events>()
 
   private var disposeBag = Set<AnyCancellable>()
 
@@ -28,12 +44,20 @@ final class IconsViewModel {
     self.bindObservers()
   }
 
-  func bindObservers() {
+  func observeEvents() -> AnyPublisher<IconsViewModel.Events, Never> {
+    eventsPublisher.eraseToAnyPublisher()
+  }
+
+  private func bindObservers() {
     NotificationCenter.default.publisher(for: .accountUpdate, object: nil)
       .sink(receiveValue: { [weak self] _ in
         self?.reloadAccount()
       })
       .store(in: &disposeBag)
+  }
+
+  private func sendEvent(_ event: IconsViewModel.Events) {
+    eventsPublisher.send(event)
   }
 
   func reloadAccount() {
@@ -45,6 +69,52 @@ final class IconsViewModel {
   }
 
   func showPro() {
-    self.coordinator.showPro()
+    onTransition?(.showPro)
+  }
+
+  func handleRestorePurchases() {
+    Task { @MainActor [weak self] in
+      guard let self = self else { return }
+
+      self.sendEvent(.showLoader(true))
+
+      do {
+        let customerInfo = try await self.accountService.restorePurchases()
+
+        self.sendEvent(.showLoader(false))
+
+        if customerInfo.nonSubscriptions.isEmpty {
+          self.sendEvent(.showAlert(
+            content: BPAlertContent(
+              title: "tip_missing_title".localized,
+              style: .alert,
+              actionItems: [BPActionItem.okAction]
+            )
+          ))
+        } else {
+          self.accountService.updateAccount(
+            id: nil,
+            email: nil,
+            donationMade: true,
+            hasSubscription: nil
+          )
+
+          self.sendEvent(.showAlert(
+            content: BPAlertContent(
+              title: "purchases_restored_title".localized,
+              style: .alert,
+              actionItems: [BPActionItem.okAction]
+            )
+          ))
+
+          self.sendEvent(.donationMade)
+        }
+      } catch {
+        self.sendEvent(.showLoader(false))
+        self.sendEvent(.showAlert(
+          content: BPAlertContent.errorAlert(message: error.localizedDescription)
+        ))
+      }
+    }
   }
 }

--- a/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
@@ -8,6 +8,7 @@
 
 import BookPlayerKit
 import Combine
+import RevenueCat
 import Themeable
 import UIKit
 import WidgetKit
@@ -63,6 +64,12 @@ class ThemesViewController: UIViewController, Storyboarded {
       target: self,
       action: #selector(self.didPressClose)
     )
+    self.navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "restore_title".localized,
+      style: .plain,
+      target: self,
+      action: #selector(self.didPressRestore)
+    )
 
     self.localThemes = ThemeManager.getLocalThemes()
     self.extractedThemes = [] // disabled
@@ -93,6 +100,32 @@ class ThemesViewController: UIViewController, Storyboarded {
 
     self.bannerView.showPlus = { [weak self] in
       self?.viewModel.showPro()
+    }
+
+    bindDataItems()
+  }
+
+  func bindDataItems() {
+    self.viewModel.observeEvents()
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] event in
+        switch event {
+        case .showAlert(let content):
+          self?.showAlert(content)
+        case .showLoader(let flag):
+          self?.showLoader(flag)
+        case .donationMade:
+          self?.donationMade()
+        }
+      }
+      .store(in: &disposeBag)
+  }
+
+  func showLoader(_ flag: Bool) {
+    if flag {
+      LoadingUtils.loadAndBlock(in: self)
+    } else {
+      LoadingUtils.stopLoading(in: self)
     }
   }
 
@@ -131,17 +164,23 @@ class ThemesViewController: UIViewController, Storyboarded {
     self.scrollContentHeightConstraint.constant = tableHeight + self.localThemesTableView.frame.origin.y
   }
 
-    @objc func donationMade() {
-        self.bannerView.isHidden = true
-        self.bannerHeightConstraint.constant = 30
-        self.localThemesTableView.reloadData()
-        self.extractedThemesTableView.reloadData()
+  @objc func donationMade() {
+    if self.viewModel.hasSubscription {
+      self.bannerView.isHidden = true
+      self.bannerHeightConstraint.constant = 30
     }
+    self.localThemesTableView.reloadData()
+    self.extractedThemesTableView.reloadData()
+  }
 
-    func extractTheme() {}
+  func extractTheme() {}
 
   @objc func didPressClose() {
     self.dismiss(animated: true, completion: nil)
+  }
+
+  @objc func didPressRestore() {
+    viewModel.handleRestorePurchases()
   }
 
     @IBAction func sliderUpdated(_ sender: UISlider) {

--- a/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
@@ -8,7 +8,6 @@
 
 import BookPlayerKit
 import Combine
-import RevenueCat
 import Themeable
 import UIKit
 import WidgetKit

--- a/BookPlayer/Utils/BPAlertContent.swift
+++ b/BookPlayer/Utils/BPAlertContent.swift
@@ -37,7 +37,7 @@ extension BPAlertContent {
       title: title,
       message: message,
       style: .alert,
-      actionItems: [BPActionItem(title: "ok_button".localized)]
+      actionItems: [BPActionItem.okAction]
     )
   }
 }
@@ -65,6 +65,14 @@ struct BPActionItem {
 }
 
 extension BPActionItem {
+  static var okAction = BPActionItem(
+    title: "ok_button".localized,
+    style: .default,
+    isEnabled: true,
+    handler: {},
+    inputHandler: nil
+  )
+
   static var cancelAction = BPActionItem(
     title: "cancel_button".localized,
     style: .cancel,


### PR DESCRIPTION
## Purpose

- Enable users to restore their purchase / donation on different devices

## Related tasks

#917

## Approach

- Add button, and use the account service to call the restore purchase functionality