### PR TITLE
Fix Testflight reported crashes

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -223,6 +223,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     if self.currentItem != nil {
       stopPlayback()
       playerItem = nil
+      /// Clear out flag when `playerItem` is nulled out
+      hasObserverRegistered = false
       currentItem = nil
     }
 
@@ -733,6 +735,8 @@ extension PlayerManager {
 
     self.currentItem = nil
     playerItem = nil
+    /// Clear out flag when `playerItem` is nulled out
+    hasObserverRegistered = false
   }
 
   private func stopPlayback() {

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -43,7 +43,11 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
   private var disposeBag = Set<AnyCancellable>()
 
   private var pendingOperations: [JobInfo] {
-    libraryQueueManager.getAll()["GLOBAL"] ?? []
+    if libraryQueueManager != nil {
+      return libraryQueueManager.getAll()["GLOBAL"] ?? []
+    } else {
+      return []
+    }
   }
 
   public var queuedJobsCount: Int { pendingOperations.count }
@@ -70,7 +74,9 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
           Self.logger.trace("Failed to delete hard link for \(relativePath): \(error.localizedDescription)")
         }
 
-        self?.libraryQueueManager.cancelOperations(uuid: "\(JobType.upload.identifier)/\(relativePath)")
+        if self?.libraryQueueManager != nil {
+          self?.libraryQueueManager.cancelOperations(uuid: "\(JobType.upload.identifier)/\(relativePath)")
+        }
       }
       .store(in: &disposeBag)
 
@@ -258,7 +264,9 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
   }
 
   public func cancelAllJobs() {
-    libraryQueueManager.cancelAllOperations()
+    if libraryQueueManager != nil {
+      libraryQueueManager.cancelAllOperations()
+    }
     libraryJobsPersister.clearAll()
   }
 


### PR DESCRIPTION
## Bugfix

- Crash when opening a book through the widget
- Crash when signing out and signing back in

## Approach

- Update observer flag, as it was trying to remove a non-existing observer for the current player item
- Check if the library queue manager exists, as this object may need to be reinstantiated when the queue is stuck
