### PR TITLE
Schedule artwork upload instead of uploading instantly

### DIFF
--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1448,25 +1448,6 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
             return downloadRemoteFilesForTypeDelegateReturnValue
         }
     }
-    //MARK: - uploadArtwork
-
-    var uploadArtworkRelativePathDataThrowableError: Error?
-    var uploadArtworkRelativePathDataCallsCount = 0
-    var uploadArtworkRelativePathDataCalled: Bool {
-        return uploadArtworkRelativePathDataCallsCount > 0
-    }
-    var uploadArtworkRelativePathDataReceivedArguments: (relativePath: String, data: Data)?
-    var uploadArtworkRelativePathDataReceivedInvocations: [(relativePath: String, data: Data)] = []
-    var uploadArtworkRelativePathDataClosure: ((String, Data) async throws -> Void)?
-    func uploadArtwork(relativePath: String, data: Data) async throws {
-        if let error = uploadArtworkRelativePathDataThrowableError {
-            throw error
-        }
-        uploadArtworkRelativePathDataCallsCount += 1
-        uploadArtworkRelativePathDataReceivedArguments = (relativePath: relativePath, data: data)
-        uploadArtworkRelativePathDataReceivedInvocations.append((relativePath: relativePath, data: data))
-        try await uploadArtworkRelativePathDataClosure?(relativePath, data)
-    }
     //MARK: - scheduleUpload
 
     var scheduleUploadItemsCallsCount = 0
@@ -1556,6 +1537,21 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
         scheduleDeleteBookmarkReceivedBookmark = bookmark
         scheduleDeleteBookmarkReceivedInvocations.append(bookmark)
         scheduleDeleteBookmarkClosure?(bookmark)
+    }
+    //MARK: - scheduleUploadArtwork
+
+    var scheduleUploadArtworkRelativePathCallsCount = 0
+    var scheduleUploadArtworkRelativePathCalled: Bool {
+        return scheduleUploadArtworkRelativePathCallsCount > 0
+    }
+    var scheduleUploadArtworkRelativePathReceivedRelativePath: String?
+    var scheduleUploadArtworkRelativePathReceivedInvocations: [String] = []
+    var scheduleUploadArtworkRelativePathClosure: ((String) -> Void)?
+    func scheduleUploadArtwork(relativePath: String) {
+        scheduleUploadArtworkRelativePathCallsCount += 1
+        scheduleUploadArtworkRelativePathReceivedRelativePath = relativePath
+        scheduleUploadArtworkRelativePathReceivedInvocations.append(relativePath)
+        scheduleUploadArtworkRelativePathClosure?(relativePath)
     }
     //MARK: - getAllQueuedJobs
 

--- a/BookPlayer/Library/ItemDetails Screen/ItemDetailsViewModel.swift
+++ b/BookPlayer/Library/ItemDetails Screen/ItemDetailsViewModel.swift
@@ -86,16 +86,12 @@ class ItemDetailsViewModel: BaseViewModel<Coordinator> {
 
       self.sendEvent(.showLoader(flag: true))
 
-      do {
-        try await self.syncService.uploadArtwork(relativePath: item.relativePath, data: imageData)
-        await ArtworkService.removeCache(for: item.relativePath)
-        await ArtworkService.storeInCache(imageData, for: cacheKey)
-        self.sendEvent(.showLoader(flag: false))
-        self.onTransition?(.done)
-      } catch {
-        self.sendEvent(.showLoader(flag: false))
-        self.sendEvent(.showAlert(content: BPAlertContent.errorAlert(message: error.localizedDescription)))
-      }
+      await ArtworkService.removeCache(for: item.relativePath)
+      await ArtworkService.storeInCache(imageData, for: cacheKey)
+      self.syncService.scheduleUploadArtwork(relativePath: cacheKey)
+
+      self.sendEvent(.showLoader(flag: false))
+      self.onTransition?(.done)
     }
   }
 

--- a/BookPlayer/Profile/Profile Screen/QueuedSyncTasksView.swift
+++ b/BookPlayer/Profile/Profile Screen/QueuedSyncTasksView.swift
@@ -31,6 +31,8 @@ struct QueuedSyncTasksView<Model: QueuedSyncTasksViewModelProtocol>: View {
       return "bookmark"
     case .deleteBookmark:
       return "bookmark.slash"
+    case .uploadArtwork:
+      return "photo"
     }
   }
 

--- a/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Folder+CoreDataClass.swift
@@ -84,6 +84,7 @@ extension Folder {
     self.details = syncItem.details
     self.relativePath = syncItem.relativePath
     self.remoteURL = syncItem.remoteURL
+    self.artworkURL = syncItem.artworkURL
     self.originalFileName = syncItem.originalFileName
     if let speed = syncItem.speed {
       self.speed = Float(speed)

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -31,6 +31,8 @@ public protocol JobSchedulerProtocol {
   func scheduleDeleteBookmarkJob(with relativePath: String, time: Double)
   /// Rename a folder
   func scheduleRenameFolderJob(with relativePath: String, name: String)
+  /// Upload current cached artwork
+  func scheduleArtworkUpload(with relativePath: String)
   /// Get all queued jobs
   func getAllQueuedJobs() -> [QueuedJobInfo]
   /// Cancel all stored and ongoing jobs
@@ -238,6 +240,21 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
 
     JobBuilder(type: LibraryItemSyncJob.type)
       .singleInstance(forId: "\(JobType.renameFolder.identifier)/\(relativePath)")
+      .persist()
+      .retry(limit: .unlimited)
+      .internet(atLeast: .cellular)
+      .with(params: params)
+      .schedule(manager: libraryQueueManager)
+  }
+
+  public func scheduleArtworkUpload(with relativePath: String) {
+    let params: [String: Any] = [
+      "relativePath": relativePath,
+      "jobType": JobType.uploadArtwork.rawValue
+    ]
+
+    JobBuilder(type: LibraryItemSyncJob.type)
+      .singleInstance(forId: "\(JobType.uploadArtwork.identifier)/\(relativePath)")
       .persist()
       .retry(limit: .unlimited)
       .internet(atLeast: .cellular)


### PR DESCRIPTION
## Purpose

Artwork updates should be queued up, as the related item may still be on queue to be uploaded, and it wouldn’t be available to link the artwork to

## Related tasks

#919 

## Approach

- Move upload implementation into a sync job
- Fix recently synced folders not storing the artwork url on the creation step