### PR TITLE
WIP: Rework CoreData interface to address random crashes

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -388,6 +388,8 @@
 		9F64C6212793C31600B2493C /* PlayerControlsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */; };
 		9F64C6242793C3DA00B2493C /* PlayerControlsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */; };
 		9F64C6262793D5B100B2493C /* PlayerControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */; };
+		9F665EC82A47C8AD004BFE27 /* LibraryService+FetchRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F665EC72A47C8AD004BFE27 /* LibraryService+FetchRequests.swift */; };
+		9F665EC92A47C8AD004BFE27 /* LibraryService+FetchRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F665EC72A47C8AD004BFE27 /* LibraryService+FetchRequests.swift */; };
 		9F6BC86627E6D03D002CF2A6 /* WatchApplicationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6BC86427E6D027002CF2A6 /* WatchApplicationContext.swift */; };
 		9F6BC86727E6D03E002CF2A6 /* WatchApplicationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6BC86427E6D027002CF2A6 /* WatchApplicationContext.swift */; };
 		9F7B64712803216100895ECC /* Account+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B64702803216100895ECC /* Account+CoreDataProperties.swift */; };
@@ -1037,6 +1039,7 @@
 		9F64C6202793C31600B2493C /* PlayerControlsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsCoordinator.swift; sourceTree = "<group>"; };
 		9F64C6232793C3DA00B2493C /* PlayerControlsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewModel.swift; sourceTree = "<group>"; };
 		9F64C6252793D5B100B2493C /* PlayerControlsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControlsViewController.swift; sourceTree = "<group>"; };
+		9F665EC72A47C8AD004BFE27 /* LibraryService+FetchRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryService+FetchRequests.swift"; sourceTree = "<group>"; };
 		9F6BC86427E6D027002CF2A6 /* WatchApplicationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApplicationContext.swift; sourceTree = "<group>"; };
 		9F7B646F28031E9300895ECC /* Audiobook Player 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 9.xcdatamodel"; sourceTree = "<group>"; };
 		9F7B64702803216100895ECC /* Account+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -1831,6 +1834,7 @@
 				9F49072B2903663800054AD6 /* SortType.swift */,
 				9FC1E4742815C6A300522FA8 /* KeychainService.swift */,
 				62AAE22B274AA3EB001EB9FF /* LibraryService.swift */,
+				9F665EC72A47C8AD004BFE27 /* LibraryService+FetchRequests.swift */,
 				9FDDD2E0289BFCE20020C428 /* LibraryService+Sync.swift */,
 				41EB071A2752FA6B00EFEE13 /* PlaybackService.swift */,
 				9FC1E4612814F68F00522FA8 /* Account */,
@@ -2898,6 +2902,7 @@
 				9FAFC9F52995BB5C00FD531E /* RemoteFileURLResponse.swift in Sources */,
 				4140EA77227289B90009F794 /* Chapter+CoreDataProperties.swift in Sources */,
 				4140EA7B227289C40009F794 /* Book+CoreDataProperties.swift in Sources */,
+				9F665EC92A47C8AD004BFE27 /* LibraryService+FetchRequests.swift in Sources */,
 				4140EA81227289D80009F794 /* Folder+CoreDataProperties.swift in Sources */,
 				41EB07192752F1BA00EFEE13 /* PlayableChapter.swift in Sources */,
 				9FC1E44B2814C4DE00522FA8 /* NetworkClient.swift in Sources */,
@@ -3192,6 +3197,7 @@
 				41A8942A2652A7DF0032E972 /* Bundle+BookPlayer.swift in Sources */,
 				41A1B0F2226E9D1200EA0400 /* BookPlayer.xcdatamodeld in Sources */,
 				41A359C5276232E00020D5F5 /* MappingModel_v7_to_v8.xcmappingmodel in Sources */,
+				9F665EC82A47C8AD004BFE27 /* LibraryService+FetchRequests.swift in Sources */,
 				41A1B125226F88C500EA0400 /* LibraryItem+CoreDataClass.swift in Sources */,
 				62CADBA52725BCB200A4A98F /* AVAudioAssetImageDataProvider.swift in Sources */,
 				9FC1E4592814E0B000522FA8 /* NetworkUtils.swift in Sources */,

--- a/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayer.xcscheme
+++ b/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayer.xcscheme
@@ -87,6 +87,24 @@
             ReferencedContainer = "container:BookPlayer.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "SQLITE_ENABLE_FILE_ASSERTIONS"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SQLITE_ENABLE_THREAD_ASSERTIONS"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <StoreKitConfigurationFileReference
          identifier = "../../IAP-Configuration.storekit">
       </StoreKitConfigurationFileReference>

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -90,22 +90,6 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return getLibraryReturnValue
         }
     }
-    //MARK: - getLibraryReference
-
-    var getLibraryReferenceCallsCount = 0
-    var getLibraryReferenceCalled: Bool {
-        return getLibraryReferenceCallsCount > 0
-    }
-    var getLibraryReferenceReturnValue: Library!
-    var getLibraryReferenceClosure: (() -> Library)?
-    func getLibraryReference() -> Library {
-        getLibraryReferenceCallsCount += 1
-        if let getLibraryReferenceClosure = getLibraryReferenceClosure {
-            return getLibraryReferenceClosure()
-        } else {
-            return getLibraryReferenceReturnValue
-        }
-    }
     //MARK: - getLibraryLastItem
 
     var getLibraryLastItemCallsCount = 0
@@ -177,13 +161,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var insertItemsFromReceivedFiles: [URL]?
     var insertItemsFromReceivedInvocations: [[URL]] = []
     var insertItemsFromReturnValue: [SimpleLibraryItem]!
-    var insertItemsFromClosure: (([URL]) -> [SimpleLibraryItem])?
-    func insertItems(from files: [URL]) -> [SimpleLibraryItem] {
+    var insertItemsFromClosure: (([URL]) async -> [SimpleLibraryItem])?
+    func insertItems(from files: [URL]) async -> [SimpleLibraryItem] {
         insertItemsFromCallsCount += 1
         insertItemsFromReceivedFiles = files
         insertItemsFromReceivedInvocations.append(files)
         if let insertItemsFromClosure = insertItemsFromClosure {
-            return insertItemsFromClosure(files)
+            return await insertItemsFromClosure(files)
         } else {
             return insertItemsFromReturnValue
         }
@@ -197,15 +181,15 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var moveItemsInsideReceivedArguments: (items: [String], relativePath: String?)?
     var moveItemsInsideReceivedInvocations: [(items: [String], relativePath: String?)] = []
-    var moveItemsInsideClosure: (([String], String?) throws -> Void)?
-    func moveItems(_ items: [String], inside relativePath: String?) throws {
+    var moveItemsInsideClosure: (([String], String?) async throws -> Void)?
+    func moveItems(_ items: [String], inside relativePath: String?) async throws {
         if let error = moveItemsInsideThrowableError {
             throw error
         }
         moveItemsInsideCallsCount += 1
         moveItemsInsideReceivedArguments = (items: items, relativePath: relativePath)
         moveItemsInsideReceivedInvocations.append((items: items, relativePath: relativePath))
-        try moveItemsInsideClosure?(items, relativePath)
+        try await moveItemsInsideClosure?(items, relativePath)
     }
     //MARK: - delete
 
@@ -216,15 +200,15 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var deleteModeReceivedArguments: (items: [SimpleLibraryItem], mode: DeleteMode)?
     var deleteModeReceivedInvocations: [(items: [SimpleLibraryItem], mode: DeleteMode)] = []
-    var deleteModeClosure: (([SimpleLibraryItem], DeleteMode) throws -> Void)?
-    func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) throws {
+    var deleteModeClosure: (([SimpleLibraryItem], DeleteMode) async throws -> Void)?
+    func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) async throws {
         if let error = deleteModeThrowableError {
             throw error
         }
         deleteModeCallsCount += 1
         deleteModeReceivedArguments = (items: items, mode: mode)
         deleteModeReceivedInvocations.append((items: items, mode: mode))
-        try deleteModeClosure?(items, mode)
+        try await deleteModeClosure?(items, mode)
     }
     //MARK: - fetchContents
 
@@ -275,13 +259,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var getLastPlayedItemsLimitReceivedLimit: Int?
     var getLastPlayedItemsLimitReceivedInvocations: [Int?] = []
     var getLastPlayedItemsLimitReturnValue: [SimpleLibraryItem]?
-    var getLastPlayedItemsLimitClosure: ((Int?) -> [SimpleLibraryItem]?)?
-    func getLastPlayedItems(limit: Int?) -> [SimpleLibraryItem]? {
+    var getLastPlayedItemsLimitClosure: ((Int?) async -> [SimpleLibraryItem]?)?
+    func getLastPlayedItems(limit: Int?) async -> [SimpleLibraryItem]? {
         getLastPlayedItemsLimitCallsCount += 1
         getLastPlayedItemsLimitReceivedLimit = limit
         getLastPlayedItemsLimitReceivedInvocations.append(limit)
         if let getLastPlayedItemsLimitClosure = getLastPlayedItemsLimitClosure {
-            return getLastPlayedItemsLimitClosure(limit)
+            return await getLastPlayedItemsLimitClosure(limit)
         } else {
             return getLastPlayedItemsLimitReturnValue
         }
@@ -295,13 +279,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var findBooksContainingReceivedFileURL: URL?
     var findBooksContainingReceivedInvocations: [URL] = []
     var findBooksContainingReturnValue: [Book]?
-    var findBooksContainingClosure: ((URL) -> [Book]?)?
-    func findBooks(containing fileURL: URL) -> [Book]? {
+    var findBooksContainingClosure: ((URL) async -> [Book]?)?
+    func findBooks(containing fileURL: URL) async -> [Book]? {
         findBooksContainingCallsCount += 1
         findBooksContainingReceivedFileURL = fileURL
         findBooksContainingReceivedInvocations.append(fileURL)
         if let findBooksContainingClosure = findBooksContainingClosure {
-            return findBooksContainingClosure(fileURL)
+            return await findBooksContainingClosure(fileURL)
         } else {
             return findBooksContainingReturnValue
         }
@@ -315,13 +299,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var getSimpleItemWithReceivedRelativePath: String?
     var getSimpleItemWithReceivedInvocations: [String] = []
     var getSimpleItemWithReturnValue: SimpleLibraryItem?
-    var getSimpleItemWithClosure: ((String) -> SimpleLibraryItem?)?
-    func getSimpleItem(with relativePath: String) -> SimpleLibraryItem? {
+    var getSimpleItemWithClosure: ((String) async -> SimpleLibraryItem?)?
+    func getSimpleItem(with relativePath: String) async -> SimpleLibraryItem? {
         getSimpleItemWithCallsCount += 1
         getSimpleItemWithReceivedRelativePath = relativePath
         getSimpleItemWithReceivedInvocations.append(relativePath)
         if let getSimpleItemWithClosure = getSimpleItemWithClosure {
-            return getSimpleItemWithClosure(relativePath)
+            return await getSimpleItemWithClosure(relativePath)
         } else {
             return getSimpleItemWithReturnValue
         }
@@ -335,13 +319,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var getItemsNotInParentFolderReceivedArguments: (relativePaths: [String], parentFolder: String?)?
     var getItemsNotInParentFolderReceivedInvocations: [(relativePaths: [String], parentFolder: String?)] = []
     var getItemsNotInParentFolderReturnValue: [SimpleLibraryItem]?
-    var getItemsNotInParentFolderClosure: (([String], String?) -> [SimpleLibraryItem]?)?
-    func getItems(notIn relativePaths: [String], parentFolder: String?) -> [SimpleLibraryItem]? {
+    var getItemsNotInParentFolderClosure: (([String], String?) async -> [SimpleLibraryItem]?)?
+    func getItems(notIn relativePaths: [String], parentFolder: String?) async -> [SimpleLibraryItem]? {
         getItemsNotInParentFolderCallsCount += 1
         getItemsNotInParentFolderReceivedArguments = (relativePaths: relativePaths, parentFolder: parentFolder)
         getItemsNotInParentFolderReceivedInvocations.append((relativePaths: relativePaths, parentFolder: parentFolder))
         if let getItemsNotInParentFolderClosure = getItemsNotInParentFolderClosure {
-            return getItemsNotInParentFolderClosure(relativePaths, parentFolder)
+            return await getItemsNotInParentFolderClosure(relativePaths, parentFolder)
         } else {
             return getItemsNotInParentFolderReturnValue
         }
@@ -375,13 +359,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var filterContentsAtQueryScopeLimitOffsetReceivedArguments: (relativePath: String?, query: String?, scope: SimpleItemType, limit: Int?, offset: Int?)?
     var filterContentsAtQueryScopeLimitOffsetReceivedInvocations: [(relativePath: String?, query: String?, scope: SimpleItemType, limit: Int?, offset: Int?)] = []
     var filterContentsAtQueryScopeLimitOffsetReturnValue: [SimpleLibraryItem]?
-    var filterContentsAtQueryScopeLimitOffsetClosure: ((String?, String?, SimpleItemType, Int?, Int?) -> [SimpleLibraryItem]?)?
-    func filterContents(at relativePath: String?, query: String?, scope: SimpleItemType, limit: Int?, offset: Int?) -> [SimpleLibraryItem]? {
+    var filterContentsAtQueryScopeLimitOffsetClosure: ((String?, String?, SimpleItemType, Int?, Int?) async -> [SimpleLibraryItem]?)?
+    func filterContents(at relativePath: String?, query: String?, scope: SimpleItemType, limit: Int?, offset: Int?) async -> [SimpleLibraryItem]? {
         filterContentsAtQueryScopeLimitOffsetCallsCount += 1
         filterContentsAtQueryScopeLimitOffsetReceivedArguments = (relativePath: relativePath, query: query, scope: scope, limit: limit, offset: offset)
         filterContentsAtQueryScopeLimitOffsetReceivedInvocations.append((relativePath: relativePath, query: query, scope: scope, limit: limit, offset: offset))
         if let filterContentsAtQueryScopeLimitOffsetClosure = filterContentsAtQueryScopeLimitOffsetClosure {
-            return filterContentsAtQueryScopeLimitOffsetClosure(relativePath, query, scope, limit, offset)
+            return await filterContentsAtQueryScopeLimitOffsetClosure(relativePath, query, scope, limit, offset)
         } else {
             return filterContentsAtQueryScopeLimitOffsetReturnValue
         }
@@ -395,13 +379,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var findFirstItemInIsUnfinishedReceivedArguments: (parentFolder: String?, isUnfinished: Bool?)?
     var findFirstItemInIsUnfinishedReceivedInvocations: [(parentFolder: String?, isUnfinished: Bool?)] = []
     var findFirstItemInIsUnfinishedReturnValue: SimpleLibraryItem?
-    var findFirstItemInIsUnfinishedClosure: ((String?, Bool?) -> SimpleLibraryItem?)?
-    func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem? {
+    var findFirstItemInIsUnfinishedClosure: ((String?, Bool?) async -> SimpleLibraryItem?)?
+    func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) async -> SimpleLibraryItem? {
         findFirstItemInIsUnfinishedCallsCount += 1
         findFirstItemInIsUnfinishedReceivedArguments = (parentFolder: parentFolder, isUnfinished: isUnfinished)
         findFirstItemInIsUnfinishedReceivedInvocations.append((parentFolder: parentFolder, isUnfinished: isUnfinished))
         if let findFirstItemInIsUnfinishedClosure = findFirstItemInIsUnfinishedClosure {
-            return findFirstItemInIsUnfinishedClosure(parentFolder, isUnfinished)
+            return await findFirstItemInIsUnfinishedClosure(parentFolder, isUnfinished)
         } else {
             return findFirstItemInIsUnfinishedReturnValue
         }
@@ -415,13 +399,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var findFirstItemInBeforeRankReceivedArguments: (parentFolder: String?, beforeRank: Int16?)?
     var findFirstItemInBeforeRankReceivedInvocations: [(parentFolder: String?, beforeRank: Int16?)] = []
     var findFirstItemInBeforeRankReturnValue: SimpleLibraryItem?
-    var findFirstItemInBeforeRankClosure: ((String?, Int16?) -> SimpleLibraryItem?)?
-    func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem? {
+    var findFirstItemInBeforeRankClosure: ((String?, Int16?) async -> SimpleLibraryItem?)?
+    func findFirstItem(in parentFolder: String?, beforeRank: Int16?) async -> SimpleLibraryItem? {
         findFirstItemInBeforeRankCallsCount += 1
         findFirstItemInBeforeRankReceivedArguments = (parentFolder: parentFolder, beforeRank: beforeRank)
         findFirstItemInBeforeRankReceivedInvocations.append((parentFolder: parentFolder, beforeRank: beforeRank))
         if let findFirstItemInBeforeRankClosure = findFirstItemInBeforeRankClosure {
-            return findFirstItemInBeforeRankClosure(parentFolder, beforeRank)
+            return await findFirstItemInBeforeRankClosure(parentFolder, beforeRank)
         } else {
             return findFirstItemInBeforeRankReturnValue
         }
@@ -435,13 +419,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var findFirstItemInAfterRankIsUnfinishedReceivedArguments: (parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?)?
     var findFirstItemInAfterRankIsUnfinishedReceivedInvocations: [(parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?)] = []
     var findFirstItemInAfterRankIsUnfinishedReturnValue: SimpleLibraryItem?
-    var findFirstItemInAfterRankIsUnfinishedClosure: ((String?, Int16?, Bool?) -> SimpleLibraryItem?)?
-    func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) -> SimpleLibraryItem? {
+    var findFirstItemInAfterRankIsUnfinishedClosure: ((String?, Int16?, Bool?) async -> SimpleLibraryItem?)?
+    func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) async -> SimpleLibraryItem? {
         findFirstItemInAfterRankIsUnfinishedCallsCount += 1
         findFirstItemInAfterRankIsUnfinishedReceivedArguments = (parentFolder: parentFolder, afterRank: afterRank, isUnfinished: isUnfinished)
         findFirstItemInAfterRankIsUnfinishedReceivedInvocations.append((parentFolder: parentFolder, afterRank: afterRank, isUnfinished: isUnfinished))
         if let findFirstItemInAfterRankIsUnfinishedClosure = findFirstItemInAfterRankIsUnfinishedClosure {
-            return findFirstItemInAfterRankIsUnfinishedClosure(parentFolder, afterRank, isUnfinished)
+            return await findFirstItemInAfterRankIsUnfinishedClosure(parentFolder, afterRank, isUnfinished)
         } else {
             return findFirstItemInAfterRankIsUnfinishedReturnValue
         }
@@ -455,13 +439,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var getChaptersFromReceivedRelativePath: String?
     var getChaptersFromReceivedInvocations: [String] = []
     var getChaptersFromReturnValue: [SimpleChapter]?
-    var getChaptersFromClosure: ((String) -> [SimpleChapter]?)?
-    func getChapters(from relativePath: String) -> [SimpleChapter]? {
+    var getChaptersFromClosure: ((String) async -> [SimpleChapter]?)?
+    func getChapters(from relativePath: String) async -> [SimpleChapter]? {
         getChaptersFromCallsCount += 1
         getChaptersFromReceivedRelativePath = relativePath
         getChaptersFromReceivedInvocations.append(relativePath)
         if let getChaptersFromClosure = getChaptersFromClosure {
-            return getChaptersFromClosure(relativePath)
+            return await getChaptersFromClosure(relativePath)
         } else {
             return getChaptersFromReturnValue
         }
@@ -475,13 +459,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var createBookFromReceivedUrl: URL?
     var createBookFromReceivedInvocations: [URL] = []
     var createBookFromReturnValue: Book!
-    var createBookFromClosure: ((URL) -> Book)?
-    func createBook(from url: URL) -> Book {
+    var createBookFromClosure: ((URL) async -> Book)?
+    func createBook(from url: URL) async -> Book {
         createBookFromCallsCount += 1
         createBookFromReceivedUrl = url
         createBookFromReceivedInvocations.append(url)
         if let createBookFromClosure = createBookFromClosure {
-            return createBookFromClosure(url)
+            return await createBookFromClosure(url)
         } else {
             return createBookFromReturnValue
         }
@@ -494,12 +478,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var loadChaptersIfNeededRelativePathAssetReceivedArguments: (relativePath: String, asset: AVAsset)?
     var loadChaptersIfNeededRelativePathAssetReceivedInvocations: [(relativePath: String, asset: AVAsset)] = []
-    var loadChaptersIfNeededRelativePathAssetClosure: ((String, AVAsset) -> Void)?
-    func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) {
+    var loadChaptersIfNeededRelativePathAssetClosure: ((String, AVAsset) async -> Void)?
+    func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) async {
         loadChaptersIfNeededRelativePathAssetCallsCount += 1
         loadChaptersIfNeededRelativePathAssetReceivedArguments = (relativePath: relativePath, asset: asset)
         loadChaptersIfNeededRelativePathAssetReceivedInvocations.append((relativePath: relativePath, asset: asset))
-        loadChaptersIfNeededRelativePathAssetClosure?(relativePath, asset)
+        await loadChaptersIfNeededRelativePathAssetClosure?(relativePath, asset)
     }
     //MARK: - createFolder
 
@@ -511,8 +495,8 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var createFolderWithInsideReceivedArguments: (title: String, relativePath: String?)?
     var createFolderWithInsideReceivedInvocations: [(title: String, relativePath: String?)] = []
     var createFolderWithInsideReturnValue: SimpleLibraryItem!
-    var createFolderWithInsideClosure: ((String, String?) throws -> SimpleLibraryItem)?
-    func createFolder(with title: String, inside relativePath: String?) throws -> SimpleLibraryItem {
+    var createFolderWithInsideClosure: ((String, String?) async throws -> SimpleLibraryItem)?
+    func createFolder(with title: String, inside relativePath: String?) async throws -> SimpleLibraryItem {
         if let error = createFolderWithInsideThrowableError {
             throw error
         }
@@ -520,7 +504,7 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         createFolderWithInsideReceivedArguments = (title: title, relativePath: relativePath)
         createFolderWithInsideReceivedInvocations.append((title: title, relativePath: relativePath))
         if let createFolderWithInsideClosure = createFolderWithInsideClosure {
-            return try createFolderWithInsideClosure(title, relativePath)
+            return try await createFolderWithInsideClosure(title, relativePath)
         } else {
             return createFolderWithInsideReturnValue
         }
@@ -534,15 +518,15 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var updateFolderAtTypeReceivedArguments: (relativePath: String, type: SimpleItemType)?
     var updateFolderAtTypeReceivedInvocations: [(relativePath: String, type: SimpleItemType)] = []
-    var updateFolderAtTypeClosure: ((String, SimpleItemType) throws -> Void)?
-    func updateFolder(at relativePath: String, type: SimpleItemType) throws {
+    var updateFolderAtTypeClosure: ((String, SimpleItemType) async throws -> Void)?
+    func updateFolder(at relativePath: String, type: SimpleItemType) async throws {
         if let error = updateFolderAtTypeThrowableError {
             throw error
         }
         updateFolderAtTypeCallsCount += 1
         updateFolderAtTypeReceivedArguments = (relativePath: relativePath, type: type)
         updateFolderAtTypeReceivedInvocations.append((relativePath: relativePath, type: type))
-        try updateFolderAtTypeClosure?(relativePath, type)
+        try await updateFolderAtTypeClosure?(relativePath, type)
     }
     //MARK: - rebuildFolderDetails
 
@@ -582,12 +566,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var renameBookAtWithReceivedArguments: (relativePath: String, newTitle: String)?
     var renameBookAtWithReceivedInvocations: [(relativePath: String, newTitle: String)] = []
-    var renameBookAtWithClosure: ((String, String) -> Void)?
-    func renameBook(at relativePath: String, with newTitle: String) {
+    var renameBookAtWithClosure: ((String, String) async -> Void)?
+    func renameBook(at relativePath: String, with newTitle: String) async {
         renameBookAtWithCallsCount += 1
         renameBookAtWithReceivedArguments = (relativePath: relativePath, newTitle: newTitle)
         renameBookAtWithReceivedInvocations.append((relativePath: relativePath, newTitle: newTitle))
-        renameBookAtWithClosure?(relativePath, newTitle)
+        await renameBookAtWithClosure?(relativePath, newTitle)
     }
     //MARK: - renameFolder
 
@@ -599,8 +583,8 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var renameFolderAtWithReceivedArguments: (relativePath: String, newTitle: String)?
     var renameFolderAtWithReceivedInvocations: [(relativePath: String, newTitle: String)] = []
     var renameFolderAtWithReturnValue: String!
-    var renameFolderAtWithClosure: ((String, String) throws -> String)?
-    func renameFolder(at relativePath: String, with newTitle: String) throws -> String {
+    var renameFolderAtWithClosure: ((String, String) async throws -> String)?
+    func renameFolder(at relativePath: String, with newTitle: String) async throws -> String {
         if let error = renameFolderAtWithThrowableError {
             throw error
         }
@@ -608,7 +592,7 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         renameFolderAtWithReceivedArguments = (relativePath: relativePath, newTitle: newTitle)
         renameFolderAtWithReceivedInvocations.append((relativePath: relativePath, newTitle: newTitle))
         if let renameFolderAtWithClosure = renameFolderAtWithClosure {
-            return try renameFolderAtWithClosure(relativePath, newTitle)
+            return try await renameFolderAtWithClosure(relativePath, newTitle)
         } else {
             return renameFolderAtWithReturnValue
         }
@@ -621,12 +605,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var updateDetailsAtDetailsReceivedArguments: (relativePath: String, details: String)?
     var updateDetailsAtDetailsReceivedInvocations: [(relativePath: String, details: String)] = []
-    var updateDetailsAtDetailsClosure: ((String, String) -> Void)?
-    func updateDetails(at relativePath: String, details: String) {
+    var updateDetailsAtDetailsClosure: ((String, String) async -> Void)?
+    func updateDetails(at relativePath: String, details: String) async {
         updateDetailsAtDetailsCallsCount += 1
         updateDetailsAtDetailsReceivedArguments = (relativePath: relativePath, details: details)
         updateDetailsAtDetailsReceivedInvocations.append((relativePath: relativePath, details: details))
-        updateDetailsAtDetailsClosure?(relativePath, details)
+        await updateDetailsAtDetailsClosure?(relativePath, details)
     }
     //MARK: - reorderItem
 
@@ -636,12 +620,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedArguments: (relativePath: String, folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath)?
     var reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedInvocations: [(relativePath: String, folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath)] = []
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure: ((String, String?, IndexPath, IndexPath) -> Void)?
-    func reorderItem(with relativePath: String, inside folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) {
+    var reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure: ((String, String?, IndexPath, IndexPath) async -> Void)?
+    func reorderItem(with relativePath: String, inside folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) async {
         reorderItemWithInsideSourceIndexPathDestinationIndexPathCallsCount += 1
         reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedArguments = (relativePath: relativePath, folderRelativePath: folderRelativePath, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
         reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedInvocations.append((relativePath: relativePath, folderRelativePath: folderRelativePath, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath))
-        reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure?(relativePath, folderRelativePath, sourceIndexPath, destinationIndexPath)
+        await reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure?(relativePath, folderRelativePath, sourceIndexPath, destinationIndexPath)
     }
     //MARK: - sortContents
 
@@ -651,12 +635,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var sortContentsAtByReceivedArguments: (relativePath: String?, type: SortType)?
     var sortContentsAtByReceivedInvocations: [(relativePath: String?, type: SortType)] = []
-    var sortContentsAtByClosure: ((String?, SortType) -> Void)?
-    func sortContents(at relativePath: String?, by type: SortType) {
+    var sortContentsAtByClosure: ((String?, SortType) async -> Void)?
+    func sortContents(at relativePath: String?, by type: SortType) async {
         sortContentsAtByCallsCount += 1
         sortContentsAtByReceivedArguments = (relativePath: relativePath, type: type)
         sortContentsAtByReceivedInvocations.append((relativePath: relativePath, type: type))
-        sortContentsAtByClosure?(relativePath, type)
+        await sortContentsAtByClosure?(relativePath, type)
     }
     //MARK: - updatePlaybackTime
 
@@ -716,12 +700,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var markAsFinishedFlagRelativePathReceivedArguments: (flag: Bool, relativePath: String)?
     var markAsFinishedFlagRelativePathReceivedInvocations: [(flag: Bool, relativePath: String)] = []
-    var markAsFinishedFlagRelativePathClosure: ((Bool, String) -> Void)?
-    func markAsFinished(flag: Bool, relativePath: String) {
+    var markAsFinishedFlagRelativePathClosure: ((Bool, String) async -> Void)?
+    func markAsFinished(flag: Bool, relativePath: String) async {
         markAsFinishedFlagRelativePathCallsCount += 1
         markAsFinishedFlagRelativePathReceivedArguments = (flag: flag, relativePath: relativePath)
         markAsFinishedFlagRelativePathReceivedInvocations.append((flag: flag, relativePath: relativePath))
-        markAsFinishedFlagRelativePathClosure?(flag, relativePath)
+        await markAsFinishedFlagRelativePathClosure?(flag, relativePath)
     }
     //MARK: - jumpToStart
 
@@ -731,47 +715,47 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var jumpToStartRelativePathReceivedRelativePath: String?
     var jumpToStartRelativePathReceivedInvocations: [String] = []
-    var jumpToStartRelativePathClosure: ((String) -> Void)?
-    func jumpToStart(relativePath: String) {
+    var jumpToStartRelativePathClosure: ((String) async -> Void)?
+    func jumpToStart(relativePath: String) async {
         jumpToStartRelativePathCallsCount += 1
         jumpToStartRelativePathReceivedRelativePath = relativePath
         jumpToStartRelativePathReceivedInvocations.append(relativePath)
-        jumpToStartRelativePathClosure?(relativePath)
+        await jumpToStartRelativePathClosure?(relativePath)
     }
-    //MARK: - getCurrentPlaybackRecord
+    //MARK: - getCurrentPlaybackRecordTime
 
-    var getCurrentPlaybackRecordCallsCount = 0
-    var getCurrentPlaybackRecordCalled: Bool {
-        return getCurrentPlaybackRecordCallsCount > 0
+    var getCurrentPlaybackRecordTimeCallsCount = 0
+    var getCurrentPlaybackRecordTimeCalled: Bool {
+        return getCurrentPlaybackRecordTimeCallsCount > 0
     }
-    var getCurrentPlaybackRecordReturnValue: PlaybackRecord!
-    var getCurrentPlaybackRecordClosure: (() -> PlaybackRecord)?
-    func getCurrentPlaybackRecord() -> PlaybackRecord {
-        getCurrentPlaybackRecordCallsCount += 1
-        if let getCurrentPlaybackRecordClosure = getCurrentPlaybackRecordClosure {
-            return getCurrentPlaybackRecordClosure()
+    var getCurrentPlaybackRecordTimeReturnValue: Double!
+    var getCurrentPlaybackRecordTimeClosure: (() async -> Double)?
+    func getCurrentPlaybackRecordTime() async -> Double {
+        getCurrentPlaybackRecordTimeCallsCount += 1
+        if let getCurrentPlaybackRecordTimeClosure = getCurrentPlaybackRecordTimeClosure {
+            return await getCurrentPlaybackRecordTimeClosure()
         } else {
-            return getCurrentPlaybackRecordReturnValue
+            return getCurrentPlaybackRecordTimeReturnValue
         }
     }
-    //MARK: - getPlaybackRecords
+    //MARK: - getFirstPlaybackRecordTime
 
-    var getPlaybackRecordsFromToCallsCount = 0
-    var getPlaybackRecordsFromToCalled: Bool {
-        return getPlaybackRecordsFromToCallsCount > 0
+    var getFirstPlaybackRecordTimeFromToCallsCount = 0
+    var getFirstPlaybackRecordTimeFromToCalled: Bool {
+        return getFirstPlaybackRecordTimeFromToCallsCount > 0
     }
-    var getPlaybackRecordsFromToReceivedArguments: (startDate: Date, endDate: Date)?
-    var getPlaybackRecordsFromToReceivedInvocations: [(startDate: Date, endDate: Date)] = []
-    var getPlaybackRecordsFromToReturnValue: [PlaybackRecord]?
-    var getPlaybackRecordsFromToClosure: ((Date, Date) -> [PlaybackRecord]?)?
-    func getPlaybackRecords(from startDate: Date, to endDate: Date) -> [PlaybackRecord]? {
-        getPlaybackRecordsFromToCallsCount += 1
-        getPlaybackRecordsFromToReceivedArguments = (startDate: startDate, endDate: endDate)
-        getPlaybackRecordsFromToReceivedInvocations.append((startDate: startDate, endDate: endDate))
-        if let getPlaybackRecordsFromToClosure = getPlaybackRecordsFromToClosure {
-            return getPlaybackRecordsFromToClosure(startDate, endDate)
+    var getFirstPlaybackRecordTimeFromToReceivedArguments: (startDate: Date, endDate: Date)?
+    var getFirstPlaybackRecordTimeFromToReceivedInvocations: [(startDate: Date, endDate: Date)] = []
+    var getFirstPlaybackRecordTimeFromToReturnValue: Double!
+    var getFirstPlaybackRecordTimeFromToClosure: ((Date, Date) async -> Double)?
+    func getFirstPlaybackRecordTime(from startDate: Date, to endDate: Date) async -> Double {
+        getFirstPlaybackRecordTimeFromToCallsCount += 1
+        getFirstPlaybackRecordTimeFromToReceivedArguments = (startDate: startDate, endDate: endDate)
+        getFirstPlaybackRecordTimeFromToReceivedInvocations.append((startDate: startDate, endDate: endDate))
+        if let getFirstPlaybackRecordTimeFromToClosure = getFirstPlaybackRecordTimeFromToClosure {
+            return await getFirstPlaybackRecordTimeFromToClosure(startDate, endDate)
         } else {
-            return getPlaybackRecordsFromToReturnValue
+            return getFirstPlaybackRecordTimeFromToReturnValue
         }
     }
     //MARK: - recordTime
@@ -780,14 +764,10 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var recordTimeCalled: Bool {
         return recordTimeCallsCount > 0
     }
-    var recordTimeReceivedPlaybackRecord: PlaybackRecord?
-    var recordTimeReceivedInvocations: [PlaybackRecord] = []
-    var recordTimeClosure: ((PlaybackRecord) -> Void)?
-    func recordTime(_ playbackRecord: PlaybackRecord) {
+    var recordTimeClosure: (() -> Void)?
+    func recordTime() {
         recordTimeCallsCount += 1
-        recordTimeReceivedPlaybackRecord = playbackRecord
-        recordTimeReceivedInvocations.append(playbackRecord)
-        recordTimeClosure?(playbackRecord)
+        recordTimeClosure?()
     }
     //MARK: - getTotalListenedTime
 
@@ -796,11 +776,11 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         return getTotalListenedTimeCallsCount > 0
     }
     var getTotalListenedTimeReturnValue: TimeInterval!
-    var getTotalListenedTimeClosure: (() -> TimeInterval)?
-    func getTotalListenedTime() -> TimeInterval {
+    var getTotalListenedTimeClosure: (() async -> TimeInterval)?
+    func getTotalListenedTime() async -> TimeInterval {
         getTotalListenedTimeCallsCount += 1
         if let getTotalListenedTimeClosure = getTotalListenedTimeClosure {
-            return getTotalListenedTimeClosure()
+            return await getTotalListenedTimeClosure()
         } else {
             return getTotalListenedTimeReturnValue
         }
@@ -814,13 +794,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var getBookmarksOfRelativePathReceivedArguments: (type: BookmarkType, relativePath: String)?
     var getBookmarksOfRelativePathReceivedInvocations: [(type: BookmarkType, relativePath: String)] = []
     var getBookmarksOfRelativePathReturnValue: [SimpleBookmark]?
-    var getBookmarksOfRelativePathClosure: ((BookmarkType, String) -> [SimpleBookmark]?)?
-    func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]? {
+    var getBookmarksOfRelativePathClosure: ((BookmarkType, String) async -> [SimpleBookmark]?)?
+    func getBookmarks(of type: BookmarkType, relativePath: String) async -> [SimpleBookmark]? {
         getBookmarksOfRelativePathCallsCount += 1
         getBookmarksOfRelativePathReceivedArguments = (type: type, relativePath: relativePath)
         getBookmarksOfRelativePathReceivedInvocations.append((type: type, relativePath: relativePath))
         if let getBookmarksOfRelativePathClosure = getBookmarksOfRelativePathClosure {
-            return getBookmarksOfRelativePathClosure(type, relativePath)
+            return await getBookmarksOfRelativePathClosure(type, relativePath)
         } else {
             return getBookmarksOfRelativePathReturnValue
         }
@@ -854,13 +834,13 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     var createBookmarkAtRelativePathTypeReceivedArguments: (time: Double, relativePath: String, type: BookmarkType)?
     var createBookmarkAtRelativePathTypeReceivedInvocations: [(time: Double, relativePath: String, type: BookmarkType)] = []
     var createBookmarkAtRelativePathTypeReturnValue: SimpleBookmark?
-    var createBookmarkAtRelativePathTypeClosure: ((Double, String, BookmarkType) -> SimpleBookmark?)?
-    func createBookmark(at time: Double, relativePath: String, type: BookmarkType) -> SimpleBookmark? {
+    var createBookmarkAtRelativePathTypeClosure: ((Double, String, BookmarkType) async -> SimpleBookmark?)?
+    func createBookmark(at time: Double, relativePath: String, type: BookmarkType) async -> SimpleBookmark? {
         createBookmarkAtRelativePathTypeCallsCount += 1
         createBookmarkAtRelativePathTypeReceivedArguments = (time: time, relativePath: relativePath, type: type)
         createBookmarkAtRelativePathTypeReceivedInvocations.append((time: time, relativePath: relativePath, type: type))
         if let createBookmarkAtRelativePathTypeClosure = createBookmarkAtRelativePathTypeClosure {
-            return createBookmarkAtRelativePathTypeClosure(time, relativePath, type)
+            return await createBookmarkAtRelativePathTypeClosure(time, relativePath, type)
         } else {
             return createBookmarkAtRelativePathTypeReturnValue
         }
@@ -873,12 +853,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var addNoteBookmarkReceivedArguments: (note: String, bookmark: SimpleBookmark)?
     var addNoteBookmarkReceivedInvocations: [(note: String, bookmark: SimpleBookmark)] = []
-    var addNoteBookmarkClosure: ((String, SimpleBookmark) -> Void)?
-    func addNote(_ note: String, bookmark: SimpleBookmark) {
+    var addNoteBookmarkClosure: ((String, SimpleBookmark) async -> Void)?
+    func addNote(_ note: String, bookmark: SimpleBookmark) async {
         addNoteBookmarkCallsCount += 1
         addNoteBookmarkReceivedArguments = (note: note, bookmark: bookmark)
         addNoteBookmarkReceivedInvocations.append((note: note, bookmark: bookmark))
-        addNoteBookmarkClosure?(note, bookmark)
+        await addNoteBookmarkClosure?(note, bookmark)
     }
     //MARK: - deleteBookmark
 
@@ -888,12 +868,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var deleteBookmarkReceivedBookmark: SimpleBookmark?
     var deleteBookmarkReceivedInvocations: [SimpleBookmark] = []
-    var deleteBookmarkClosure: ((SimpleBookmark) -> Void)?
-    func deleteBookmark(_ bookmark: SimpleBookmark) {
+    var deleteBookmarkClosure: ((SimpleBookmark) async -> Void)?
+    func deleteBookmark(_ bookmark: SimpleBookmark) async {
         deleteBookmarkCallsCount += 1
         deleteBookmarkReceivedBookmark = bookmark
         deleteBookmarkReceivedInvocations.append(bookmark)
-        deleteBookmarkClosure?(bookmark)
+        await deleteBookmarkClosure?(bookmark)
     }
 }
 class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
@@ -921,13 +901,13 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
     var getPlayableItemBeforeParentFolderReceivedArguments: (relativePath: String, parentFolder: String?)?
     var getPlayableItemBeforeParentFolderReceivedInvocations: [(relativePath: String, parentFolder: String?)] = []
     var getPlayableItemBeforeParentFolderReturnValue: PlayableItem?
-    var getPlayableItemBeforeParentFolderClosure: ((String, String?) -> PlayableItem?)?
-    func getPlayableItem(before relativePath: String, parentFolder: String?) -> PlayableItem? {
+    var getPlayableItemBeforeParentFolderClosure: ((String, String?) async -> PlayableItem?)?
+    func getPlayableItem(before relativePath: String, parentFolder: String?) async -> PlayableItem? {
         getPlayableItemBeforeParentFolderCallsCount += 1
         getPlayableItemBeforeParentFolderReceivedArguments = (relativePath: relativePath, parentFolder: parentFolder)
         getPlayableItemBeforeParentFolderReceivedInvocations.append((relativePath: relativePath, parentFolder: parentFolder))
         if let getPlayableItemBeforeParentFolderClosure = getPlayableItemBeforeParentFolderClosure {
-            return getPlayableItemBeforeParentFolderClosure(relativePath, parentFolder)
+            return await getPlayableItemBeforeParentFolderClosure(relativePath, parentFolder)
         } else {
             return getPlayableItemBeforeParentFolderReturnValue
         }
@@ -941,13 +921,13 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
     var getPlayableItemAfterParentFolderAutoplayedRestartFinishedReceivedArguments: (relativePath: String, parentFolder: String?, autoplayed: Bool, restartFinished: Bool)?
     var getPlayableItemAfterParentFolderAutoplayedRestartFinishedReceivedInvocations: [(relativePath: String, parentFolder: String?, autoplayed: Bool, restartFinished: Bool)] = []
     var getPlayableItemAfterParentFolderAutoplayedRestartFinishedReturnValue: PlayableItem?
-    var getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure: ((String, String?, Bool, Bool) -> PlayableItem?)?
-    func getPlayableItem(after relativePath: String, parentFolder: String?, autoplayed: Bool, restartFinished: Bool) -> PlayableItem? {
+    var getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure: ((String, String?, Bool, Bool) async -> PlayableItem?)?
+    func getPlayableItem(after relativePath: String, parentFolder: String?, autoplayed: Bool, restartFinished: Bool) async -> PlayableItem? {
         getPlayableItemAfterParentFolderAutoplayedRestartFinishedCallsCount += 1
         getPlayableItemAfterParentFolderAutoplayedRestartFinishedReceivedArguments = (relativePath: relativePath, parentFolder: parentFolder, autoplayed: autoplayed, restartFinished: restartFinished)
         getPlayableItemAfterParentFolderAutoplayedRestartFinishedReceivedInvocations.append((relativePath: relativePath, parentFolder: parentFolder, autoplayed: autoplayed, restartFinished: restartFinished))
         if let getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure = getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure {
-            return getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure(relativePath, parentFolder, autoplayed, restartFinished)
+            return await getPlayableItemAfterParentFolderAutoplayedRestartFinishedClosure(relativePath, parentFolder, autoplayed, restartFinished)
         } else {
             return getPlayableItemAfterParentFolderAutoplayedRestartFinishedReturnValue
         }
@@ -962,8 +942,8 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
     var getFirstPlayableItemInIsUnfinishedReceivedArguments: (folder: SimpleLibraryItem, isUnfinished: Bool?)?
     var getFirstPlayableItemInIsUnfinishedReceivedInvocations: [(folder: SimpleLibraryItem, isUnfinished: Bool?)] = []
     var getFirstPlayableItemInIsUnfinishedReturnValue: PlayableItem?
-    var getFirstPlayableItemInIsUnfinishedClosure: ((SimpleLibraryItem, Bool?) throws -> PlayableItem?)?
-    func getFirstPlayableItem(in folder: SimpleLibraryItem, isUnfinished: Bool?) throws -> PlayableItem? {
+    var getFirstPlayableItemInIsUnfinishedClosure: ((SimpleLibraryItem, Bool?) async throws -> PlayableItem?)?
+    func getFirstPlayableItem(in folder: SimpleLibraryItem, isUnfinished: Bool?) async throws -> PlayableItem? {
         if let error = getFirstPlayableItemInIsUnfinishedThrowableError {
             throw error
         }
@@ -971,7 +951,7 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
         getFirstPlayableItemInIsUnfinishedReceivedArguments = (folder: folder, isUnfinished: isUnfinished)
         getFirstPlayableItemInIsUnfinishedReceivedInvocations.append((folder: folder, isUnfinished: isUnfinished))
         if let getFirstPlayableItemInIsUnfinishedClosure = getFirstPlayableItemInIsUnfinishedClosure {
-            return try getFirstPlayableItemInIsUnfinishedClosure(folder, isUnfinished)
+            return try await getFirstPlayableItemInIsUnfinishedClosure(folder, isUnfinished)
         } else {
             return getFirstPlayableItemInIsUnfinishedReturnValue
         }
@@ -986,8 +966,8 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
     var getPlayableItemFromReceivedItem: SimpleLibraryItem?
     var getPlayableItemFromReceivedInvocations: [SimpleLibraryItem] = []
     var getPlayableItemFromReturnValue: PlayableItem?
-    var getPlayableItemFromClosure: ((SimpleLibraryItem) throws -> PlayableItem?)?
-    func getPlayableItem(from item: SimpleLibraryItem) throws -> PlayableItem? {
+    var getPlayableItemFromClosure: ((SimpleLibraryItem) async throws -> PlayableItem?)?
+    func getPlayableItem(from item: SimpleLibraryItem) async throws -> PlayableItem? {
         if let error = getPlayableItemFromThrowableError {
             throw error
         }
@@ -995,7 +975,7 @@ class PlaybackServiceProtocolMock: PlaybackServiceProtocol {
         getPlayableItemFromReceivedItem = item
         getPlayableItemFromReceivedInvocations.append(item)
         if let getPlayableItemFromClosure = getPlayableItemFromClosure {
-            return try getPlayableItemFromClosure(item)
+            return try await getPlayableItemFromClosure(item)
         } else {
             return getPlayableItemFromReturnValue
         }

--- a/BookPlayer/Library/SearchList Screen/SearchListViewModel.swift
+++ b/BookPlayer/Library/SearchList Screen/SearchListViewModel.swift
@@ -148,21 +148,23 @@ class SearchListViewModel: BaseViewModel<Coordinator> {
 
   /// Load next page items with same query and selected scope
   func loadNextItems(query: String?, scopeIndex: Int) {
-    guard
-      let fetchedItems = libraryService.filterContents(
-        at: folderRelativePath,
-        query: query,
-        scope: searchScopes[scopeIndex],
-        limit: pageSize,
-        offset: resultsOffset
-      ),
-      !fetchedItems.isEmpty
-    else {
-      return
-    }
+    Task { @MainActor in
+      guard
+        let fetchedItems = await libraryService.filterContents(
+          at: folderRelativePath,
+          query: query,
+          scope: searchScopes[scopeIndex],
+          limit: pageSize,
+          offset: resultsOffset
+        ),
+        !fetchedItems.isEmpty
+      else {
+        return
+      }
 
-    resultsOffset += fetchedItems.count
-    items.value += fetchedItems
+      resultsOffset += fetchedItems.count
+      items.value += fetchedItems
+    }
   }
 
   /// Pass callback with item selected

--- a/BookPlayer/Player/ButtonFree Screen/ButtonFreeViewModel.swift
+++ b/BookPlayer/Player/ButtonFree Screen/ButtonFreeViewModel.swift
@@ -81,24 +81,26 @@ class ButtonFreeViewModel: BaseViewModel<ButtonFreeCoordinator> {
 
     let currentTime = floor(currentItem.currentTime)
 
-    if let bookmark = self.libraryService.createBookmark(
-      at: currentTime,
-      relativePath: currentItem.relativePath,
-      type: .user
-    ) {
-      syncService.scheduleSetBookmark(
+    Task { @MainActor in
+      if let bookmark = await self.libraryService.createBookmark(
+        at: currentTime,
         relativePath: currentItem.relativePath,
-        time: currentTime,
-        note: nil
-      )
-      let formattedTime = TimeParser.formatTime(bookmark.time)
-      let message = String.localizedStringWithFormat(
-        "bookmark_created_title".localized,
-        formattedTime
-      )
-      eventPublisher.send(message)
-    } else {
-      eventPublisher.send("file_missing_title".localized)
+        type: .user
+      ) {
+        syncService.scheduleSetBookmark(
+          relativePath: currentItem.relativePath,
+          time: currentTime,
+          note: nil
+        )
+        let formattedTime = TimeParser.formatTime(bookmark.time)
+        let message = String.localizedStringWithFormat(
+          "bookmark_created_title".localized,
+          formattedTime
+        )
+        eventPublisher.send(message)
+      } else {
+        eventPublisher.send("file_missing_title".localized)
+      }
     }
   }
 }

--- a/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
+++ b/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
@@ -162,11 +162,13 @@ class ProfileViewModel: ProfileViewModelProtocol {
   }
 
   func reloadListenedTime() {
-    let time = libraryService.getTotalListenedTime()
+    Task { @MainActor in
+      let time = await libraryService.getTotalListenedTime()
 
-    guard let formattedTime = formatTime(time) else { return }
+      guard let formattedTime = formatTime(time) else { return }
 
-    totalListeningTimeFormatted = formattedTime
+      totalListeningTimeFormatted = formattedTime
+    }
   }
 
   func formatTime(

--- a/BookPlayer/Services/UserActivityManager.swift
+++ b/BookPlayer/Services/UserActivityManager.swift
@@ -13,7 +13,6 @@ import Intents
 class UserActivityManager {
   let libraryService: LibraryServiceProtocol
   var currentActivity: NSUserActivity
-  var playbackRecord: PlaybackRecord?
 
   init(libraryService: LibraryServiceProtocol) {
     self.libraryService = libraryService
@@ -33,24 +32,13 @@ class UserActivityManager {
 
   func resumePlaybackActivity() {
     self.currentActivity.becomeCurrent()
-
-    self.playbackRecord = self.libraryService.getCurrentPlaybackRecord()
-
-    guard let record = self.playbackRecord else { return }
-
-    guard !Calendar.current.isDate(record.date, inSameDayAs: Date()) else { return }
-
-    self.playbackRecord = self.libraryService.getCurrentPlaybackRecord()
   }
 
   func stopPlaybackActivity() {
     self.currentActivity.resignCurrent()
-    self.playbackRecord = nil
   }
 
   func recordTime() {
-    guard let record = self.playbackRecord else { return }
-
-    self.libraryService.recordTime(record)
+    self.libraryService.recordTime()
   }
 }

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -50,7 +50,7 @@ class LibraryListCoordinatorTests: XCTestCase {
 
   func testShowFolder() {
     let folder = try! StubFactory.folder(dataManager: self.dataManager, title: "folder 1")
-    let library = self.libraryListCoordinator.libraryService.getLibraryReference()
+    let library = self.libraryListCoordinator.libraryService.getLibrary()
     library.addToItems(folder)
 
     self.libraryListCoordinator.showFolder(folder.relativePath)

--- a/BookPlayerTests/ItemListViewModelTests.swift
+++ b/BookPlayerTests/ItemListViewModelTests.swift
@@ -47,7 +47,7 @@ class ItemListViewModelTests: XCTestCase {
     library.addToItems(
       StubFactory.book(dataManager: self.dataManager, title: "book4", duration: 100)
     )
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(self.dataManager.getContext())
   }
 
   func testLoadingInitialItems() {

--- a/BookPlayerTests/Services/AccountServiceTests.swift
+++ b/BookPlayerTests/Services/AccountServiceTests.swift
@@ -31,7 +31,7 @@ class AccountServiceTests: XCTestCase {
     account.email = ""
     account.hasSubscription = false
     account.donationMade = false
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(context)
   }
 
   func testGetAccount() {

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -31,7 +31,7 @@ class LibraryServiceTests: XCTestCase {
       duration: 100
     )
 
-    let newLibrary = self.sut.getLibraryReference()
+    let newLibrary = self.sut.getLibrary()
     newLibrary.addToItems(book)
 
     let loadedLibrary = self.sut.getLibrary()
@@ -50,12 +50,12 @@ class LibraryServiceTests: XCTestCase {
       duration: 100
     )
 
-    let newLibrary = self.sut.getLibraryReference()
+    let newLibrary = self.sut.getLibrary()
     XCTAssert(newLibrary.lastPlayedItem == nil)
     newLibrary.lastPlayedItem = book
     newLibrary.addToItems(book)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     let lastBook = sut.getLibraryLastItem()
     XCTAssert(lastBook?.relativePath == book.relativePath)
@@ -70,20 +70,21 @@ class LibraryServiceTests: XCTestCase {
     XCTAssert(currentTheme?.title == "Default / Dark")
   }
 
-  func testCreateBook() {
+  func testCreateBook() async {
     let filename = "test-book.txt"
     let bookContents = "bookcontents".data(using: .utf8)!
     let processedFolder = DataManager.getProcessedFolderURL()
 
     // Add test file to Processed folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
-    let newBook = self.sut.createBook(from: fileUrl)
+    let newBook = await self.sut.createBook(from: fileUrl)
     XCTAssert(newBook.title == "test-book.txt")
     XCTAssert(newBook.relativePath == "test-book.txt")
   }
 
   func testGetItemWithIdentifier() {
-    let nilBook = self.sut.getItem(with: "test-book1")
+    let context = self.sut.dataManager.getContext()
+    let nilBook = self.sut.getItem(with: "test-book1", context: context)
     XCTAssert(nilBook == nil)
 
     let testBook = StubFactory.book(
@@ -92,18 +93,18 @@ class LibraryServiceTests: XCTestCase {
       duration: 100
     )
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(context)
 
-    let book = self.sut.getItem(with: testBook.relativePath)
+    let book = self.sut.getItem(with: testBook.relativePath, context: context)
     XCTAssert(testBook.relativePath == book?.relativePath)
   }
 
-  func testFindEmptyBooksWithURL() {
-    let books = self.sut.findBooks(containing: URL(string: "test/url")!)!
+  func testFindEmptyBooksWithURL() async {
+    let books = await self.sut.findBooks(containing: URL(string: "test/url")!)!
     XCTAssert(books.isEmpty)
   }
 
-  func testFindBooksWithURL() {
+  func testFindBooksWithURL() async {
     _ = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test1-book",
@@ -116,20 +117,20 @@ class LibraryServiceTests: XCTestCase {
       duration: 100
     )
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     let testURL = DataManager.getProcessedFolderURL().appendingPathComponent("-book.txt")
 
-    let books = self.sut.findBooks(containing: testURL)!
+    let books = await self.sut.findBooks(containing: testURL)!
     XCTAssert(books.count == 2)
   }
 
-  func testFindEmptyOrderedBooks() {
-    let books = self.sut.getLastPlayedItems(limit: 20)!
+  func testFindEmptyOrderedBooks() async {
+    let books = await self.sut.getLastPlayedItems(limit: 20)!
     XCTAssert(books.isEmpty)
   }
 
-  func testFindOrderedBooks() {
+  func testFindOrderedBooks() async {
     let book1 = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test1-book",
@@ -144,9 +145,9 @@ class LibraryServiceTests: XCTestCase {
     )
     book2.lastPlayDate = Date()
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let books = self.sut.getLastPlayedItems(limit: 20)!
+    let books = await self.sut.getLastPlayedItems(limit: 20)!
     XCTAssert(books.count == 2)
     let fetchedBook1 = books.first!
     XCTAssert(fetchedBook1.relativePath == book2.relativePath)
@@ -155,16 +156,17 @@ class LibraryServiceTests: XCTestCase {
   }
 
   func testFindEmptyFolder() {
-    let folder = self.sut.getItemReference(with: "test/url")
+    let folder = self.sut.getItemReference(with: "test/url", context: self.sut.dataManager.getContext())
     XCTAssert(folder == nil)
   }
 
   func testFindFolder() {
+    let context = self.sut.dataManager.getContext()
     _ = try! StubFactory.folder(dataManager: self.sut.dataManager, title: "test1-folder")
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(context)
 
-    let folder = self.sut.getItemReference(with: "test1-folder")
+    let folder = self.sut.getItemReference(with: "test1-folder", context: context)
     XCTAssert(folder?.relativePath == "test1-folder")
   }
 
@@ -174,10 +176,11 @@ class LibraryServiceTests: XCTestCase {
       title: "test1-book",
       duration: 100
     )
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: self.sut.dataManager.getContext()) == false)
   }
 
-  func testHasLibraryLinked() throws {
+  func testHasLibraryLinked() async throws {
+    let context = self.sut.dataManager.getContext()
     let library = self.sut.getLibrary()
 
     let book1 = StubFactory.book(
@@ -187,22 +190,22 @@ class LibraryServiceTests: XCTestCase {
     )
     library.addToItems(book1)
 
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: context) == true)
 
     let folder1 = try! StubFactory.folder(
       dataManager: self.sut.dataManager,
       title: "test1-folder"
     )
 
-    try sut.moveItems([book1.relativePath], inside: folder1.relativePath)
+    try await sut.moveItems([book1.relativePath], inside: folder1.relativePath)
 
-    XCTAssert(self.sut.hasLibraryLinked(item: folder1) == false)
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder1, context: context) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: context) == false)
 
-    try sut.moveItems([folder1.relativePath], inside: nil)
+    try await sut.moveItems([folder1.relativePath], inside: nil)
 
-    XCTAssert(self.sut.hasLibraryLinked(item: folder1) == true)
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder1, context: context) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: context) == true)
 
     let folder2 = try! StubFactory.folder(
       dataManager: self.sut.dataManager,
@@ -210,20 +213,20 @@ class LibraryServiceTests: XCTestCase {
       destinationFolder: DataManager.getProcessedFolderURL().appendingPathComponent(folder1.relativePath)
     )
 
-    XCTAssert(self.sut.hasLibraryLinked(item: folder2) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder2, context: context) == false)
 
-    try sut.moveItems([folder2.relativePath], inside: folder1.relativePath)
+    try await sut.moveItems([folder2.relativePath], inside: folder1.relativePath)
 
-    XCTAssert(self.sut.hasLibraryLinked(item: folder2) == true)
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == true)
-    XCTAssert(self.sut.hasLibraryLinked(item: folder1) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder2, context: context) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: context) == true)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder1, context: context) == true)
 
     library.removeFromItems(folder1)
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(context)
 
-    XCTAssert(self.sut.hasLibraryLinked(item: folder2) == false)
-    XCTAssert(self.sut.hasLibraryLinked(item: book1) == false)
-    XCTAssert(self.sut.hasLibraryLinked(item: folder1) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder2, context: context) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: book1, context: context) == false)
+    XCTAssert(self.sut.hasLibraryLinked(item: folder1, context: context) == false)
   }
 
   func testNotRemovingFolderIfNeeded() {
@@ -239,7 +242,8 @@ class LibraryServiceTests: XCTestCase {
     XCTAssert(FileManager.default.fileExists(atPath: fileURL.path))
 
     try! self.sut.removeFolderIfNeeded(
-      DataManager.getProcessedFolderURL().appendingPathComponent("test1-folder")
+      DataManager.getProcessedFolderURL().appendingPathComponent("test1-folder"),
+      context: self.sut.dataManager.getContext()
     )
 
     XCTAssert(FileManager.default.fileExists(atPath: fileURL.path))
@@ -255,7 +259,7 @@ class LibraryServiceTests: XCTestCase {
 
     XCTAssert(FileManager.default.fileExists(atPath: fileURL.path))
 
-    try! self.sut.removeFolderIfNeeded(fileURL)
+    try! self.sut.removeFolderIfNeeded(fileURL, context: self.sut.dataManager.getContext())
 
     XCTAssert(FileManager.default.fileExists(atPath: fileURL.path) == false)
 
@@ -285,66 +289,66 @@ class LibraryServiceTests: XCTestCase {
     folder2.addToItems(folder3)
 
     XCTAssert(FileManager.default.fileExists(atPath: nestedURL.path))
-    try! self.sut.removeFolderIfNeeded(nestedURL)
+    try! self.sut.removeFolderIfNeeded(nestedURL, context: self.sut.dataManager.getContext())
     XCTAssert(FileManager.default.fileExists(atPath: nestedURL.path))
     folder2.library = nil
-    try! self.sut.removeFolderIfNeeded(nestedURL)
+    try! self.sut.removeFolderIfNeeded(nestedURL, context: self.sut.dataManager.getContext())
     XCTAssert(FileManager.default.fileExists(atPath: nestedURL.path) == false)
   }
 
-  func testCreateFolderInLibrary() {
-    _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+  func testCreateFolderInLibrary() async {
+    _ = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     let library = self.sut.getLibrary()
 
     XCTAssert(library.itemsArray.first?.relativePath == folder.relativePath)
     XCTAssert(folder.items?.count == 0)
 
-    _ = try! self.sut.createFolder(with: "test-folder2", inside: nil)
-    let folder2 = self.sut.getItem(with: "test-folder2") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder2", inside: nil)
+    let folder2 = self.sut.getItem(with: "test-folder2", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.itemsArray.count == 2)
     XCTAssert(library.itemsArray.contains(where: { $0.relativePath == folder.relativePath}))
     XCTAssert(library.itemsArray.contains(where: { $0.relativePath == folder2.relativePath}))
 
-    _ = try! self.sut.createFolder(with: "test-folder3", inside: nil)
-    let folder3 = self.sut.getItem(with: "test-folder3") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder3", inside: nil)
+    let folder3 = self.sut.getItem(with: "test-folder3", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.itemsArray.count == 3)
     XCTAssert(library.itemsArray.contains(where: { $0.relativePath == folder3.relativePath}))
   }
 
-  func testCreateFolderInFolder() {
-    _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
-    _ = try! self.sut.createFolder(with: "test-folder2", inside: "test-folder")
-    let folder2 = self.sut.getItem(with: "test-folder/test-folder2") as! Folder
+  func testCreateFolderInFolder() async {
+    _ = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder2", inside: "test-folder")
+    let folder2 = self.sut.getItem(with: "test-folder/test-folder2", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(folder.items?.count == 1)
     XCTAssert((folder.items?.allObjects.first as? Folder)?.relativePath == folder2.relativePath)
 
-    _ = try! self.sut.createFolder(with: "test-folder3", inside: "test-folder")
-    let folder3 = self.sut.getItem(with: "test-folder/test-folder3") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder3", inside: "test-folder")
+    let folder3 = self.sut.getItem(with: "test-folder/test-folder3", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(folder.items?.count == 2)
 
     XCTAssert((folder.items?.allObjects as? [LibraryItem])?
       .contains(where: { $0.relativePath == folder3.relativePath}) ?? false)
 
-    _ = try! self.sut.createFolder(with: "test-folder4", inside: "test-folder")
-    let folder4 = self.sut.getItem(with: "test-folder/test-folder4") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder4", inside: "test-folder")
+    let folder4 = self.sut.getItem(with: "test-folder/test-folder4", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(folder.items?.count == 3)
     XCTAssert((folder.items?.allObjects as? [LibraryItem])?
       .contains(where: { $0.relativePath == folder4.relativePath}) ?? false)
   }
 
-  func testFetchContents() {
-    let folder = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder2 = try! self.sut.createFolder(with: "test-folder2", inside: "test-folder")
-    let folder3 = try! self.sut.createFolder(with: "test-folder3", inside: "test-folder")
-    _ = try! self.sut.createFolder(with: "test-folder4", inside: "test-folder")
+  func testFetchContents() async {
+    let folder = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder2 = try! await self.sut.createFolder(with: "test-folder2", inside: "test-folder")
+    let folder3 = try! await self.sut.createFolder(with: "test-folder3", inside: "test-folder")
+    _ = try! await self.sut.createFolder(with: "test-folder4", inside: "test-folder")
 
     let totalResults = self.sut.fetchContents(at: "test-folder", limit: nil, offset: nil)
     XCTAssert(totalResults?.count == 3)
@@ -357,8 +361,8 @@ class LibraryServiceTests: XCTestCase {
     XCTAssert(partialResults2?.count == 1)
     XCTAssert(partialResults2?[0].relativePath == folder3.relativePath)
 
-    let folder5 = try! self.sut.createFolder(with: "test-folder5", inside: nil)
-    _ = try! self.sut.createFolder(with: "test-folder6", inside: nil)
+    let folder5 = try! await self.sut.createFolder(with: "test-folder5", inside: nil)
+    _ = try! await self.sut.createFolder(with: "test-folder6", inside: nil)
 
     let totalLibraryResults = self.sut.fetchContents(at: nil, limit: nil, offset: nil)
     XCTAssert(totalLibraryResults?.count == 3)
@@ -372,7 +376,7 @@ class LibraryServiceTests: XCTestCase {
     XCTAssert(partialLibraryResults2?[0].relativePath == folder5.relativePath)
   }
 
-  func testMarkAsFinished() {
+  func testMarkAsFinished() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
@@ -380,11 +384,11 @@ class LibraryServiceTests: XCTestCase {
     )
 
     XCTAssert(book.isFinished == false)
-    self.sut.markAsFinished(flag: true, relativePath: book.relativePath)
+    await self.sut.markAsFinished(flag: true, relativePath: book.relativePath)
     XCTAssert(book.isFinished == true)
 
-    _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     let book2 = StubFactory.book(
       dataManager: self.sut.dataManager,
@@ -403,19 +407,19 @@ class LibraryServiceTests: XCTestCase {
     folder.addToItems(book2)
     folder.addToItems(book3)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     XCTAssert(book2.isFinished == false)
     XCTAssert(book3.isFinished == false)
-    self.sut.markAsFinished(flag: true, relativePath: folder.relativePath)
+    await self.sut.markAsFinished(flag: true, relativePath: folder.relativePath)
     XCTAssert(book2.isFinished == true)
     XCTAssert(book3.isFinished == true)
-    self.sut.markAsFinished(flag: false, relativePath: folder.relativePath)
+    await self.sut.markAsFinished(flag: false, relativePath: folder.relativePath)
     XCTAssert(book2.isFinished == false)
     XCTAssert(book3.isFinished == false)
   }
 
-  func testJumpToStart() {
+  func testJumpToStart() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
@@ -423,11 +427,11 @@ class LibraryServiceTests: XCTestCase {
     )
     book.currentTime = 50
 
-    self.sut.jumpToStart(relativePath: book.relativePath)
+    await self.sut.jumpToStart(relativePath: book.relativePath)
     XCTAssert(book.currentTime == 0)
 
-    _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     let book2 = StubFactory.book(
       dataManager: self.sut.dataManager,
@@ -446,31 +450,30 @@ class LibraryServiceTests: XCTestCase {
     folder.addToItems(book2)
     folder.addToItems(book3)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    self.sut.jumpToStart(relativePath: folder.relativePath)
+    await self.sut.jumpToStart(relativePath: folder.relativePath)
 
     XCTAssert(book2.currentTime == 0)
     XCTAssert(book3.currentTime == 0)
   }
 
-  func testRecordTime() {
-    let record = self.sut.getCurrentPlaybackRecord()
-    XCTAssert(record.time == 0)
-    self.sut.recordTime(record)
-    XCTAssert(record.time == 1)
+  func testRecordTime() async {
+    let initialTime = await self.sut.getCurrentPlaybackRecordTime()
+    XCTAssert(initialTime == 0)
+    self.sut.recordTime()
+    let finalTime = await self.sut.getCurrentPlaybackRecordTime()
+    XCTAssert(finalTime == 1)
   }
 
-  func testGetCurrentPlaybackRecord() {
-    let record = self.sut.getCurrentPlaybackRecord()
-    self.sut.recordTime(record)
-    XCTAssert(record.time == 1)
-    let record2 = self.sut.getCurrentPlaybackRecord()
-    XCTAssert(record2.time == 1)
+  func testGetCurrentPlaybackRecord() async {
+    self.sut.recordTime()
+    let time = await self.sut.getCurrentPlaybackRecordTime()
+    XCTAssert(time == 1)
   }
 
   // swiftlint:disable:next function_body_length
-  func testGetPlaybackRecordsFromDate() {
+  func testGetPlaybackRecordsFromDate() async {
     let calendar = Calendar.current
     let startToday = calendar.startOfDay(for: Date())
     let endDate = calendar.date(byAdding: .day, value: 1, to: startToday)!
@@ -505,59 +508,61 @@ class LibraryServiceTests: XCTestCase {
     record7.date = startSeventhDay
     record7.time = 7
 
-    self.sut.dataManager.saveContext()
-
-    let firstRecord = (self.sut.getPlaybackRecords(from: startFirstDay, to: startSecondDay) ?? []).first
-    XCTAssert(firstRecord?.time == 1)
-    let secondRecord = (self.sut.getPlaybackRecords(from: startSecondDay, to: startThirdDay) ?? []).first
-    XCTAssert(secondRecord?.time == 2)
-    let thirdRecord = (self.sut.getPlaybackRecords(from: startThirdDay, to: startFourthDay) ?? []).first
-    XCTAssert(thirdRecord?.time == 3)
-    let fourthRecord = (self.sut.getPlaybackRecords(from: startFourthDay, to: startFifthDay) ?? []).first
-    XCTAssert(fourthRecord?.time == 4)
-    let fifthRecord = (self.sut.getPlaybackRecords(from: startFifthDay, to: startSixthDay) ?? []).first
-    XCTAssert(fifthRecord?.time == 5)
-    let sixthRecord = (self.sut.getPlaybackRecords(from: startSixthDay, to: startSeventhDay) ?? []).first
-    XCTAssert(sixthRecord?.time == 6)
-    let seventhRecord = (self.sut.getPlaybackRecords(from: startSeventhDay, to: endDate) ?? []).first
-    XCTAssert(seventhRecord?.time == 7)
+    let context = self.sut.dataManager.getContext()
+    self.sut.dataManager.saveContext(context)
+    let firstRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startFirstDay, to: startSecondDay)
+    XCTAssert(firstRecordTime == 1)
+    let secondRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startSecondDay, to: startThirdDay)
+    XCTAssert(secondRecordTime == 2)
+    let thirdRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startThirdDay, to: startFourthDay)
+    XCTAssert(thirdRecordTime == 3)
+    let fourthRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startFourthDay, to: startFifthDay)
+    XCTAssert(fourthRecordTime == 4)
+    let fifthRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startFifthDay, to: startSixthDay)
+    XCTAssert(fifthRecordTime == 5)
+    let sixthRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startSixthDay, to: startSeventhDay)
+    XCTAssert(sixthRecordTime == 6)
+    let seventhRecordTime = await self.sut.getFirstPlaybackRecordTime(from: startSeventhDay, to: endDate)
+    XCTAssert(seventhRecordTime == 7)
   }
 
-  func testCreateBookmark() {
+  func testCreateBookmark() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
 
-    let bookmark = self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
+    let bookmark = await self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
     XCTAssert(bookmark.time == 5)
     XCTAssert(bookmark.type == .skip)
     XCTAssert(bookmark.relativePath == book.relativePath)
 
-    let sameBookmark = self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
+    let sameBookmark = await self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
 
     XCTAssert(bookmark.time == sameBookmark.time)
     XCTAssert(bookmark.type == sameBookmark.type)
     XCTAssert(bookmark.relativePath == sameBookmark.relativePath)
   }
 
-  func testGetBookmarks() {
+  func testGetBookmarks() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
 
-    XCTAssert(self.sut.getBookmarks(of: .user, relativePath: book.relativePath)!.isEmpty)
+    let bookmarksEmpty = await self.sut.getBookmarks(of: .user, relativePath: book.relativePath)!
+    XCTAssert(bookmarksEmpty.isEmpty)
 
     let bookmark = Bookmark.create(in: self.sut.dataManager.getContext())
     bookmark.type = .user
     book.addToBookmarks(bookmark)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    XCTAssert(!self.sut.getBookmarks(of: .user, relativePath: book.relativePath)!.isEmpty)
+    let bookmarksNotEmpty = await self.sut.getBookmarks(of: .user, relativePath: book.relativePath)!
+    XCTAssert(!bookmarksNotEmpty.isEmpty)
   }
 
   func testGetBookmarkOfType() {
@@ -574,52 +579,52 @@ class LibraryServiceTests: XCTestCase {
     bookmark.time = 10
     book.addToBookmarks(bookmark)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     XCTAssert(self.sut.getBookmark(at: 10, relativePath: book.relativePath, type: .play) != nil)
   }
 
-  func testAddNote() {
+  func testAddNote() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
 
-    let bookmark = self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
+    let bookmark = await self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
     XCTAssert(bookmark.note == nil)
-    self.sut.addNote("Test bookmark", bookmark: bookmark)
-    self.sut.dataManager.saveContext()
+    await self.sut.addNote("Test bookmark", bookmark: bookmark)
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
     let fetchedBookmark = self.sut.getBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
     XCTAssert(fetchedBookmark.note == "Test bookmark")
   }
 
-  func testDeleteBookmark() {
+  func testDeleteBookmark() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
 
-    let bookmark = self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
-    self.sut.deleteBookmark(bookmark)
+    let bookmark = await self.sut.createBookmark(at: 5, relativePath: book.relativePath, type: .skip)!
+    await self.sut.deleteBookmark(bookmark)
 
     let fetchedBookmark = self.sut.getBookmark(at: 5, relativePath: book.relativePath, type: .skip)
     XCTAssert(fetchedBookmark == nil)
   }
 
-  func testRenameBookItem() {
+  func testRenameBookItem() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
 
-    sut.renameBook(at: book.relativePath, with: "rename-test")
+    await sut.renameBook(at: book.relativePath, with: "rename-test")
     XCTAssert(book.title == "rename-test")
   }
 
-  func testRenameFolderItem() throws {
+  func testRenameFolderItem() async throws {
     let folder = try StubFactory.folder(
       dataManager: self.sut.dataManager,
       title: "test-folder1"
@@ -628,16 +633,16 @@ class LibraryServiceTests: XCTestCase {
       dataManager: self.sut.dataManager,
       title: "test-folder2"
     )
-    try self.sut.moveItems([folder2.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([folder2.relativePath], inside: folder.relativePath)
 
-    _ = try self.sut.renameFolder(at: folder.relativePath, with: "rename-test")
+    _ = try await self.sut.renameFolder(at: folder.relativePath, with: "rename-test")
     XCTAssert(folder.title == "rename-test")
     XCTAssert(folder.relativePath == "rename-test")
     XCTAssert(folder.originalFileName == "rename-test")
     XCTAssert(FileManager.default.fileExists(atPath: folder.fileURL!.path))
 
-    let fetchedFolder2 = sut.getItem(with: "rename-test/test-folder2")!
-    _ = try self.sut.renameFolder(at: fetchedFolder2.relativePath, with: "rename-test2")
+    let fetchedFolder2 = sut.getItem(with: "rename-test/test-folder2", context: self.sut.dataManager.getContext())!
+    _ = try await self.sut.renameFolder(at: fetchedFolder2.relativePath, with: "rename-test2")
     XCTAssert(fetchedFolder2.title == "rename-test2")
     XCTAssert(fetchedFolder2.relativePath == "rename-test/rename-test2")
     XCTAssert(fetchedFolder2.originalFileName == "rename-test2")
@@ -648,16 +653,16 @@ class LibraryServiceTests: XCTestCase {
 // MARK: - insertBooks(from:into:or:completion:)
 
 class InsertBooksTests: LibraryServiceTests {
-  func testInsertEmptyBooksInLibrary() throws {
+  func testInsertEmptyBooksInLibrary() async throws {
 
     let library = self.sut.getLibrary()
 
-    try self.sut.moveItems([], inside: nil)
+    try await self.sut.moveItems([], inside: nil)
 
     XCTAssert(library.items?.count == 0)
   }
 
-  func testInsertOneBookInLibrary() throws {
+  func testInsertOneBookInLibrary() async throws {
     let library = self.sut.getLibrary()
 
     let filename = "file.txt"
@@ -667,13 +672,13 @@ class InsertBooksTests: LibraryServiceTests {
     // Add test file to Processed folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
 
-    let processedItems = self.sut.insertItems(from: [fileUrl])
+    let processedItems = await self.sut.insertItems(from: [fileUrl])
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(processedItems.count == 1)
   }
 
-  func testInsertMultipleBooksInLibrary() throws {
+  func testInsertMultipleBooksInLibrary() async throws {
     let library = self.sut.getLibrary()
 
     let filename1 = "file1.txt"
@@ -686,28 +691,28 @@ class InsertBooksTests: LibraryServiceTests {
     let file1Url = DataTestUtils.generateTestFile(name: filename1, contents: book1Contents, destinationFolder: processedFolder)
     let file2Url = DataTestUtils.generateTestFile(name: filename2, contents: book2Contents, destinationFolder: processedFolder)
 
-    let processedItems = self.sut.insertItems(from: [file1Url, file2Url])
+    let processedItems = await self.sut.insertItems(from: [file1Url, file2Url])
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(processedItems.count == 2)
   }
 
-  func testInsertEmptyBooksIntoPlaylist() throws {
+  func testInsertEmptyBooksIntoPlaylist() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
     XCTAssert(library.items?.count == 1)
 
-    try? self.sut.moveItems([], inside: folder.relativePath)
+    try? await self.sut.moveItems([], inside: folder.relativePath)
     XCTAssert(folder.items?.count == 0)
   }
 
-  func testInsertOneBookIntoPlaylist() throws {
+  func testInsertOneBookIntoPlaylist() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.items?.count == 1)
 
@@ -718,19 +723,19 @@ class InsertBooksTests: LibraryServiceTests {
     // Add test file to Documents folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
 
-    let processedItems = sut.insertItems(from: [fileUrl])
+    let processedItems = await sut.insertItems(from: [fileUrl])
       .map({ $0.relativePath })
-    try sut.moveItems(processedItems, inside: folder.relativePath)
+    try await sut.moveItems(processedItems, inside: folder.relativePath)
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 1)
     XCTAssert(processedItems.count == 1)
   }
 
-  func testInsertMultipleBooksIntoPlaylist() throws {
+  func testInsertMultipleBooksIntoPlaylist() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.items?.count == 1)
 
@@ -744,20 +749,20 @@ class InsertBooksTests: LibraryServiceTests {
     let file1Url = DataTestUtils.generateTestFile(name: filename1, contents: book1Contents, destinationFolder: processedFolder)
     let file2Url = DataTestUtils.generateTestFile(name: filename2, contents: book2Contents, destinationFolder: processedFolder)
 
-    let processedItems = sut.insertItems(from: [file1Url, file2Url])
+    let processedItems = await sut.insertItems(from: [file1Url, file2Url])
       .map({ $0.relativePath })
-    try sut.moveItems(processedItems, inside: folder.relativePath)
+    try await sut.moveItems(processedItems, inside: folder.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 2)
     XCTAssert(processedItems.count == 2)
   }
 
-  func testInsertExistingBookFromLibraryIntoPlaylist() throws {
+  func testInsertExistingBookFromLibraryIntoPlaylist() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.items?.count == 1)
 
@@ -768,23 +773,23 @@ class InsertBooksTests: LibraryServiceTests {
     // Add test file to Documents folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
 
-    let processedItems = self.sut.insertItems(from: [fileUrl])
+    let processedItems = await self.sut.insertItems(from: [fileUrl])
       .map({ $0.relativePath })
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(folder.items?.count == 0)
 
-    try self.sut.moveItems(processedItems, inside: folder.relativePath)
+    try await self.sut.moveItems(processedItems, inside: folder.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 1)
   }
 
-  func testInsertExistingBookFromPlaylistIntoLibrary() throws {
+  func testInsertExistingBookFromPlaylistIntoLibrary() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder", inside: nil)
-    let folder = self.sut.getItem(with: "test-folder") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder", inside: nil)
+    let folder = self.sut.getItem(with: "test-folder", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.items?.count == 1)
 
@@ -795,28 +800,28 @@ class InsertBooksTests: LibraryServiceTests {
     // Add test file to Documents folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
 
-    let processedItems = self.sut.insertItems(from: [fileUrl])
+    let processedItems = await self.sut.insertItems(from: [fileUrl])
       .map({ $0.relativePath })
 
-    try self.sut.moveItems(processedItems, inside: folder.relativePath)
+    try await self.sut.moveItems(processedItems, inside: folder.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 1)
     XCTAssert(processedItems.count == 1)
 
-    try self.sut.moveItems(["test-folder/file.txt"], inside: nil)
+    try await self.sut.moveItems(["test-folder/file.txt"], inside: nil)
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(folder.items?.count == 0)
   }
 
-  func testInsertExistingBookFromPlaylistIntoPlaylist() throws {
+  func testInsertExistingBookFromPlaylistIntoPlaylist() async throws {
     let library = self.sut.getLibrary()
 
-    _ = try self.sut.createFolder(with: "test-folder1", inside: nil)
-    let folder1 = self.sut.getItem(with: "test-folder1") as! Folder
-    _ = try self.sut.createFolder(with: "test-folder2", inside: nil)
-    let folder2 = self.sut.getItem(with: "test-folder2") as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder1", inside: nil)
+    let folder1 = self.sut.getItem(with: "test-folder1", context: self.sut.dataManager.getContext()) as! Folder
+    _ = try await self.sut.createFolder(with: "test-folder2", inside: nil)
+    let folder2 = self.sut.getItem(with: "test-folder2", context: self.sut.dataManager.getContext()) as! Folder
 
     XCTAssert(library.items?.count == 2)
 
@@ -827,17 +832,17 @@ class InsertBooksTests: LibraryServiceTests {
     // Add test file to Processed folder
     let fileUrl = DataTestUtils.generateTestFile(name: filename, contents: bookContents, destinationFolder: processedFolder)
 
-    let processedItems = self.sut.insertItems(from: [fileUrl])
+    let processedItems = await self.sut.insertItems(from: [fileUrl])
       .map({ $0.relativePath })
 
-    try self.sut.moveItems(processedItems, inside: folder1.relativePath)
+    try await self.sut.moveItems(processedItems, inside: folder1.relativePath)
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(folder1.items?.count == 1)
     XCTAssert(folder2.items?.count == 0)
     XCTAssert(processedItems.count == 1)
 
-    try self.sut.moveItems(["test-folder1/file.txt"], inside: folder2.relativePath)
+    try await self.sut.moveItems(["test-folder1/file.txt"], inside: folder2.relativePath)
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(folder1.items?.count == 0)
@@ -848,7 +853,7 @@ class InsertBooksTests: LibraryServiceTests {
 // MARK: - Modify Library
 
 class ModifyLibraryTests: LibraryServiceTests {
-  func testMoveItemsIntoFolder() throws {
+  func testMoveItemsIntoFolder() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     library.addToItems(book1)
@@ -857,11 +862,11 @@ class ModifyLibraryTests: LibraryServiceTests {
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
     library.addToItems(folder)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     XCTAssert(library.items?.count == 3)
 
-    try self.sut.moveItems([book1.relativePath, book2.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath], inside: folder.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 2)
@@ -873,115 +878,115 @@ class ModifyLibraryTests: LibraryServiceTests {
     folder2.addToItems(book3)
     folder2.addToItems(book4)
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
     XCTAssert(library.items?.count == 2)
 
-    try self.sut.moveItems([folder2.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([folder2.relativePath], inside: folder.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder.items?.count == 3)
   }
 
-  func testMoveItemsIntoLibrary() throws {
+  func testMoveItemsIntoLibrary() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
 
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
-    try self.sut.moveItems([book1.relativePath, book2.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath], inside: folder.relativePath)
 
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     let folder2 = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder2")
 
-    try self.sut.moveItems([book3.relativePath, book4.relativePath, folder2.relativePath], inside: nil)
-    try self.sut.moveItems([folder.relativePath, book3.relativePath, book4.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath, folder2.relativePath], inside: nil)
+    try await self.sut.moveItems([folder.relativePath, book3.relativePath, book4.relativePath], inside: folder2.relativePath)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert(folder2.items?.count == 3)
 
-    try self.sut.moveItems([folder.relativePath], inside: nil)
+    try await self.sut.moveItems([folder.relativePath], inside: nil)
 
     XCTAssert(library.items?.count == 2)
     XCTAssert(folder.items?.count == 2)
 
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: nil)
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: nil)
 
     XCTAssert(library.items?.count == 4)
     XCTAssert(folder2.items?.count == 0)
   }
 
-  func testFolderShallowDeleteWithOneBook() throws {
+  func testFolderShallowDeleteWithOneBook() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book1.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book1.relativePath], inside: folder.relativePath)
     let folder2 = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder2")
-    try self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
-    try self.sut.moveItems([folder2.relativePath], inside: nil)
+    try await self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([folder2.relativePath], inside: nil)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .shallow)
+    try await self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .shallow)
 
     XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == folder)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder)], mode: .shallow)
+    try await self.sut.delete([SimpleLibraryItem(from: folder)], mode: .shallow)
 
     XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == book1)
   }
 
-  func testFolderShallowDeleteWithMultipleBooks() throws {
+  func testFolderShallowDeleteWithMultipleBooks() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
-    try self.sut.moveItems([book1.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath], inside: nil)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book2.relativePath], inside: folder.relativePath)
-    try self.sut.moveItems([book3.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book2.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book3.relativePath], inside: folder.relativePath)
     let folder2 = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder2")
-    try self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
-    try self.sut.moveItems([book4.relativePath], inside: folder2.relativePath)
-    try self.sut.moveItems([folder2.relativePath], inside: nil)
+    try await self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([book4.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([folder2.relativePath], inside: nil)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .shallow)
+    try await self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .shallow)
 
     XCTAssert(library.itemsArray
           .contains(where: { $0.relativePath == book1.relativePath}))
     XCTAssert(library.itemsArray
           .contains(where: { $0.relativePath == book4.relativePath}))
 
-    try self.sut.delete([SimpleLibraryItem(from: folder)], mode: .shallow)
+    try await self.sut.delete([SimpleLibraryItem(from: folder)], mode: .shallow)
 
     XCTAssert(library.items?.allObjects is [Book])
     XCTAssert(library.items?.count == 4)
   }
 
-  func testFolderDeepDeleteWithOneBook() throws {
+  func testFolderDeepDeleteWithOneBook() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
     let folder2 = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder2")
 
-    try self.sut.moveItems([book1.relativePath, folder.relativePath, folder2.relativePath], inside: nil)
-    try self.sut.moveItems([book1.relativePath], inside: folder.relativePath)
-    try self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([book1.relativePath, folder.relativePath, folder2.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([folder.relativePath], inside: folder2.relativePath)
 
     XCTAssert(folder2.items?.count == 1)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder)], mode: .deep)
+    try await self.sut.delete([SimpleLibraryItem(from: folder)], mode: .deep)
 
     XCTAssert(folder2.items?.count == 0)
     XCTAssert(library.items?.count == 1)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .deep)
+    try await self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .deep)
 
     XCTAssert(library.items?.count == 0)
   }
 
-  func testFolderDeepDeleteWithMultipleBooks() throws {
+  func testFolderDeepDeleteWithMultipleBooks() async throws {
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     library.addToItems(book1)
@@ -996,23 +1001,23 @@ class ModifyLibraryTests: LibraryServiceTests {
     let folder2 = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder2")
     library.addToItems(folder2)
 
-    try self.sut.moveItems([book2.relativePath, book3.relativePath], inside: folder.relativePath)
-    try self.sut.moveItems([book4.relativePath, folder.relativePath], inside: folder2.relativePath)
+    try await self.sut.moveItems([book2.relativePath, book3.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book4.relativePath, folder.relativePath], inside: folder2.relativePath)
 
     XCTAssert(folder2.items?.count == 2)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder)], mode: .deep)
+    try await self.sut.delete([SimpleLibraryItem(from: folder)], mode: .deep)
 
     XCTAssert(folder2.items?.count == 1)
     XCTAssert(library.items?.count == 2)
 
-    try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .deep)
+    try await self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .deep)
 
     XCTAssert(library.items?.count == 1)
     XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == book1)
   }
 
-  func testGetMaxItemsCount() throws {
+  func testGetMaxItemsCount() async throws {
     XCTAssert(self.sut.getMaxItemsCount(at: nil) == 0)
     let library = self.sut.getLibrary()
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
@@ -1029,28 +1034,28 @@ class ModifyLibraryTests: LibraryServiceTests {
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
     library.addToItems(folder)
 
-    sut.dataManager.saveContext()
+    sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, book3.relativePath, book4.relativePath], inside: folder.relativePath)
 
     XCTAssert(self.sut.getMaxItemsCount(at: nil) == 1)
     XCTAssert(self.sut.getMaxItemsCount(at: "folder") == 4)
   }
 
-  func testReplaceOrderItems() throws {
+  func testReplaceOrderItems() async throws {
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
 
-    try sut.moveItems([book4.relativePath, book3.relativePath, book2.relativePath, book1.relativePath], inside: nil)
+    try await sut.moveItems([book4.relativePath, book3.relativePath, book2.relativePath, book1.relativePath], inside: nil)
 
     let originalContents = sut.fetchContents(at: nil, limit: nil, offset: nil)
 
     XCTAssert(originalContents?[0].title == book4.title)
     XCTAssert(originalContents?[3].title == book1.title)
 
-    self.sut.sortContents(at: nil, by: .metadataTitle)
+    await self.sut.sortContents(at: nil, by: .metadataTitle)
 
     let sortedContents = sut.fetchContents(at: nil, limit: nil, offset: nil)
 
@@ -1058,32 +1063,32 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(sortedContents?[3].title == book4.title)
 
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try sut.moveItems([folder.relativePath], inside: nil)
-    try self.sut.moveItems([book4.relativePath, book3.relativePath, book2.relativePath, book1.relativePath], inside: folder.relativePath)
+    try await sut.moveItems([folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book4.relativePath, book3.relativePath, book2.relativePath, book1.relativePath], inside: folder.relativePath)
 
     let folderContents = sut.fetchContents(at: folder.relativePath, limit: nil, offset: nil)
     XCTAssert(folderContents?[0].title == book4.title)
     XCTAssert(folderContents?[3].title == book1.title)
 
-    self.sut.sortContents(at: folder.relativePath, by: .metadataTitle)
+    await self.sut.sortContents(at: folder.relativePath, by: .metadataTitle)
 
     let sortedFolderContents = sut.fetchContents(at: folder.relativePath, limit: nil, offset: nil)
     XCTAssert(sortedFolderContents?[0].title == book1.title)
     XCTAssert(sortedFolderContents?[3].title == book4.title)
   }
 
-  func testReorderItem() throws {
+  func testReorderItem() async throws {
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
 
-    try sut.moveItems([book3.relativePath, book2.relativePath, book1.relativePath], inside: nil)
+    try await sut.moveItems([book3.relativePath, book2.relativePath, book1.relativePath], inside: nil)
 
     let contents = sut.fetchContents(at: nil, limit: nil, offset: nil)
     XCTAssert(contents?[0].title == book3.title)
     XCTAssert(contents?[2].title == book1.title)
 
-    self.sut.reorderItem(
+    await self.sut.reorderItem(
       with: book3.relativePath,
       inside: nil,
       sourceIndexPath: IndexPath(row: 0, section: .data),
@@ -1097,14 +1102,14 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
 
-    try sut.moveItems([folder.relativePath], inside: nil)
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, book3.relativePath], inside: folder.relativePath)
+    try await sut.moveItems([folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, book3.relativePath], inside: folder.relativePath)
 
     let folderContents = sut.fetchContents(at: folder.relativePath, limit: nil, offset: nil)
     XCTAssert(folderContents?[0].title == book1.title)
     XCTAssert(folderContents?[2].title == book3.title)
 
-    self.sut.reorderItem(
+    await self.sut.reorderItem(
       with: book3.relativePath,
       inside: folder.relativePath,
       sourceIndexPath: IndexPath(row: 2, section: .data),
@@ -1116,14 +1121,14 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(sortedFolderContents?[2].title == book2.title)
   }
 
-  func testUpdateBookSpeed() throws {
+  func testUpdateBookSpeed() async throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book.relativePath], inside: folder.relativePath)
 
     self.sut.updateBookSpeed(at: book.relativePath, speed: 2.0)
 
@@ -1150,14 +1155,14 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(library.lastPlayedItem == nil)
   }
 
-  func testUpdateBookLastPlayDate() throws {
+  func testUpdateBookLastPlayDate() async throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book.relativePath], inside: folder.relativePath)
 
     let now = Date()
     self.sut.updatePlaybackTime(
@@ -1171,14 +1176,14 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(book.currentTime == 50)
   }
 
-  func testGetItemSpeed() throws {
+  func testGetItemSpeed() async throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
       duration: 100
     )
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book.relativePath], inside: folder.relativePath)
 
     XCTAssert(book.speed == 1.0)
     XCTAssert(folder.speed == 1.0)
@@ -1202,7 +1207,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(speed3 == 3.0)
   }
 
-  func testGetChapters() {
+  func testGetChapters() async {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
@@ -1216,26 +1221,26 @@ class ModifyLibraryTests: LibraryServiceTests {
     ]
 
     book.chapters = NSOrderedSet(array: chapters)
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let fetchedChapters = self.sut.getChapters(from: book.relativePath)
+    let fetchedChapters = await self.sut.getChapters(from: book.relativePath)
 
     XCTAssert(fetchedChapters?.first?.index == 0)
     XCTAssert(fetchedChapters?[1].index == 1)
     XCTAssert(fetchedChapters?.last?.index == 2)
   }
 
-  func testGetItemsNotIncluded() throws {
-    let emptyResult = self.sut.getItemsToSync(remoteIdentifiers: [])
+  func testGetItemsNotIncluded() async throws {
+    let emptyResult = await self.sut.getItemsToSync(remoteIdentifiers: [])
     XCTAssert(emptyResult?.isEmpty == true)
 
-    _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
-    _ = try! self.sut.createFolder(with: "test-folder2", inside: nil)
+    _ = try! await self.sut.createFolder(with: "test-folder", inside: nil)
+    _ = try! await self.sut.createFolder(with: "test-folder2", inside: nil)
 
-    let secondResult = self.sut.getItemsToSync(remoteIdentifiers: [])
+    let secondResult = await self.sut.getItemsToSync(remoteIdentifiers: [])
     XCTAssert(secondResult?.count == 2)
 
-    let thirdResult = self.sut.getItemsToSync(remoteIdentifiers: ["test-folder"])
+    let thirdResult = await self.sut.getItemsToSync(remoteIdentifiers: ["test-folder"])
     XCTAssert(thirdResult?.count == 1)
   }
 
@@ -1246,7 +1251,7 @@ class ModifyLibraryTests: LibraryServiceTests {
       duration: 100
     )
 
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
     let fetchedTitle = self.sut.getItemProperty("title", relativePath: book.relativePath) as? String
     XCTAssert(fetchedTitle == "test-book1")
     let fetchedDuration = self.sut.getItemProperty("duration", relativePath: book.relativePath) as? Double
@@ -1255,101 +1260,101 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(fetchedIsFinished == false)
   }
 
-  func testFindItem() throws {
+  func testFindItem() async throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
 
     book1.isFinished = true
     book3.isFinished = true
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let fetchedBook1 = self.sut.findFirstItem(in: nil, isUnfinished: nil)
-    let fetchedBook2 = self.sut.findFirstItem(in: nil, isUnfinished: true)
+    let fetchedBook1 = await self.sut.findFirstItem(in: nil, isUnfinished: nil)
+    let fetchedBook2 = await self.sut.findFirstItem(in: nil, isUnfinished: true)
 
     XCTAssert(fetchedBook1?.relativePath == book1.relativePath)
     XCTAssert(fetchedBook2?.relativePath == book2.relativePath)
 
-    let fetchedBook3 = self.sut.findFirstItem(in: folder.relativePath, isUnfinished: nil)
-    let fetchedBook4 = self.sut.findFirstItem(in: folder.relativePath, isUnfinished: true)
+    let fetchedBook3 = await self.sut.findFirstItem(in: folder.relativePath, isUnfinished: nil)
+    let fetchedBook4 = await self.sut.findFirstItem(in: folder.relativePath, isUnfinished: true)
 
     XCTAssert(fetchedBook3?.relativePath == book3.relativePath)
     XCTAssert(fetchedBook4?.relativePath == book4.relativePath)
   }
 
-  func testFindItemBeforeRank() throws {
+  func testFindItemBeforeRank() async throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
 
-    let fetchedBook1 = self.sut.findFirstItem(in: nil, beforeRank: 1)
+    let fetchedBook1 = await self.sut.findFirstItem(in: nil, beforeRank: 1)
 
     XCTAssert(fetchedBook1?.relativePath == book1.relativePath)
 
-    let fetchedBook2 = self.sut.findFirstItem(in: folder.relativePath, beforeRank: 1)
+    let fetchedBook2 = await self.sut.findFirstItem(in: folder.relativePath, beforeRank: 1)
 
     XCTAssert(fetchedBook2?.relativePath == book3.relativePath)
   }
 
-  func testFindItemAfterRank() throws {
+  func testFindItemAfterRank() async throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
 
     book1.isFinished = true
     book3.isFinished = true
-    self.sut.dataManager.saveContext()
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let fetchedBook1 = self.sut.findFirstItem(in: nil, afterRank: nil, isUnfinished: nil)
-    let fetchedBook2 = self.sut.findFirstItem(in: nil, afterRank: 0, isUnfinished: true)
+    let fetchedBook1 = await self.sut.findFirstItem(in: nil, afterRank: nil, isUnfinished: nil)
+    let fetchedBook2 = await self.sut.findFirstItem(in: nil, afterRank: 0, isUnfinished: true)
 
     XCTAssert(fetchedBook1?.relativePath == book1.relativePath)
     XCTAssert(fetchedBook2?.relativePath == book2.relativePath)
 
-    let fetchedBook3 = self.sut.findFirstItem(in: folder.relativePath, afterRank: nil, isUnfinished: nil)
-    let fetchedBook4 = self.sut.findFirstItem(in: folder.relativePath, afterRank: 0, isUnfinished: true)
+    let fetchedBook3 = await self.sut.findFirstItem(in: folder.relativePath, afterRank: nil, isUnfinished: nil)
+    let fetchedBook4 = await self.sut.findFirstItem(in: folder.relativePath, afterRank: 0, isUnfinished: true)
 
     XCTAssert(fetchedBook3?.relativePath == book3.relativePath)
     XCTAssert(fetchedBook4?.relativePath == book4.relativePath)
   }
 
-  func testFilterBookItems() throws {
+  func testFilterBookItems() async throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
-    self.sut.dataManager.saveContext()
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let fetchedNilBooks = self.sut.filterContents(at: nil, query: "book21", scope: .book, limit: nil, offset: nil)
+    let fetchedNilBooks = await self.sut.filterContents(at: nil, query: "book21", scope: .book, limit: nil, offset: nil)
 
     XCTAssert(fetchedNilBooks?.count == 0)
 
-    let fetchedAllBooks = self.sut.filterContents(at: nil, query: "book", scope: .book, limit: nil, offset: nil)
+    let fetchedAllBooks = await self.sut.filterContents(at: nil, query: "book", scope: .book, limit: nil, offset: nil)
 
     XCTAssert(fetchedAllBooks?.count == 4)
 
-    let fetchedResults = self.sut.filterContents(at: nil, query: "book1", scope: .book, limit: nil, offset: nil)
+    let fetchedResults = await self.sut.filterContents(at: nil, query: "book1", scope: .book, limit: nil, offset: nil)
 
     XCTAssert(fetchedResults?.count == 1)
     XCTAssert(fetchedResults?.first?.relativePath == book1.relativePath)
   }
 
-  func testFilterFolderItems() throws {
+  func testFilterFolderItems() async throws {
     let now = Date().timeIntervalSince1970
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     book1.lastPlayDate = Date(timeIntervalSince1970: now + 1)
@@ -1357,23 +1362,23 @@ class ModifyLibraryTests: LibraryServiceTests {
     book2.lastPlayDate = Date(timeIntervalSince1970: now + 2)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
     folder.lastPlayDate = Date(timeIntervalSince1970: now + 3)
-    try self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
+    try await self.sut.moveItems([book1.relativePath, book2.relativePath, folder.relativePath], inside: nil)
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     book3.lastPlayDate = Date(timeIntervalSince1970: now + 4)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     book4.lastPlayDate = Date(timeIntervalSince1970: now + 5)
-    try self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
-    self.sut.dataManager.saveContext()
+    try await self.sut.moveItems([book3.relativePath, book4.relativePath], inside: folder.relativePath)
+    self.sut.dataManager.saveContext(self.sut.dataManager.getContext())
 
-    let fetchedNilFolders = self.sut.filterContents(at: nil, query: "folder2", scope: .folder, limit: nil, offset: nil)
+    let fetchedNilFolders = await self.sut.filterContents(at: nil, query: "folder2", scope: .folder, limit: nil, offset: nil)
 
     XCTAssert(fetchedNilFolders?.count == 0)
 
-    let fetchedFolders = self.sut.filterContents(at: nil, query: "folder", scope: .folder, limit: nil, offset: nil)
+    let fetchedFolders = await self.sut.filterContents(at: nil, query: "folder", scope: .folder, limit: nil, offset: nil)
 
     XCTAssert(fetchedFolders?.count == 1)
 
-    let fetchedResults = self.sut.filterContents(
+    let fetchedResults = await self.sut.filterContents(
       at: folder.relativePath,
       query: nil,
       scope: .book,

--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -118,7 +118,7 @@ class StorageViewModelMissingFileTests: XCTestCase {
     XCTAssert(brokenItems.isEmpty)
   }
 
-  func testUnicodeMissingItem() throws {
+  func testUnicodeMissingItem() async throws {
     let folderName = "Maigretův první případ"
     let bookName = "idyllica_04_herrick_64kb.mp3"
 
@@ -135,12 +135,12 @@ class StorageViewModelMissingFileTests: XCTestCase {
         expectation.fulfill()
       }
 
-    wait(for: [expectation], timeout: 5.0)
+    await fulfillment(of: [expectation], timeout: 5.0)
 
     // Manual recreation of folder and book inside library
-    let folder = try self.viewModel.libraryService.createFolder(with: folderName, inside: nil)
-    let book = self.viewModel.libraryService.createBook(from: loadedFileURL)
-    try viewModel.libraryService.moveItems([book.relativePath], inside: folder.relativePath)
+    let folder = try await self.viewModel.libraryService.createFolder(with: folderName, inside: nil)
+    let book = await self.viewModel.libraryService.createBook(from: loadedFileURL)
+    try await viewModel.libraryService.moveItems([book.relativePath], inside: folder.relativePath)
 
     XCTAssertFalse(self.viewModel.shouldShowWarning(for: "Maigretův první případ/idyllica_04_herrick_64kb.mp3"))
   }

--- a/BookPlayerWidgetUI/WidgetUtils.swift
+++ b/BookPlayerWidgetUI/WidgetUtils.swift
@@ -23,23 +23,19 @@ struct PlaybackRecordViewer: Hashable {
 }
 
 extension PlaybackRecordViewer {
-    init(record: PlaybackRecord?, date: Date) {
+    init(time: Double?, date: Date) {
         self.date = date
-        self.time = 0
-
-        if let record = record {
-            self.time = record.time
-        }
+        self.time = time ?? 0
     }
 }
 
 class WidgetUtils {
-  class func getPlaybackRecord(with libraryService: LibraryService) -> PlaybackRecordViewer {
-    let record = libraryService.getCurrentPlaybackRecord()
-    return PlaybackRecordViewer(record: record, date: Date())
+  class func getPlaybackRecord(with libraryService: LibraryService) async -> PlaybackRecordViewer {
+    let recordTime = await libraryService.getCurrentPlaybackRecordTime()
+    return PlaybackRecordViewer(time: recordTime, date: Date())
   }
 
-  class func getPlaybackRecords(with libraryService: LibraryService) -> [PlaybackRecordViewer] {
+  class func getPlaybackRecords(with libraryService: LibraryService) async -> [PlaybackRecordViewer] {
       let calendar = Calendar.current
       let now = Date()
       let startToday = calendar.startOfDay(for: now)
@@ -53,20 +49,20 @@ class WidgetUtils {
       let startSixthDay = calendar.date(byAdding: .day, value: 1, to: startFifthDay)!
       let startSeventhDay = calendar.date(byAdding: .day, value: 1, to: startSixthDay)!
 
-      let firstRecord = (libraryService.getPlaybackRecords(from: startFirstDay, to: startSecondDay) ?? []).first
-      let firstRecordViewer = PlaybackRecordViewer(record: firstRecord, date: startFirstDay)
-      let secondRecord = (libraryService.getPlaybackRecords(from: startSecondDay, to: startThirdDay) ?? []).first
-      let secondRecordViewer = PlaybackRecordViewer(record: secondRecord, date: startSecondDay)
-      let thirdRecord = (libraryService.getPlaybackRecords(from: startThirdDay, to: startFourthDay) ?? []).first
-      let thirdRecordViewer = PlaybackRecordViewer(record: thirdRecord, date: startThirdDay)
-      let fourthRecord = (libraryService.getPlaybackRecords(from: startFourthDay, to: startFifthDay) ?? []).first
-      let fourthRecordViewer = PlaybackRecordViewer(record: fourthRecord, date: startFourthDay)
-      let fifthRecord = (libraryService.getPlaybackRecords(from: startFifthDay, to: startSixthDay) ?? []).first
-      let fifthRecordViewer = PlaybackRecordViewer(record: fifthRecord, date: startFifthDay)
-      let sixthRecord = (libraryService.getPlaybackRecords(from: startSixthDay, to: startSeventhDay) ?? []).first
-      let sixthRecordViewer = PlaybackRecordViewer(record: sixthRecord, date: startSixthDay)
-      let seventhRecord = (libraryService.getPlaybackRecords(from: startSeventhDay, to: endDate) ?? []).first
-      let seventhRecordViewer = PlaybackRecordViewer(record: seventhRecord, date: startSeventhDay)
+      let firstRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startFirstDay, to: startSecondDay)
+      let firstRecordViewer = PlaybackRecordViewer(time: firstRecordTime, date: startFirstDay)
+      let secondRecordTime = await  libraryService.getFirstPlaybackRecordTime(from: startSecondDay, to: startThirdDay)
+      let secondRecordViewer = PlaybackRecordViewer(time: secondRecordTime, date: startSecondDay)
+      let thirdRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startThirdDay, to: startFourthDay)
+      let thirdRecordViewer = PlaybackRecordViewer(time: thirdRecordTime, date: startThirdDay)
+      let fourthRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startFourthDay, to: startFifthDay)
+      let fourthRecordViewer = PlaybackRecordViewer(time: fourthRecordTime, date: startFourthDay)
+      let fifthRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startFifthDay, to: startSixthDay)
+      let fifthRecordViewer = PlaybackRecordViewer(time: fifthRecordTime, date: startFifthDay)
+      let sixthRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startSixthDay, to: startSeventhDay)
+      let sixthRecordViewer = PlaybackRecordViewer(time: sixthRecordTime, date: startSixthDay)
+      let seventhRecordTime = await libraryService.getFirstPlaybackRecordTime(from: startSeventhDay, to: endDate)
+      let seventhRecordViewer = PlaybackRecordViewer(time: seventhRecordTime, date: startSeventhDay)
 
       return [firstRecordViewer, secondRecordViewer, thirdRecordViewer, fourthRecordViewer, fifthRecordViewer, sixthRecordViewer, seventhRecordViewer]
     }

--- a/Shared/CoreData/CoreDataStack.swift
+++ b/Shared/CoreData/CoreDataStack.swift
@@ -51,14 +51,15 @@ public class CoreDataStack {
   public func loadStore(completionHandler: ((NSPersistentStoreDescription, Error?) -> Void)?) {
     self.storeContainer.loadPersistentStores { storeDescription, error in
       self.storeContainer.viewContext.undoManager = nil
+      self.storeContainer.viewContext.automaticallyMergesChangesFromParent = true
       completionHandler?(storeDescription, error)
     }
   }
 
-  public func saveContext() {
-    guard self.managedContext.hasChanges else { return }
+  public func saveContext(_ context: NSManagedObjectContext) {
+    guard context.hasChanges else { return }
     do {
-      try self.managedContext.save()
+      try context.save()
     } catch let error as NSError {
       fatalError("Unresolved error \(error), \(error.userInfo)")
     }
@@ -66,5 +67,20 @@ public class CoreDataStack {
 
   public func getBackgroundContext() -> NSManagedObjectContext {
     return self.storeContainer.newBackgroundContext()
+  }
+
+  public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+    storeContainer.performBackgroundTask(block)
+  }
+}
+
+public extension NSManagedObjectContext {
+  func saveContext() {
+    guard hasChanges else { return }
+    do {
+      try save()
+    } catch let error as NSError {
+      fatalError("Unresolved error \(error), \(error.userInfo)")
+    }
   }
 }

--- a/Shared/CoreData/Migrations/ManualOrderMigrationUtils.swift
+++ b/Shared/CoreData/Migrations/ManualOrderMigrationUtils.swift
@@ -13,32 +13,39 @@ extension DataMigrationManager {
   func populateFolderDetails(dataManager: DataManager) {
     let fetch: NSFetchRequest<Folder> = Folder.fetchRequest()
     fetch.returnsObjectsAsFaults = false
-    guard let folders = try? dataManager.getContext().fetch(fetch) as [Folder] else { return }
 
-    folders.forEach { folder in
-      let count = folder.items?.count ?? 0
-      folder.details = String.localizedStringWithFormat("files_title".localized, count)
+    let context = dataManager.getContext()
+    context.performAndWait {
+      guard let folders = try? context.fetch(fetch) as [Folder] else { return }
+
+      folders.forEach { folder in
+        let count = folder.items?.count ?? 0
+        folder.details = String.localizedStringWithFormat("files_title".localized, count)
+      }
+
+      dataManager.saveContext(context)
     }
-
-    dataManager.saveContext()
   }
 
   func populateIsFinished(dataManager: DataManager) {
     let fetch: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     fetch.propertiesToFetch = ["isFinished"]
 
-    guard
-      let items = try? dataManager.getContext().fetch(fetch) as [LibraryItem]
-    else { return }
+    let context = dataManager.getContext()
+    context.performAndWait {
+      guard
+        let items = try? context.fetch(fetch) as [LibraryItem]
+      else { return }
 
-    items.forEach { item in
-      if item.isFinished {
-        item.isFinished = true
-      } else {
-        item.isFinished = false
+      items.forEach { item in
+        if item.isFinished {
+          item.isFinished = true
+        } else {
+          item.isFinished = false
+        }
       }
-    }
 
-    dataManager.saveContext()
+      dataManager.saveContext(context)
+    }
   }
 }

--- a/Shared/Services/Account/AccountService.swift
+++ b/Shared/Services/Account/AccountService.swift
@@ -129,7 +129,7 @@ public final class AccountService: AccountServiceProtocol {
     account.email = ""
     account.hasSubscription = false
     account.donationMade = donationMade
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(context)
   }
 
   public func updateAccount(from customerInfo: CustomerInfo) {
@@ -162,7 +162,7 @@ public final class AccountService: AccountServiceProtocol {
       account.hasSubscription = hasSubscription
     }
 
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(self.dataManager.getContext())
 
     DispatchQueue.main.async {
       NotificationCenter.default.post(name: .accountUpdate, object: self)

--- a/Shared/Services/LibraryService+FetchRequests.swift
+++ b/Shared/Services/LibraryService+FetchRequests.swift
@@ -1,0 +1,73 @@
+//
+//  LibraryService+FetchRequests.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 24/6/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+extension LibraryService {
+  static func bookmarkReferenceFetchRequest(bookmark: SimpleBookmark) -> NSFetchRequest<Bookmark> {
+    let fetchRequest: NSFetchRequest<Bookmark> = Bookmark.fetchRequest()
+    fetchRequest.predicate = NSPredicate(
+      format: "%K == %@ && type == %d && time == %f",
+      #keyPath(Bookmark.item.relativePath),
+      bookmark.relativePath,
+      bookmark.type.rawValue,
+      bookmark.time
+    )
+    fetchRequest.fetchLimit = 1
+    fetchRequest.propertiesToFetch = [
+      #keyPath(Bookmark.time),
+      #keyPath(Bookmark.note),
+      #keyPath(Bookmark.type),
+    ]
+
+    return fetchRequest
+  }
+
+  static func simpleBookmarkFetchRequest(
+    time: Double?,
+    relativePath: String,
+    type: BookmarkType
+  ) -> NSFetchRequest<NSDictionary> {
+    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Bookmark")
+    fetchRequest.propertiesToFetch = SimpleBookmark.fetchRequestProperties
+    fetchRequest.resultType = .dictionaryResultType
+    if let time {
+      fetchRequest.predicate = NSPredicate(
+        format: "%K == %@ && type == %d && time == %f",
+        #keyPath(Bookmark.item.relativePath),
+        relativePath,
+        type.rawValue,
+        floor(time)
+      )
+    } else {
+      fetchRequest.predicate = NSPredicate(
+        format: "%K == %@ && type == %d",
+        #keyPath(Bookmark.item.relativePath),
+        relativePath,
+        type.rawValue
+      )
+    }
+    let sort = NSSortDescriptor(key: #keyPath(Bookmark.time), ascending: true)
+    fetchRequest.sortDescriptors = [sort]
+
+    return fetchRequest
+  }
+
+  static func itemReferenceFetchRequest(relativePath: String) -> NSFetchRequest<LibraryItem> {
+    let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
+    fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
+    fetchRequest.fetchLimit = 1
+    fetchRequest.propertiesToFetch = [
+      #keyPath(LibraryItem.relativePath),
+      #keyPath(LibraryItem.originalFileName)
+    ]
+
+    return fetchRequest
+  }
+}

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -18,8 +18,6 @@ public protocol LibraryServiceProtocol {
 
   /// Gets (or create) the library for the App. There should be only one Library object at all times
   func getLibrary() -> Library
-  /// Get the stored library object with no properties loaded
-  func getLibraryReference() -> Library
   /// Get last item played
   func getLibraryLastItem() -> SimpleLibraryItem?
   /// Get current theme selected
@@ -29,24 +27,24 @@ public protocol LibraryServiceProtocol {
   /// Set the last played book
   func setLibraryLastBook(with relativePath: String?)
   /// Import and insert items
-  func insertItems(from files: [URL]) -> [SimpleLibraryItem]
+  func insertItems(from files: [URL]) async -> [SimpleLibraryItem]
   /// Move items between folders
-  func moveItems(_ items: [String], inside relativePath: String?) throws
+  func moveItems(_ items: [String], inside relativePath: String?) async throws
   /// Delete items
-  func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) throws
+  func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) async throws
 
   /// Fetch folder or library contents at the specified path
   func fetchContents(at relativePath: String?, limit: Int?, offset: Int?) -> [SimpleLibraryItem]?
   /// Get max items count inside the specified path
   func getMaxItemsCount(at relativePath: String?) -> Int
   /// Fetch the most recent played items
-  func getLastPlayedItems(limit: Int?) -> [SimpleLibraryItem]?
+  func getLastPlayedItems(limit: Int?) async -> [SimpleLibraryItem]?
   /// Fetch the books that contain the file URL
-  func findBooks(containing fileURL: URL) -> [Book]?
+  func findBooks(containing fileURL: URL) async -> [Book]?
   /// Fetch a single item with properties loaded
-  func getSimpleItem(with relativePath: String) -> SimpleLibraryItem?
+  func getSimpleItem(with relativePath: String) async -> SimpleLibraryItem?
   /// Get items not included in a specific set
-  func getItems(notIn relativePaths: [String], parentFolder: String?) -> [SimpleLibraryItem]?
+  func getItems(notIn relativePaths: [String], parentFolder: String?) async -> [SimpleLibraryItem]?
   /// Fetch a property from a stored library item
   func getItemProperty(_ property: String, relativePath: String) -> Any?
   /// Search
@@ -56,45 +54,45 @@ public protocol LibraryServiceProtocol {
     scope: SimpleItemType,
     limit: Int?,
     offset: Int?
-  ) -> [SimpleLibraryItem]?
+  ) async -> [SimpleLibraryItem]?
   /// Autoplay
   /// Find first item that is unfinished in a folder
-  func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem?
+  func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) async -> SimpleLibraryItem?
   /// Fetch first item before a specific position in a folder
-  func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem?
+  func findFirstItem(in parentFolder: String?, beforeRank: Int16?) async -> SimpleLibraryItem?
   /// Fetch first item after a specific position in a folder considering if it's unfinished or not
-  func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) -> SimpleLibraryItem?
+  func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) async -> SimpleLibraryItem?
   /// Get metadata chapters from item
-  func getChapters(from relativePath: String) -> [SimpleChapter]?
+  func getChapters(from relativePath: String) async -> [SimpleChapter]?
 
   /// Update metadata
   /// Create book core data object
-  func createBook(from url: URL) -> Book
+  func createBook(from url: URL) async -> Book
   /// Load metadata chapters if needed
-  func loadChaptersIfNeeded(relativePath: String, asset: AVAsset)
+  func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) async
   /// Create folder
-  func createFolder(with title: String, inside relativePath: String?) throws -> SimpleLibraryItem
+  func createFolder(with title: String, inside relativePath: String?) async throws -> SimpleLibraryItem
   /// Update folder type
-  func updateFolder(at relativePath: String, type: SimpleItemType) throws
+  func updateFolder(at relativePath: String, type: SimpleItemType) async throws
   /// Rebuild folder details
   func rebuildFolderDetails(_ relativePath: String)
   /// Rebuild folder progress
   func recursiveFolderProgressUpdate(from relativePath: String)
   /// Rename book title
-  func renameBook(at relativePath: String, with newTitle: String)
+  func renameBook(at relativePath: String, with newTitle: String) async
   /// Rename folder title
-  func renameFolder(at relativePath: String, with newTitle: String) throws -> String
+  func renameFolder(at relativePath: String, with newTitle: String) async throws -> String
   /// Update item details
-  func updateDetails(at relativePath: String, details: String)
+  func updateDetails(at relativePath: String, details: String) async
   /// Update item order to new rank
   func reorderItem(
     with relativePath: String,
     inside folderRelativePath: String?,
     sourceIndexPath: IndexPath,
     destinationIndexPath: IndexPath
-  )
+  ) async
   /// Sort entire list at the given path
-  func sortContents(at relativePath: String?, by type: SortType)
+  func sortContents(at relativePath: String?, by type: SortType) async
   /// Playback
   /// Update playback time for item
   func updatePlaybackTime(relativePath: String, time: Double, date: Date, scheduleSave: Bool)
@@ -103,31 +101,38 @@ public protocol LibraryServiceProtocol {
   /// Get item speed
   func getItemSpeed(at relativePath: String) -> Float
   /// Mark item as finished
-  func markAsFinished(flag: Bool, relativePath: String)
+  func markAsFinished(flag: Bool, relativePath: String) async
   /// Jump to the start of an item
-  func jumpToStart(relativePath: String)
+  func jumpToStart(relativePath: String) async
 
   /// Time listened
-  /// Get playback record for the day
-  func getCurrentPlaybackRecord() -> PlaybackRecord
-  /// Get array of playback records across two dates
-  func getPlaybackRecords(from startDate: Date, to endDate: Date) -> [PlaybackRecord]?
+  /// Get playback time for today
+  func getCurrentPlaybackRecordTime() async -> Double
+  /// Get the first playback time for a specific range of dates
+  func getFirstPlaybackRecordTime(
+    from startDate: Date,
+    to endDate: Date
+  ) async -> Double
   /// Record a second of listened time
-  func recordTime(_ playbackRecord: PlaybackRecord)
+  func recordTime()
   /// Get total listened time across all items
-  func getTotalListenedTime() -> TimeInterval
+  func getTotalListenedTime() async -> TimeInterval
 
   /// Bookmarks
   /// Fetch bookmarks for an item
-  func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]?
-  /// Fetch a bookmark at a specific time
-  func getBookmark(at time: Double, relativePath: String, type: BookmarkType) -> SimpleBookmark?
+  func getBookmarks(of type: BookmarkType, relativePath: String) async -> [SimpleBookmark]?
+
+  func getBookmark(
+    at time: Double,
+    relativePath: String,
+    type: BookmarkType
+  ) -> SimpleBookmark?
   /// Create a bookmark at the given time
-  func createBookmark(at time: Double, relativePath: String, type: BookmarkType) -> SimpleBookmark?
+  func createBookmark(at time: Double, relativePath: String, type: BookmarkType) async -> SimpleBookmark?
   /// Add a note to a bookmark
-  func addNote(_ note: String, bookmark: SimpleBookmark)
+  func addNote(_ note: String, bookmark: SimpleBookmark) async
   /// Delete a bookmark
-  func deleteBookmark(_ bookmark: SimpleBookmark)
+  func deleteBookmark(_ bookmark: SimpleBookmark) async
 }
 
 // swiftlint:disable force_cast
@@ -160,7 +165,7 @@ public final class LibraryService: LibraryServiceProtocol {
     self.dataManager = dataManager
   }
 
-  private func rebuildRelativePaths(for item: LibraryItem, parentFolder: String?) {
+  private func rebuildRelativePaths(for item: LibraryItem, parentFolder: String?, context: NSManagedObjectContext) {
     switch item {
     case let book as Book:
       if let parentPath = parentFolder {
@@ -176,7 +181,8 @@ public final class LibraryService: LibraryServiceProtocol {
         propertiesToFetch: [
         #keyPath(LibraryItem.relativePath),
         #keyPath(LibraryItem.originalFileName)
-        ]
+        ],
+        context: context
       ) ?? []
 
       if let parentPath = parentFolder {
@@ -187,23 +193,17 @@ public final class LibraryService: LibraryServiceProtocol {
       }
 
       for nestedItem in contents {
-        rebuildRelativePaths(for: nestedItem, parentFolder: folder.relativePath)
+        rebuildRelativePaths(for: nestedItem, parentFolder: folder.relativePath, context: context)
       }
     default:
       break
     }
   }
 
-  func getItemReference(with relativePath: String) -> LibraryItem? {
-    let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
-    fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
-    fetchRequest.fetchLimit = 1
-    fetchRequest.propertiesToFetch = [
-      #keyPath(LibraryItem.relativePath),
-      #keyPath(LibraryItem.originalFileName)
-    ]
+  func getItemReference(with relativePath: String, context: NSManagedObjectContext) -> LibraryItem? {
+    let fetchRequest = Self.itemReferenceFetchRequest(relativePath: relativePath)
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
   }
 
   public func hasItemProperty(_ property: String, relativePath: String) -> Bool {
@@ -301,7 +301,7 @@ public final class LibraryService: LibraryServiceProtocol {
     })
   }
 
-  func getNextOrderRank(in folderPath: String?) -> Int16 {
+  func getNextOrderRank(in folderPath: String?, context: NSManagedObjectContext) -> Int16 {
     let maxExpression = NSExpressionDescription()
     maxExpression.expression = NSExpression(
       forFunction: "max:",
@@ -320,7 +320,7 @@ public final class LibraryService: LibraryServiceProtocol {
     fetchRequest.resultType = .dictionaryResultType
 
     guard
-      let results = try? dataManager.getContext().fetch(fetchRequest) as? [[String: Int16]],
+      let results = try? context.fetch(fetchRequest) as? [[String: Int16]],
       let maxOrderRank = results.first?["maxOrderRank"]
     else {
       return 0
@@ -376,11 +376,10 @@ extension LibraryService {
     let fetch: NSFetchRequest<Library> = Library.fetchRequest()
     fetch.returnsObjectsAsFaults = false
 
-    return (try? context.fetch(fetch).first) ?? self.createLibrary()
+    return (try? context.fetch(fetch).first) ?? self.createLibrary(context: context)
   }
 
-  public func getLibraryReference() -> Library {
-    let context = self.dataManager.getContext()
+  func getLibraryReference(context: NSManagedObjectContext) -> Library {
     let fetch: NSFetchRequest<Library> = Library.fetchRequest()
     fetch.includesPropertyValues = false
     fetch.fetchLimit = 1
@@ -388,10 +387,9 @@ extension LibraryService {
     return (try? context.fetch(fetch).first)!
   }
 
-  private func createLibrary() -> Library {
-    let context = self.dataManager.getContext()
+  private func createLibrary(context: NSManagedObjectContext) -> Library {
     let library = Library.create(in: context)
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(context)
     return library
   }
 
@@ -408,7 +406,7 @@ extension LibraryService {
       return nil
     }
 
-    return getSimpleItem(with: relativePath)
+    return getSimpleItem(with: relativePath, context: context)
   }
 
   public func getLibraryCurrentTheme() -> SimpleTheme? {
@@ -429,49 +427,66 @@ extension LibraryService {
   }
 
   public func setLibraryTheme(with simpleTheme: SimpleTheme) {
-    let library = self.getLibraryReference()
+    dataManager.performTask { [weak self] context in
+      guard let self else { return }
 
-    library.currentTheme = getTheme(with: simpleTheme.title)
-    ?? Theme(
-      simpleTheme: simpleTheme,
-      context: dataManager.getContext()
-    )
+      let library = self.getLibraryReference(context: context)
 
-    self.dataManager.saveContext()
+      library.currentTheme = getTheme(with: simpleTheme.title, context: context)
+      ?? Theme(
+        simpleTheme: simpleTheme,
+        context: context
+      )
+
+      self.dataManager.saveContext(context)
+    }
   }
 
-  private func getTheme(with title: String) -> Theme? {
+  private func getTheme(with title: String, context: NSManagedObjectContext) -> Theme? {
     let fetchRequest: NSFetchRequest<Theme> = Theme.fetchRequest()
     fetchRequest.predicate = NSPredicate(format: "title == %@", title)
     fetchRequest.fetchLimit = 1
     fetchRequest.returnsObjectsAsFaults = false
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
   }
 
   public func setLibraryLastBook(with relativePath: String?) {
-    let library = self.getLibraryReference()
+    dataManager.performBackgroundTask { [weak self] context in
+      guard let self else { return }
 
-    if let relativePath = relativePath {
-      library.lastPlayedItem = getItemReference(with: relativePath)
-    } else {
-      library.lastPlayedItem = nil
+      let library = self.getLibraryReference(context: context)
+
+      if let relativePath = relativePath {
+        library.lastPlayedItem = getItemReference(with: relativePath, context: context)
+      } else {
+        library.lastPlayedItem = nil
+      }
+
+      self.dataManager.saveContext(context)
     }
-
-    self.dataManager.saveContext()
   }
 
   @discardableResult
-  public func insertItems(from files: [URL]) -> [SimpleLibraryItem] {
-    return insertItems(from: files, parentPath: nil)
+  public func insertItems(from files: [URL]) async -> [SimpleLibraryItem] {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard let self else {
+          continuation.resume(returning: [])
+          return
+        }
+
+        continuation.resume(returning: insertItems(from: files, parentPath: nil, context: context))
+      }
+    }
   }
 
   /// This handles the Core Data objects creation from the Import operation. This method doesn't handle moving files on disk,
   /// as we don't want this method to throw, and the files are already in the processed folder
   @discardableResult
-  func insertItems(from files: [URL], parentPath: String? = nil) -> [SimpleLibraryItem] {
+  func insertItems(from files: [URL], parentPath: String? = nil, context: NSManagedObjectContext) -> [SimpleLibraryItem] {
     let context = dataManager.getContext()
-    let library = getLibraryReference()
+    let library = getLibraryReference(context: context)
 
     var processedFiles = [SimpleLibraryItem]()
     for file in files {
@@ -482,15 +497,15 @@ extension LibraryService {
          type == .typeDirectory {
         libraryItem = Folder(from: file, context: context)
         /// Kick-off separate function to handle instatiating the folder contents
-        self.handleDirectory(file)
+        self.handleDirectory(file, context: context)
       } else {
         libraryItem = Book(from: file, context: context)
       }
 
-      libraryItem.orderRank = getNextOrderRank(in: parentPath)
+      libraryItem.orderRank = getNextOrderRank(in: parentPath, context: context)
 
       if let parentPath,
-         let parentFolder = getItemReference(with: parentPath) as? Folder {
+         let parentFolder = getItemReference(with: parentPath, context: context) as? Folder {
         parentFolder.addToItems(libraryItem)
         /// update details on parent folder
       } else {
@@ -498,13 +513,13 @@ extension LibraryService {
       }
 
       processedFiles.append(SimpleLibraryItem(from: libraryItem))
-      dataManager.saveContext()
+      dataManager.saveContext(context)
     }
 
     return processedFiles
   }
 
-  private func handleDirectory(_ folderURL: URL) {
+  private func handleDirectory(_ folderURL: URL, context: NSManagedObjectContext) {
     let enumerator = FileManager.default.enumerator(
       at: folderURL,
       includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
@@ -525,8 +540,8 @@ extension LibraryService {
     let sortedFiles = orderedSet.sortedArray(using: [sortDescriptor]) as! [URL]
 
     let parentPath = folderURL.relativePath(to: DataManager.getProcessedFolderURL())
-    insertItems(from: sortedFiles, parentPath: parentPath)
-    rebuildFolderDetails(parentPath)
+    insertItems(from: sortedFiles, parentPath: parentPath, context: context)
+    rebuildFolderDetails(parentPath, context: context)
   }
 
   private func moveFileIfNeeded(
@@ -553,12 +568,26 @@ extension LibraryService {
     )
   }
 
-  public func moveItems(_ items: [String], inside relativePath: String?) throws {
+  public func moveItems(_ items: [String], inside relativePath: String?) async throws {
+    return try await withCheckedThrowingContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        do {
+          try self?.moveItems(items, inside: relativePath, context: context)
+          continuation.resume()
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  // swiftlint:disable:next function_body_length
+  func moveItems(_ items: [String], inside relativePath: String?, context: NSManagedObjectContext) throws {
     var folder: Folder?
-    let library = self.getLibraryReference()
+    let library = self.getLibraryReference(context: context)
 
     if let relativePath = relativePath,
-       let folderReference = getItemReference(with: relativePath) as? Folder {
+       let folderReference = getItemReference(with: relativePath, context: context) as? Folder {
       folder = folderReference
     }
 
@@ -567,15 +596,16 @@ extension LibraryService {
     if let firstPath = items.first {
       originalParentPath = getItemProperty(
         #keyPath(LibraryItem.folder.relativePath),
-        relativePath: firstPath
+        relativePath: firstPath,
+        context: context
        ) as? String
     }
 
     let processedFolderURL = DataManager.getProcessedFolderURL()
-    let startingIndex = getNextOrderRank(in: relativePath)
+    let startingIndex = getNextOrderRank(in: relativePath, context: context)
 
     for (index, itemPath) in items.enumerated() {
-      guard let libraryItem = getItemReference(with: itemPath) else { continue }
+      guard let libraryItem = getItemReference(with: itemPath, context: context) else { continue }
 
       let sourceUrl = processedFolderURL
         .appendingPathComponent(itemPath)
@@ -587,7 +617,7 @@ extension LibraryService {
       )
 
       libraryItem.orderRank = startingIndex + Int16(index)
-      rebuildRelativePaths(for: libraryItem, parentFolder: relativePath)
+      rebuildRelativePaths(for: libraryItem, parentFolder: relativePath, context: context)
 
       if let folder = folder {
         /// Remove reference to Library if it exists
@@ -598,33 +628,35 @@ extension LibraryService {
       } else {
         if let parentPath = getItemProperty(
           #keyPath(LibraryItem.folder.relativePath),
-          relativePath: itemPath
+          relativePath: itemPath,
+          context: context
         ) as? String,
-           let parentFolder = getItemReference(with: parentPath) as? Folder {
+           let parentFolder = getItemReference(with: parentPath, context: context) as? Folder {
           parentFolder.removeFromItems(libraryItem)
         }
         library.addToItems(libraryItem)
       }
     }
 
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(context)
 
     if let folder {
-      rebuildFolderDetails(folder.relativePath)
+      rebuildFolderDetails(folder.relativePath, context: context)
     }
     if let originalParentPath {
-      rebuildOrderRank(in: originalParentPath)
+      rebuildOrderRank(in: originalParentPath, context: context)
     }
   }
 
-  func rebuildOrderRank(in folderRelativePath: String?) {
+  func rebuildOrderRank(in folderRelativePath: String?, context: NSManagedObjectContext) {
     guard
       let contents = fetchRawContents(
         at: folderRelativePath,
         propertiesToFetch: [
           #keyPath(LibraryItem.relativePath),
           #keyPath(LibraryItem.orderRank)
-        ]
+        ],
+        context: context
       )
     else { return }
 
@@ -636,27 +668,53 @@ extension LibraryService {
       ])
     }
 
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(context)
   }
 
-  public func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) throws {
+  func getItemIdentifiers(in parentFolder: String?, context: NSManagedObjectContext) -> [String]? {
+    let fetchRequest = buildListContentsFetchRequest(
+      properties: ["relativePath"],
+      relativePath: parentFolder,
+      limit: nil,
+      offset: nil
+    )
+
+    let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+
+    return results?.compactMap({ $0["relativePath"] as? String })
+  }
+
+  public func delete(_ items: [SimpleLibraryItem], mode: DeleteMode) async throws {
+    return try await withCheckedThrowingContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        do {
+          try self?.delete(items, mode: mode, context: context)
+          continuation.resume()
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  func delete(_ items: [SimpleLibraryItem], mode: DeleteMode, context: NSManagedObjectContext) throws {
     for item in items {
       switch item.type {
       case .book:
-        try deleteItem(item)
+        try deleteItem(item, context: context)
       case .bound, .folder:
         switch mode {
         case .deep:
-          try deleteFolderContents(item)
+          try deleteFolderContents(item, context: context)
         case .shallow:
           // Move children to parent folder or library
-          if let items = getItemIdentifiers(in: item.relativePath),
+          if let items = getItemIdentifiers(in: item.relativePath, context: context),
              !items.isEmpty {
-            try moveItems(items, inside: item.parentFolder)
+            try moveItems(items, inside: item.parentFolder, context: context)
           }
         }
 
-        try deleteItem(item)
+        try deleteItem(item, context: context)
       }
 
       /// Clean up artwork cache
@@ -664,29 +722,48 @@ extension LibraryService {
     }
   }
 
-  func deleteItem(_ item: SimpleLibraryItem) throws {
+  func deleteItem(_ item: SimpleLibraryItem, context: NSManagedObjectContext) throws {
     // Delete file item if it exists
     let fileURL = item.fileURL
     if FileManager.default.fileExists(atPath: fileURL.path) {
       try FileManager.default.removeItem(at: fileURL)
     }
 
-    if let bookReference = getItemReference(with: item.relativePath) {
-      dataManager.delete(bookReference)
+    if let bookReference = getItemReference(with: item.relativePath, context: context) {
+      dataManager.delete(bookReference, context: context)
     }
   }
 
-  func deleteFolderContents(_ folder: SimpleLibraryItem) throws {
+  func deleteFolderContents(_ folder: SimpleLibraryItem, context: NSManagedObjectContext) throws {
     // Delete folder contents
-    guard let items = fetchContents(at: folder.relativePath, limit: nil, offset: nil) else { return }
+    guard let items = fetchContents(
+      at: folder.relativePath,
+      limit: nil,
+      offset: nil,
+      context: context
+    ) else { return }
 
-    try self.delete(items, mode: .deep)
+    try self.delete(items, mode: .deep, context: context)
   }
 }
 
 // MARK: - Fetch library items
 extension LibraryService {
   public func fetchContents(at relativePath: String?, limit: Int?, offset: Int?) -> [SimpleLibraryItem]? {
+    return fetchContents(
+      at: relativePath,
+      limit: limit,
+      offset: offset,
+      context: dataManager.getContext()
+    )
+  }
+
+  func fetchContents(
+    at relativePath: String?,
+    limit: Int?,
+    offset: Int?,
+    context: NSManagedObjectContext
+  ) -> [SimpleLibraryItem]? {
     let fetchRequest = buildListContentsFetchRequest(
       properties: SimpleLibraryItem.fetchRequestProperties,
       relativePath: relativePath,
@@ -694,12 +771,12 @@ extension LibraryService {
       offset: offset
     )
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
+    let results = try? context.fetch(fetchRequest) as? [[String: Any]]
 
     return parseFetchedItems(from: results)
   }
 
-  func fetchRawContents(at relativePath: String?, propertiesToFetch: [String]) -> [LibraryItem]? {
+  func fetchRawContents(at relativePath: String?, propertiesToFetch: [String], context: NSManagedObjectContext) -> [LibraryItem]? {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     fetchRequest.propertiesToFetch = propertiesToFetch
 
@@ -711,10 +788,14 @@ extension LibraryService {
     let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true)
     fetchRequest.sortDescriptors = [sort]
 
-    return try? self.dataManager.getContext().fetch(fetchRequest)
+    return try? context.fetch(fetchRequest)
   }
 
   public func getMaxItemsCount(at relativePath: String?) -> Int {
+    return getMaxItemsCount(at: relativePath, context: dataManager.getContext())
+  }
+
+  func getMaxItemsCount(at relativePath: String?, context: NSManagedObjectContext) -> Int {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     if let relativePath = relativePath {
       fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.folder.relativePath), relativePath)
@@ -722,83 +803,107 @@ extension LibraryService {
       fetchRequest.predicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
     }
 
-    return (try? self.dataManager.getContext().count(for: fetchRequest)) ?? 0
+    return (try? context.count(for: fetchRequest)) ?? 0
   }
 
-  public func getLastPlayedItems(limit: Int?) -> [SimpleLibraryItem]? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-    fetchRequest.predicate = NSPredicate(format: "type != 0 && lastPlayDate != nil")
-    fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
+  public func getLastPlayedItems(limit: Int?) async -> [SimpleLibraryItem]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
+        fetchRequest.predicate = NSPredicate(format: "type != 0 && lastPlayDate != nil")
+        fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
+        fetchRequest.resultType = .dictionaryResultType
 
-    if let limit = limit {
-      fetchRequest.fetchLimit = limit
+        if let limit = limit {
+          fetchRequest.fetchLimit = limit
+        }
+
+        let sort = NSSortDescriptor(key: #keyPath(LibraryItem.lastPlayDate), ascending: false)
+        fetchRequest.sortDescriptors = [sort]
+
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+
+        continuation.resume(returning: self?.parseFetchedItems(from: results))
+      }
     }
-
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.lastPlayDate), ascending: false)
-    fetchRequest.sortDescriptors = [sort]
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return parseFetchedItems(from: results)
   }
 
-  public func findBooks(containing fileURL: URL) -> [Book]? {
-    let fetch: NSFetchRequest<Book> = Book.fetchRequest()
-    fetch.predicate = NSPredicate(format: "relativePath ENDSWITH[C] %@", fileURL.lastPathComponent)
-    let context = self.dataManager.getContext()
+  public func findBooks(containing fileURL: URL) async -> [Book]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { context in
+        let fetch: NSFetchRequest<Book> = Book.fetchRequest()
+        fetch.predicate = NSPredicate(format: "relativePath ENDSWITH[C] %@", fileURL.lastPathComponent)
 
-    return try? context.fetch(fetch)
+        let books = try? context.fetch(fetch)
+        continuation.resume(returning: books)
+      }
+    }
   }
 
-  public func getSimpleItem(with relativePath: String) -> SimpleLibraryItem? {
+  public func getSimpleItem(with relativePath: String) async -> SimpleLibraryItem? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let item = self?.getSimpleItem(with: relativePath, context: context)
+        continuation.resume(returning: item)
+      }
+    }
+  }
+
+  func getSimpleItem(with relativePath: String, context: NSManagedObjectContext) -> SimpleLibraryItem? {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
     fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
     fetchRequest.fetchLimit = 1
     fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
     fetchRequest.resultType = .dictionaryResultType
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
+    let results = try? context.fetch(fetchRequest) as? [[String: Any]]
 
     return parseFetchedItems(from: results)?.first
   }
 
-  public func getItem(with relativePath: String) -> LibraryItem? {
+  public func getItem(with relativePath: String, context: NSManagedObjectContext) -> LibraryItem? {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
     fetchRequest.fetchLimit = 1
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
   }
 
-  public func getItems(notIn relativePaths: [String], parentFolder: String?) -> [SimpleLibraryItem]? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-    fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
+  public func getItems(notIn relativePaths: [String], parentFolder: String?) async -> [SimpleLibraryItem]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
+        fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
+        fetchRequest.resultType = .dictionaryResultType
 
-    if let parentFolder = parentFolder {
-      fetchRequest.predicate = NSPredicate(
-        format: "%K == %@ AND NOT (%K IN %@)",
-        #keyPath(LibraryItem.folder.relativePath),
-        parentFolder,
-        #keyPath(LibraryItem.relativePath),
-        relativePaths
-      )
-    } else {
-      fetchRequest.predicate = NSPredicate(
-        format: "%K != nil AND NOT (%K IN %@)",
-        #keyPath(LibraryItem.library),
-        #keyPath(LibraryItem.relativePath),
-        relativePaths
-      )
+        if let parentFolder = parentFolder {
+          fetchRequest.predicate = NSPredicate(
+            format: "%K == %@ AND NOT (%K IN %@)",
+            #keyPath(LibraryItem.folder.relativePath),
+            parentFolder,
+            #keyPath(LibraryItem.relativePath),
+            relativePaths
+          )
+        } else {
+          fetchRequest.predicate = NSPredicate(
+            format: "%K != nil AND NOT (%K IN %@)",
+            #keyPath(LibraryItem.library),
+            #keyPath(LibraryItem.relativePath),
+            relativePaths
+          )
+        }
+
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+        continuation.resume(returning: self?.parseFetchedItems(from: results))
+      }
     }
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return parseFetchedItems(from: results)
   }
 
   public func getItemProperty(_ property: String, relativePath: String) -> Any? {
+    return getItemProperty(property, relativePath: relativePath, context: dataManager.getContext())
+  }
+
+  func getItemProperty(_ property: String, relativePath: String, context: NSManagedObjectContext) -> Any? {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
     fetchRequest.propertiesToFetch = [property]
     fetchRequest.predicate = NSPredicate(
@@ -809,7 +914,7 @@ extension LibraryService {
     fetchRequest.resultType = .dictionaryResultType
     fetchRequest.fetchLimit = 1
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest).first as? [String: Any]
+    let results = try? context.fetch(fetchRequest).first as? [String: Any]
 
     return results?[property]
   }
@@ -820,30 +925,39 @@ extension LibraryService {
     scope: SimpleItemType,
     limit: Int?,
     offset: Int?
-  ) -> [SimpleLibraryItem]? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-    fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
-    fetchRequest.predicate = buildFilterPredicate(
-      relativePath: relativePath,
-      query: query,
-      scope: scope
-    )
+  ) async -> [SimpleLibraryItem]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard let self else {
+          continuation.resume(returning: nil)
+          return
+        }
 
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.lastPlayDate), ascending: false)
-    fetchRequest.sortDescriptors = [sort]
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
+        fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
+        fetchRequest.resultType = .dictionaryResultType
+        fetchRequest.predicate = buildFilterPredicate(
+          relativePath: relativePath,
+          query: query,
+          scope: scope
+        )
 
-    if let limit = limit {
-      fetchRequest.fetchLimit = limit
+        let sort = NSSortDescriptor(key: #keyPath(LibraryItem.lastPlayDate), ascending: false)
+        fetchRequest.sortDescriptors = [sort]
+
+        if let limit = limit {
+          fetchRequest.fetchLimit = limit
+        }
+
+        if let offset = offset {
+          fetchRequest.fetchOffset = offset
+        }
+
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+
+        continuation.resume(returning: parseFetchedItems(from: results))
+      }
     }
-
-    if let offset = offset {
-      fetchRequest.fetchOffset = offset
-    }
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return parseFetchedItems(from: results)
   }
 
   func findFirstItem(
@@ -851,50 +965,54 @@ extension LibraryService {
     rankPredicate: NSPredicate?,
     sortAscending: Bool,
     isUnfinished: Bool?
-  ) -> SimpleLibraryItem? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
+  ) async -> SimpleLibraryItem? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
 
-    let pathPredicate: NSPredicate
+        let pathPredicate: NSPredicate
 
-    if let parentFolder = parentFolder {
-      pathPredicate = NSPredicate(
-        format: "%K == %@", #keyPath(LibraryItem.folder.relativePath), parentFolder
-      )
-    } else {
-      pathPredicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
+        if let parentFolder = parentFolder {
+          pathPredicate = NSPredicate(
+            format: "%K == %@", #keyPath(LibraryItem.folder.relativePath), parentFolder
+          )
+        } else {
+          pathPredicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
+        }
+
+        var predicates = [
+          pathPredicate
+        ]
+
+        if let rankPredicate = rankPredicate {
+          predicates.append(rankPredicate)
+        }
+
+        if isUnfinished != nil {
+          // TODO: Add default value for `isFinished`
+          predicates.append(NSPredicate(
+            format: "%K == 0 || %K == nil",
+            #keyPath(LibraryItem.isFinished),
+            #keyPath(LibraryItem.isFinished)
+          ))
+        }
+
+        fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: sortAscending)
+        fetchRequest.sortDescriptors = [sort]
+        fetchRequest.fetchLimit = 1
+        fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
+        fetchRequest.resultType = .dictionaryResultType
+
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+
+        continuation.resume(returning: self?.parseFetchedItems(from: results)?.first)
+      }
     }
-
-    var predicates = [
-      pathPredicate
-    ]
-
-    if let rankPredicate = rankPredicate {
-      predicates.append(rankPredicate)
-    }
-
-    if isUnfinished != nil {
-      // TODO: Add default value for `isFinished`
-      predicates.append(NSPredicate(
-        format: "%K == 0 || %K == nil",
-        #keyPath(LibraryItem.isFinished),
-        #keyPath(LibraryItem.isFinished)
-      ))
-    }
-
-    fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: sortAscending)
-    fetchRequest.sortDescriptors = [sort]
-    fetchRequest.fetchLimit = 1
-    fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return parseFetchedItems(from: results)?.first
   }
 
-  public func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem? {
-    return findFirstItem(
+  public func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) async -> SimpleLibraryItem? {
+    return await findFirstItem(
       in: parentFolder,
       rankPredicate: nil,
       sortAscending: true,
@@ -902,12 +1020,12 @@ extension LibraryService {
     )
   }
 
-  public func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem? {
+  public func findFirstItem(in parentFolder: String?, beforeRank: Int16?) async -> SimpleLibraryItem? {
     var rankPredicate: NSPredicate?
     if let beforeRank = beforeRank {
       rankPredicate = NSPredicate(format: "%K < %d", #keyPath(LibraryItem.orderRank), beforeRank)
     }
-    return findFirstItem(
+    return await findFirstItem(
       in: parentFolder,
       rankPredicate: rankPredicate,
       sortAscending: false,
@@ -919,12 +1037,12 @@ extension LibraryService {
     in parentFolder: String?,
     afterRank: Int16?,
     isUnfinished: Bool?
-  ) -> SimpleLibraryItem? {
+  ) async -> SimpleLibraryItem? {
     var rankPredicate: NSPredicate?
     if let afterRank = afterRank {
       rankPredicate = NSPredicate(format: "%K > %d", #keyPath(LibraryItem.orderRank), afterRank)
     }
-    return findFirstItem(
+    return await findFirstItem(
       in: parentFolder,
       rankPredicate: rankPredicate,
       sortAscending: true,
@@ -932,53 +1050,77 @@ extension LibraryService {
     )
   }
 
-  public func getChapters(from relativePath: String) -> [SimpleChapter]? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Chapter")
-    fetchRequest.propertiesToFetch = ["title", "start", "duration", "index"]
-    fetchRequest.resultType = .dictionaryResultType
-    fetchRequest.predicate = NSPredicate(format: "%K == %@",
-                                         #keyPath(Chapter.book.relativePath),
-                                         relativePath)
-    let sort = NSSortDescriptor(key: #keyPath(Chapter.index), ascending: true)
-    fetchRequest.sortDescriptors = [sort]
+  public func getChapters(from relativePath: String) async -> [SimpleChapter]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { context in
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Chapter")
+        fetchRequest.propertiesToFetch = ["title", "start", "duration", "index"]
+        fetchRequest.resultType = .dictionaryResultType
+        fetchRequest.predicate = NSPredicate(format: "%K == %@",
+                                             #keyPath(Chapter.book.relativePath),
+                                             relativePath)
+        let sort = NSSortDescriptor(key: #keyPath(Chapter.index), ascending: true)
+        fetchRequest.sortDescriptors = [sort]
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
 
-    return results?.compactMap({ dictionary -> SimpleChapter? in
-      guard
-        let title = dictionary["title"] as? String,
-        let start = dictionary["start"] as? Double,
-        let duration = dictionary["duration"] as? Double,
-        let index = dictionary["index"] as? Int16
-      else { return nil }
+        let chapters = results?.compactMap({ dictionary -> SimpleChapter? in
+          guard
+            let title = dictionary["title"] as? String,
+            let start = dictionary["start"] as? Double,
+            let duration = dictionary["duration"] as? Double,
+            let index = dictionary["index"] as? Int16
+          else { return nil }
 
-      return SimpleChapter(
-        title: title,
-        start: start,
-        duration: duration,
-        index: index
-      )
-    })
+          return SimpleChapter(
+            title: title,
+            start: start,
+            duration: duration,
+            index: index
+          )
+        })
+
+        continuation.resume(returning: chapters)
+      }
+    }
   }
 }
 
 // MARK: - Metadata update
 extension LibraryService {
-  public func createBook(from url: URL) -> Book {
-    let newBook = Book(from: url, context: self.dataManager.getContext())
-    self.dataManager.saveContext()
-    return newBook
+  public func createBook(from url: URL) async -> Book {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let newBook = Book(from: url, context: context)
+        self?.dataManager.saveContext(context)
+
+        continuation.resume(returning: newBook)
+      }
+    }
   }
 
-  public func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) {
-    guard let book = self.getItem(with: relativePath) as? Book else { return }
+  public func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { context in
+        let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
+        fetchRequest.fetchLimit = 1
 
-    book.loadChaptersIfNeeded(from: asset, context: dataManager.getContext())
+        guard let book = try? context.fetch(fetchRequest).first as? Book else {
+          continuation.resume()
+          return
+        }
 
-    dataManager.saveContext()
+        book.loadChaptersIfNeeded(from: asset, context: context)
+
+        context.saveContext()
+
+        continuation.resume()
+      }
+    }
   }
 
-  func createFolderOnDisk(title: String, inside relativePath: String?) throws {
+  func createFolderOnDisk(title: String, inside relativePath: String?, context: NSManagedObjectContext) throws {
     let processedFolder = DataManager.getProcessedFolderURL()
     let destinationURL: URL
 
@@ -988,11 +1130,11 @@ extension LibraryService {
       destinationURL = processedFolder.appendingPathComponent(title)
     }
 
-    try? removeFolderIfNeeded(destinationURL)
+    try? removeFolderIfNeeded(destinationURL, context: context)
     try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: false, attributes: nil)
   }
 
-  func hasLibraryLinked(item: LibraryItem) -> Bool {
+  func hasLibraryLinked(item: LibraryItem, context: NSManagedObjectContext) -> Bool {
     var keyPath = item.relativePath.split(separator: "/")
       .dropLast()
       .map({ _ in return "folder" })
@@ -1004,20 +1146,20 @@ extension LibraryService {
 
     fetchRequest.predicate = NSPredicate(format: "relativePath == %@ && \(keyPath) != nil", item.relativePath)
 
-    return (try? self.dataManager.getContext().fetch(fetchRequest).first) != nil
+    return (try? context.fetch(fetchRequest).first) != nil
   }
 
-  func removeFolderIfNeeded(_ fileURL: URL) throws {
+  func removeFolderIfNeeded(_ fileURL: URL, context: NSManagedObjectContext) throws {
     guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
 
     let folderPath = fileURL.relativePath(to: DataManager.getProcessedFolderURL())
 
     // Delete folder if it belongs to an orphaned folder
-    if let existingFolder = getItemReference(with: folderPath) as? Folder {
-      if !self.hasLibraryLinked(item: existingFolder) {
+    if let existingFolder = getItemReference(with: folderPath, context: context) as? Folder {
+      if !self.hasLibraryLinked(item: existingFolder, context: context) {
         // Delete folder if it doesn't belong to active folder
         try FileManager.default.removeItem(at: fileURL)
-        self.dataManager.delete(existingFolder)
+        self.dataManager.delete(existingFolder, context: context)
       }
     } else {
       // Delete folder if it doesn't belong to active folder
@@ -1025,80 +1167,105 @@ extension LibraryService {
     }
   }
 
-  public func createFolder(with title: String, inside relativePath: String?) throws -> SimpleLibraryItem {
-    try createFolderOnDisk(title: title, inside: relativePath)
+  public func createFolder(with title: String, inside relativePath: String?) async throws -> SimpleLibraryItem {
+    return try await withCheckedThrowingContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard let self else {
+          continuation.resume(throwing: BookPlayerError.runtimeError("Deallocated self"))
+          return
+        }
 
-    let newFolder = Folder(title: title, context: dataManager.getContext())
-    newFolder.orderRank = getNextOrderRank(in: relativePath)
-    /// Override relative path
-    if let relativePath {
-      newFolder.relativePath = "\(relativePath)/\(title)"
-    }
+        do {
+          try createFolderOnDisk(title: title, inside: relativePath, context: context)
+        } catch {
+          continuation.resume(throwing: error)
+          return
+        }
 
-    // insert into existing folder or library at index
-    if let parentPath = relativePath {
-      guard
-        let parentFolder = getItemReference(with: parentPath) as? Folder
-      else {
-        throw BookPlayerError.runtimeError("Parent folder does not exist at: \(parentPath)")
+        let newFolder = Folder(title: title, context: context)
+        newFolder.orderRank = getNextOrderRank(in: relativePath, context: context)
+        /// Override relative path
+        if let relativePath {
+          newFolder.relativePath = "\(relativePath)/\(title)"
+        }
+
+        // insert into existing folder or library at index
+        if let parentPath = relativePath {
+          guard
+            let parentFolder = getItemReference(with: parentPath, context: context) as? Folder
+          else {
+            continuation.resume(throwing: BookPlayerError.runtimeError("Parent folder does not exist at: \(parentPath)"))
+            return
+          }
+
+          let existingParentContentsCount = getMaxItemsCount(at: parentPath, context: context)
+          parentFolder.addToItems(newFolder)
+          parentFolder.details = String.localizedStringWithFormat("files_title".localized, existingParentContentsCount + 1)
+        } else {
+          getLibraryReference(context: context).addToItems(newFolder)
+        }
+
+        dataManager.saveContext(context)
+
+        continuation.resume(returning: SimpleLibraryItem(from: newFolder))
       }
-
-      let existingParentContentsCount = getMaxItemsCount(at: parentPath)
-      parentFolder.addToItems(newFolder)
-      parentFolder.details = String.localizedStringWithFormat("files_title".localized, existingParentContentsCount + 1)
-    } else {
-      getLibraryReference().addToItems(newFolder)
     }
-
-    dataManager.saveContext()
-
-    return SimpleLibraryItem(from: newFolder)
   }
 
-  public func updateFolder(at relativePath: String, type: SimpleItemType) throws {
-    guard let folder = self.getItem(with: relativePath) as? Folder else {
-      throw BookPlayerError.runtimeError("Can't find the folder")
+  public func updateFolder(at relativePath: String, type: SimpleItemType) async throws {
+    return try await withCheckedThrowingContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          let folder = self.getItem(with: relativePath, context: context) as? Folder
+        else {
+          continuation.resume(throwing: BookPlayerError.runtimeError("Can't find the folder"))
+          return
+        }
+
+        var metadataUpdates: [String: Any] = [
+          #keyPath(LibraryItem.relativePath): relativePath,
+          #keyPath(LibraryItem.type): type.rawValue,
+        ]
+
+        switch type {
+        case .folder:
+          folder.type = .folder
+          folder.lastPlayDate = nil
+          metadataUpdates[#keyPath(LibraryItem.lastPlayDate)] = ""
+        case .bound:
+          guard let items = folder.items?.allObjects as? [Book] else {
+            continuation.resume(throwing: BookPlayerError.runtimeError("The folder needs to only contain book items"))
+            return
+          }
+
+          guard !items.isEmpty else {
+            continuation.resume(throwing: BookPlayerError.runtimeError("The folder can't be empty"))
+            return
+          }
+
+          for item in items {
+            item.lastPlayDate = nil
+            metadataPassthroughPublisher.send([
+              #keyPath(LibraryItem.relativePath): item.relativePath!,
+              #keyPath(LibraryItem.lastPlayDate): "",
+            ])
+          }
+
+          folder.type = .bound
+        case .book:
+          return
+        }
+
+        metadataPassthroughPublisher.send(metadataUpdates)
+
+        self.dataManager.saveContext(context)
+      }
     }
-
-    var metadataUpdates: [String: Any] = [
-      #keyPath(LibraryItem.relativePath): relativePath,
-      #keyPath(LibraryItem.type): type.rawValue,
-    ]
-
-    switch type {
-    case .folder:
-      folder.type = .folder
-      folder.lastPlayDate = nil
-      metadataUpdates[#keyPath(LibraryItem.lastPlayDate)] = ""
-    case .bound:
-      guard let items = folder.items?.allObjects as? [Book] else {
-        throw BookPlayerError.runtimeError("The folder needs to only contain book items")
-      }
-
-      guard !items.isEmpty else {
-        throw BookPlayerError.runtimeError("The folder can't be empty")
-      }
-
-      for item in items {
-        item.lastPlayDate = nil
-        metadataPassthroughPublisher.send([
-          #keyPath(LibraryItem.relativePath): item.relativePath!,
-          #keyPath(LibraryItem.lastPlayDate): "",
-        ])
-      }
-
-      folder.type = .bound
-    case .book:
-      return
-    }
-
-    metadataPassthroughPublisher.send(metadataUpdates)
-
-    self.dataManager.saveContext()
   }
 
   /// Internal function to calculate the entire folder's progress
-  func calculateFolderProgress(at relativePath: String) -> (Double, Int) {
+  func calculateFolderProgress(at relativePath: String, context: NSManagedObjectContext) -> (Double, Int) {
     let progressExpression = NSExpressionDescription()
     progressExpression.expression = NSExpression(
       forConditional: NSPredicate(format: "%K == 1", #keyPath(LibraryItem.isFinished)),
@@ -1114,7 +1281,7 @@ extension LibraryService {
     fetchRequest.resultType = .dictionaryResultType
 
     guard
-      let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Double]],
+      let results = try? context.fetch(fetchRequest) as? [[String: Double]],
       !results.isEmpty
     else {
       return (0, 0)
@@ -1129,11 +1296,17 @@ extension LibraryService {
   }
 
   public func rebuildFolderDetails(_ relativePath: String) {
-    guard let folder = getItemReference(with: relativePath) as? Folder else { return }
+    dataManager.performBackgroundTask { [weak self] context in
+      self?.rebuildFolderDetails(relativePath, context: context)
+    }
+  }
 
-    let (progress, contentsCount) = calculateFolderProgress(at: relativePath)
+  func rebuildFolderDetails(_ relativePath: String, context: NSManagedObjectContext) {
+    guard let folder = getItemReference(with: relativePath, context: context) as? Folder else { return }
+
+    let (progress, contentsCount) = calculateFolderProgress(at: relativePath, context: context)
     folder.percentCompleted = progress
-    folder.duration = calculateFolderDuration(at: relativePath)
+    folder.duration = calculateFolderDuration(at: relativePath, context: context)
     folder.details = String.localizedStringWithFormat("files_title".localized, contentsCount)
 
     metadataPassthroughPublisher.send([
@@ -1143,20 +1316,27 @@ extension LibraryService {
       #keyPath(LibraryItem.details): folder.details!,
     ])
 
-    dataManager.saveContext()
+    dataManager.saveContext(context)
 
     if let parentFolderPath = getItemProperty(
       #keyPath(LibraryItem.folder.relativePath),
-      relativePath: relativePath
+      relativePath: relativePath,
+      context: context
     ) as? String {
-      rebuildFolderDetails(parentFolderPath)
+      rebuildFolderDetails(parentFolderPath, context: context)
     }
   }
 
   public func recursiveFolderProgressUpdate(from relativePath: String) {
-    guard let folder = getItemReference(with: relativePath) as? Folder else { return }
+    dataManager.performBackgroundTask { [weak self] context in
+      self?.recursiveFolderProgressUpdate(from: relativePath, context: context)
+    }
+  }
 
-    let (progress, _) = calculateFolderProgress(at: relativePath)
+  func recursiveFolderProgressUpdate(from relativePath: String, context: NSManagedObjectContext) {
+    guard let folder = getItemReference(with: relativePath, context: context) as? Folder else { return }
+
+    let (progress, _) = calculateFolderProgress(at: relativePath, context: context)
     folder.percentCompleted = progress
 
     metadataPassthroughPublisher.send([
@@ -1174,92 +1354,135 @@ extension LibraryService {
       ]
     )
 
-    dataManager.saveContext()
+    dataManager.saveContext(context)
 
     if let parentFolderPath = getItemProperty(
       #keyPath(LibraryItem.folder.relativePath),
-      relativePath: relativePath
+      relativePath: relativePath,
+      context: context
     ) as? String {
-      recursiveFolderProgressUpdate(from: parentFolderPath)
+      recursiveFolderProgressUpdate(from: parentFolderPath, context: context)
     }
   }
 
-  public func renameBook(at relativePath: String, with newTitle: String) {
-    guard let item = self.getItemReference(with: relativePath) else { return }
+  public func renameBook(at relativePath: String, with newTitle: String) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          let item = self.getItemReference(with: relativePath, context: context)
+        else {
+          continuation.resume()
+          return
+        }
 
-    item.title = newTitle
+        item.title = newTitle
 
-    metadataPassthroughPublisher.send([
-      #keyPath(LibraryItem.relativePath): relativePath,
-      #keyPath(LibraryItem.title): newTitle,
-    ])
+        metadataPassthroughPublisher.send([
+          #keyPath(LibraryItem.relativePath): relativePath,
+          #keyPath(LibraryItem.title): newTitle,
+        ])
 
-    self.dataManager.saveContext()
+        self.dataManager.saveContext(context)
+      }
+    }
   }
 
-  public func renameFolder(at relativePath: String, with newTitle: String) throws -> String {
-    guard let folder = self.getItemReference(with: relativePath) as? Folder else { return relativePath }
+  // swiftlint:disable:next function_body_length
+  public func renameFolder(at relativePath: String, with newTitle: String) async throws -> String {
+    return try await withCheckedThrowingContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          let folder = self.getItemReference(with: relativePath, context: context) as? Folder
+        else {
+          continuation.resume(returning: relativePath)
+          return
+        }
 
-    let processedFolderURL = DataManager.getProcessedFolderURL()
+        let processedFolderURL = DataManager.getProcessedFolderURL()
 
-    let sourceUrl = processedFolderURL
-      .appendingPathComponent(folder.relativePath)
+        let sourceUrl = processedFolderURL
+          .appendingPathComponent(folder.relativePath)
 
-    let destinationUrl: URL
-    let newRelativePath: String
+        let destinationUrl: URL
+        let newRelativePath: String
 
-    if let parentFolderPath = getItemProperty(
-      #keyPath(LibraryItem.folder.relativePath),
-      relativePath: folder.relativePath
-    ) as? String {
-      destinationUrl = processedFolderURL
-        .appendingPathComponent(parentFolderPath)
-        .appendingPathComponent(newTitle)
-      newRelativePath = destinationUrl.relativePath(to: processedFolderURL)
-    } else {
-      destinationUrl = processedFolderURL
-        .appendingPathComponent(newTitle)
-      newRelativePath = newTitle
+        if let parentFolderPath = getItemProperty(
+          #keyPath(LibraryItem.folder.relativePath),
+          relativePath: folder.relativePath,
+          context: context
+        ) as? String {
+          destinationUrl = processedFolderURL
+            .appendingPathComponent(parentFolderPath)
+            .appendingPathComponent(newTitle)
+          newRelativePath = destinationUrl.relativePath(to: processedFolderURL)
+        } else {
+          destinationUrl = processedFolderURL
+            .appendingPathComponent(newTitle)
+          newRelativePath = newTitle
+        }
+
+        do {
+          try FileManager.default.moveItem(
+            at: sourceUrl,
+            to: destinationUrl
+          )
+        } catch {
+          continuation.resume(throwing: error)
+          return
+        }
+
+        folder.originalFileName = newTitle
+        folder.relativePath = newRelativePath
+        folder.title = newTitle
+
+        if let items = fetchRawContents(
+          at: relativePath,
+          propertiesToFetch: [
+            #keyPath(LibraryItem.relativePath),
+            #keyPath(LibraryItem.originalFileName)
+          ],
+          context: context
+        ) {
+          for item in items {
+            rebuildRelativePaths(for: item, parentFolder: folder.relativePath, context: context)
+          }
+        }
+
+        self.dataManager.saveContext(context)
+
+        continuation.resume(returning: newRelativePath)
+      }
     }
-
-    try FileManager.default.moveItem(
-      at: sourceUrl,
-      to: destinationUrl
-    )
-
-    folder.originalFileName = newTitle
-    folder.relativePath = newRelativePath
-    folder.title = newTitle
-
-    if let items = fetchRawContents(
-      at: relativePath,
-      propertiesToFetch: [
-        #keyPath(LibraryItem.relativePath),
-        #keyPath(LibraryItem.originalFileName)
-      ]
-    ) {
-      items.forEach({ rebuildRelativePaths(for: $0, parentFolder: folder.relativePath) })
-    }
-
-    self.dataManager.saveContext()
-
-    return newRelativePath
   }
 
-  public func updateDetails(at relativePath: String, details: String) {
-    guard let item = self.getItemReference(with: relativePath) else { return }
+  public func updateDetails(at relativePath: String, details: String) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          let item = self.getItemReference(with: relativePath, context: context)
+        else {
+          continuation.resume()
+          return
+        }
 
-    item.details = details
+        item.details = details
 
-    metadataPassthroughPublisher.send([
-      #keyPath(LibraryItem.relativePath): relativePath,
-      #keyPath(LibraryItem.details): details,
-    ])
-    self.dataManager.saveContext()
+        metadataPassthroughPublisher.send([
+          #keyPath(LibraryItem.relativePath): relativePath,
+          #keyPath(LibraryItem.details): details,
+        ])
+
+        self.dataManager.saveContext(context)
+        continuation.resume()
+      }
+    }
   }
 
   /// Internal function to calculate the entire folder's duration
-  func calculateFolderDuration(at relativePath: String) -> Double {
+  func calculateFolderDuration(at relativePath: String, context: NSManagedObjectContext) -> Double {
     let durationExpression = NSExpressionDescription()
     durationExpression.expression = NSExpression(
       forFunction: "sum:",
@@ -1274,7 +1497,7 @@ extension LibraryService {
     fetchRequest.resultType = .dictionaryResultType
 
     guard
-      let results = try? self.dataManager.getContext().fetch(fetchRequest).first as? [String: Double]
+      let results = try? context.fetch(fetchRequest).first as? [String: Double]
     else {
       return 0
     }
@@ -1287,74 +1510,97 @@ extension LibraryService {
     inside folderRelativePath: String?,
     sourceIndexPath: IndexPath,
     destinationIndexPath: IndexPath
-  ) {
-    guard
-      var contents = fetchRawContents(
-        at: folderRelativePath,
-        propertiesToFetch: [
-          #keyPath(LibraryItem.relativePath),
-          #keyPath(LibraryItem.orderRank)
-        ]
-      )
-    else { return }
+  ) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          var contents = fetchRawContents(
+            at: folderRelativePath,
+            propertiesToFetch: [
+              #keyPath(LibraryItem.relativePath),
+              #keyPath(LibraryItem.orderRank)
+            ],
+            context: context
+          )
+        else {
+          continuation.resume()
+          return
+        }
 
-    let movedItem = contents.remove(at: sourceIndexPath.row)
-    contents.insert(movedItem, at: destinationIndexPath.row)
+        let movedItem = contents.remove(at: sourceIndexPath.row)
+        contents.insert(movedItem, at: destinationIndexPath.row)
 
-    /// Rebuild order rank
-    for (index, item) in contents.enumerated() {
-      item.orderRank = Int16(index)
-      metadataPassthroughPublisher.send([
-        #keyPath(LibraryItem.relativePath): item.relativePath!,
-        #keyPath(LibraryItem.orderRank): item.orderRank,
-      ])
+        /// Rebuild order rank
+        for (index, item) in contents.enumerated() {
+          item.orderRank = Int16(index)
+          metadataPassthroughPublisher.send([
+            #keyPath(LibraryItem.relativePath): item.relativePath!,
+            #keyPath(LibraryItem.orderRank): item.orderRank,
+          ])
+        }
+
+        self.dataManager.saveContext(context)
+        continuation.resume()
+      }
     }
-
-    self.dataManager.saveContext()
   }
 
-  public func sortContents(at relativePath: String?, by type: SortType) {
-    guard
-      let results = fetchRawContents(at: relativePath, propertiesToFetch: type.fetchProperties()),
-      !results.isEmpty
-    else { return }
+  public func sortContents(at relativePath: String?, by type: SortType) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard
+          let self,
+          let results = fetchRawContents(at: relativePath, propertiesToFetch: type.fetchProperties(), context: context),
+          !results.isEmpty
+        else {
+          continuation.resume()
+          return
+        }
 
-    let sortedResults = type.sortItems(results)
+        let sortedResults = type.sortItems(results)
 
-    /// Rebuild order rank
-    for (index, item) in sortedResults.enumerated() {
-      item.orderRank = Int16(index)
-      metadataPassthroughPublisher.send([
-        #keyPath(LibraryItem.relativePath): item.relativePath!,
-        #keyPath(LibraryItem.orderRank): item.orderRank,
-      ])
+        /// Rebuild order rank
+        for (index, item) in sortedResults.enumerated() {
+          item.orderRank = Int16(index)
+          metadataPassthroughPublisher.send([
+            #keyPath(LibraryItem.relativePath): item.relativePath!,
+            #keyPath(LibraryItem.orderRank): item.orderRank,
+          ])
+        }
+
+        self.dataManager.saveContext(context)
+        continuation.resume()
+      }
     }
-
-    self.dataManager.saveContext()
   }
 
   public func updatePlaybackTime(relativePath: String, time: Double, date: Date, scheduleSave: Bool) {
-    guard let item = self.getItem(with: relativePath) else { return }
+    dataManager.performBackgroundTask { [weak self] context in
+      guard
+        let self,
+        let item = self.getItem(with: relativePath, context: context)
+      else { return }
 
-    /// Metadata update already handled by the socket for playback
-    item.currentTime = time
-    item.lastPlayDate = date
-    item.percentCompleted = round((item.currentTime / item.duration) * 100)
+      /// Metadata update already handled by the socket for playback
+      item.currentTime = time
+      item.lastPlayDate = date
+      item.percentCompleted = round((item.currentTime / item.duration) * 100)
 
-    if let parentFolderPath = item.folder?.relativePath {
-      recursiveFolderLastPlayedDateUpdate(from: parentFolderPath, date: date)
+      if let parentFolderPath = item.folder?.relativePath {
+        recursiveFolderLastPlayedDateUpdate(from: parentFolderPath, date: date, context: context)
+      }
+
+      if scheduleSave {
+        dataManager.scheduleSaveContext(context)
+      } else {
+        dataManager.saveContext(context)
+      }
     }
-
-    if scheduleSave {
-      dataManager.scheduleSaveContext()
-    } else {
-      dataManager.saveContext()
-    }
-
   }
 
-  func recursiveFolderLastPlayedDateUpdate(from relativePath: String, date: Date) {
-    guard let folder = getItemReference(with: relativePath) as? Folder else { return }
+  func recursiveFolderLastPlayedDateUpdate(from relativePath: String, date: Date, context: NSManagedObjectContext) {
+    guard let folder = getItemReference(with: relativePath, context: context) as? Folder else { return }
 
     folder.lastPlayDate = date
 
@@ -1365,54 +1611,69 @@ extension LibraryService {
 
     if let parentFolderPath = getItemProperty(
       #keyPath(LibraryItem.folder.relativePath),
-      relativePath: relativePath
+      relativePath: relativePath,
+      context: context
     ) as? String {
-      recursiveFolderLastPlayedDateUpdate(from: parentFolderPath, date: date)
+      recursiveFolderLastPlayedDateUpdate(from: parentFolderPath, date: date, context: context)
     }
   }
 
   public func updateBookSpeed(at relativePath: String, speed: Float) {
-    guard let item = self.getItem(with: relativePath) else { return }
+    dataManager.performBackgroundTask { [weak self] context in
+      guard
+        let self,
+        let item = self.getItem(with: relativePath, context: context)
+      else { return }
 
-    item.speed = speed
-    item.folder?.speed = speed
+      item.speed = speed
+      item.folder?.speed = speed
 
-    metadataPassthroughPublisher.send([
-      #keyPath(LibraryItem.relativePath): relativePath,
-      #keyPath(LibraryItem.speed): speed,
-    ])
-
-    if let folder = item.folder,
-       let folderPath = folder.relativePath {
       metadataPassthroughPublisher.send([
-        #keyPath(LibraryItem.relativePath): folderPath,
+        #keyPath(LibraryItem.relativePath): relativePath,
         #keyPath(LibraryItem.speed): speed,
       ])
-    }
 
-    self.dataManager.saveContext()
+      if let folder = item.folder,
+         let folderPath = folder.relativePath {
+        metadataPassthroughPublisher.send([
+          #keyPath(LibraryItem.relativePath): folderPath,
+          #keyPath(LibraryItem.speed): speed,
+        ])
+      }
+
+      self.dataManager.saveContext(context)
+    }
   }
 
   public func getItemSpeed(at relativePath: String) -> Float {
-    guard let item = self.getItem(with: relativePath) else { return 1.0 }
+    guard let item = self.getItem(with: relativePath, context: dataManager.getContext()) else { return 1.0 }
 
     return item.folder?.speed ?? item.speed
   }
 
-  public func markAsFinished(flag: Bool, relativePath: String) {
-    guard let item = self.getItem(with: relativePath) else { return }
+  public func markAsFinished(flag: Bool, relativePath: String) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        self?.markAsFinished(flag: flag, relativePath: relativePath, context: context)
+        continuation.resume()
+      }
+    }
+  }
+
+  func markAsFinished(flag: Bool, relativePath: String, context: NSManagedObjectContext) {
+    guard let item = self.getItem(with: relativePath, context: context) else { return }
 
     switch item {
     case let folder as Folder:
-      self.markAsFinished(flag: flag, folder: folder)
+      self.markAsFinished(flag: flag, folder: folder, context: context)
     case let book as Book:
-      self.markAsFinished(flag: flag, book: book)
+      self.markAsFinished(flag: flag, book: book, context: context)
     default:
       break
     }
   }
 
-  func markAsFinished(flag: Bool, book: Book) {
+  func markAsFinished(flag: Bool, book: Book, context: NSManagedObjectContext) {
     var metadataUpdates: [String: Any] = [
       #keyPath(LibraryItem.relativePath): book.relativePath!,
       #keyPath(LibraryItem.isFinished): flag,
@@ -1428,10 +1689,10 @@ extension LibraryService {
 
     metadataPassthroughPublisher.send(metadataUpdates)
 
-    self.dataManager.saveContext()
+    self.dataManager.saveContext(context)
   }
 
-  func markAsFinished(flag: Bool, folder: Folder) {
+  func markAsFinished(flag: Bool, folder: Folder, context: NSManagedObjectContext) {
     folder.isFinished = flag
 
     metadataPassthroughPublisher.send([
@@ -1439,25 +1700,39 @@ extension LibraryService {
       #keyPath(LibraryItem.isFinished): flag,
     ])
 
-    guard let itemIdentifiers = getItemIdentifiers(in: folder.relativePath) else { return }
+    guard let itemIdentifiers = getItemIdentifiers(in: folder.relativePath, context: context) else {
+      context.saveContext()
+      return
+    }
 
-    itemIdentifiers.forEach({ self.markAsFinished(flag: flag, relativePath: $0) })
+    for itemIdentifier in itemIdentifiers {
+      markAsFinished(flag: flag, relativePath: itemIdentifier, context: context)
+    }
   }
 
-  public func jumpToStart(relativePath: String) {
-    guard let item = getItemReference(with: relativePath) else { return }
+  public func jumpToStart(relativePath: String) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        self?.jumpToStart(relativePath: relativePath, context: context)
+        continuation.resume()
+      }
+    }
+  }
+
+  func jumpToStart(relativePath: String, context: NSManagedObjectContext) {
+    guard let item = getItemReference(with: relativePath, context: context) else { return }
 
     switch item {
     case let folder as Folder:
-      self.jumpToStart(folder: folder)
+      self.jumpToStart(folder: folder, context: context)
     case let book as Book:
-      self.jumpToStart(book: book)
+      self.jumpToStart(book: book, context: context)
     default:
       break
     }
   }
 
-  func jumpToStart(book: Book) {
+  func jumpToStart(book: Book, context: NSManagedObjectContext) {
     book.currentTime = 0
     book.percentCompleted = 0
     book.isFinished = false
@@ -1469,10 +1744,10 @@ extension LibraryService {
       #keyPath(LibraryItem.isFinished): false,
     ])
 
-    self.dataManager.saveContext()
+    dataManager.saveContext(context)
   }
 
-  func jumpToStart(folder: Folder) {
+  func jumpToStart(folder: Folder, context: NSManagedObjectContext) {
     folder.currentTime = 0
     folder.percentCompleted = 0
     folder.isFinished = false
@@ -1484,64 +1759,110 @@ extension LibraryService {
       #keyPath(LibraryItem.isFinished): false,
     ])
 
-    guard let itemIdentifiers = getItemIdentifiers(in: folder.relativePath) else { return }
+    guard let itemIdentifiers = getItemIdentifiers(in: folder.relativePath, context: context) else {
+      context.saveContext()
+      return
+    }
 
-    itemIdentifiers.forEach({ self.jumpToStart(relativePath: $0) })
+    for itemIdentifier in itemIdentifiers {
+      jumpToStart(relativePath: itemIdentifier, context: context)
+    }
   }
 }
 
 // MARK: - Time record
-extension LibraryService {
-  public func getCurrentPlaybackRecord() -> PlaybackRecord {
-    let calendar = Calendar.current
 
+extension LibraryService {
+  public func getCurrentPlaybackRecordTime() async -> Double {
+    let calendar = Calendar.current
     let today = Date()
     let dateFrom = calendar.startOfDay(for: today)
     let dateTo = calendar.date(byAdding: .day, value: 1, to: dateFrom)!
 
-    let record = self.getPlaybackRecords(from: dateFrom, to: dateTo)?.first
-
-    return record ?? PlaybackRecord.create(in: self.dataManager.getContext())
+    return await getFirstPlaybackRecordTime(from: dateFrom, to: dateTo)
   }
 
-  public func getPlaybackRecords(from startDate: Date, to endDate: Date) -> [PlaybackRecord]? {
+  public func getFirstPlaybackRecordTime(
+    from startDate: Date,
+    to endDate: Date
+  ) async -> Double {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let playbackRecord = self?.getFirstPlaybackRecord(from: startDate, to: endDate, context: context)
+
+        continuation.resume(returning: playbackRecord?.time ?? 0)
+      }
+    }
+  }
+
+  func getCurrentPlaybackRecord(context: NSManagedObjectContext) -> PlaybackRecord {
+    let calendar = Calendar.current
+    let today = Date()
+    let dateFrom = calendar.startOfDay(for: today)
+    let dateTo = calendar.date(byAdding: .day, value: 1, to: dateFrom)!
+
+    if let playbackRecord = getFirstPlaybackRecord(from: dateFrom, to: dateTo, context: context) {
+      return playbackRecord
+    }
+
+    let playbackRecord = PlaybackRecord.create(in: context)
+    context.saveContext()
+
+    return playbackRecord
+  }
+
+  /// Fetch the first playback record found between two dates
+  func getFirstPlaybackRecord(
+    from startDate: Date,
+    to endDate: Date,
+    context: NSManagedObjectContext
+  ) -> PlaybackRecord? {
     let fromPredicate = NSPredicate(format: "date >= %@", startDate as NSDate)
     let toPredicate = NSPredicate(format: "date < %@", endDate as NSDate)
     let datePredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [fromPredicate, toPredicate])
 
     let fetch: NSFetchRequest<PlaybackRecord> = PlaybackRecord.fetchRequest()
     fetch.predicate = datePredicate
-    let context = self.dataManager.getContext()
 
-    return try? context.fetch(fetch)
+    return try? context.fetch(fetch).first
   }
 
-  public func recordTime(_ playbackRecord: PlaybackRecord) {
-    playbackRecord.time += 1
-    self.dataManager.scheduleSaveContext()
-  }
+  public func recordTime() {
+    dataManager.performBackgroundTask { [weak self] context in
+      guard let playbackRecord = self?.getCurrentPlaybackRecord(context: context) else {
+        return
+      }
 
-  public func getTotalListenedTime() -> TimeInterval {
-    let totalTimeExpression = NSExpressionDescription()
-    totalTimeExpression.expression = NSExpression(
-      forFunction: "sum:",
-      arguments: [NSExpression(forKeyPath: #keyPath(PlaybackRecord.time))]
-    )
-    totalTimeExpression.name = "totalTime"
-    totalTimeExpression.expressionResultType = NSAttributeType.doubleAttributeType
-
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "PlaybackRecord")
-    fetchRequest.propertiesToFetch = [totalTimeExpression]
-    fetchRequest.resultType = .dictionaryResultType
-
-    guard
-      let results = try? self.dataManager.getContext().fetch(fetchRequest).first as? [String: Double]
-    else {
-      return 0
+      playbackRecord.time += 1
+      self?.dataManager.scheduleSaveContext(context)
     }
+  }
 
-    return results["totalTime"] ?? 0
+  public func getTotalListenedTime() async -> TimeInterval {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { context in
+        let totalTimeExpression = NSExpressionDescription()
+        totalTimeExpression.expression = NSExpression(
+          forFunction: "sum:",
+          arguments: [NSExpression(forKeyPath: #keyPath(PlaybackRecord.time))]
+        )
+        totalTimeExpression.name = "totalTime"
+        totalTimeExpression.expressionResultType = NSAttributeType.doubleAttributeType
 
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "PlaybackRecord")
+        fetchRequest.propertiesToFetch = [totalTimeExpression]
+        fetchRequest.resultType = .dictionaryResultType
+
+        guard
+          let results = try? context.fetch(fetchRequest).first as? [String: Double]
+        else {
+          continuation.resume(returning: 0)
+          return
+        }
+
+        continuation.resume(returning: results["totalTime"] ?? 0)
+      }
+    }
   }
 }
 
@@ -1596,90 +1917,114 @@ extension LibraryService {
     })
   }
 
-  func getBookmarkReference(from bookmark: SimpleBookmark) -> Bookmark? {
+  func getBookmarkReference(from bookmark: SimpleBookmark, context: NSManagedObjectContext) -> Bookmark? {
+    let fetchRequest = Self.bookmarkReferenceFetchRequest(bookmark: bookmark)
 
-    let fetchRequest: NSFetchRequest<Bookmark> = Bookmark.fetchRequest()
-    fetchRequest.predicate = NSPredicate(
-      format: "%K == %@ && type == %d && time == %f",
-      #keyPath(Bookmark.item.relativePath),
-      bookmark.relativePath,
-      bookmark.type.rawValue,
-      bookmark.time
-    )
-    fetchRequest.fetchLimit = 1
-    fetchRequest.propertiesToFetch = [
-      #keyPath(Bookmark.time),
-      #keyPath(Bookmark.note),
-      #keyPath(Bookmark.type),
-    ]
-
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
   }
 
-  public func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]? {
-    let fetchRequest = buildBookmarksFetchRequest(
-      properties: SimpleBookmark.fetchRequestProperties,
-      time: nil,
-      relativePath: relativePath,
-      type: type
-    )
+  public func getBookmarks(of type: BookmarkType, relativePath: String) async -> [SimpleBookmark]? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        let fetchRequest = Self.simpleBookmarkFetchRequest(
+          time: nil,
+          relativePath: relativePath,
+          type: type
+        )
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
 
-    return parseFetchedBookmarks(from: results)
+        continuation.resume(returning: self?.parseFetchedBookmarks(from: results))
+      }
+    }
   }
 
-  public func getBookmark(at time: Double, relativePath: String, type: BookmarkType) -> SimpleBookmark? {
-    let fetchRequest = buildBookmarksFetchRequest(
-      properties: SimpleBookmark.fetchRequestProperties,
+  public func getBookmark(
+    at time: Double,
+    relativePath: String,
+    type: BookmarkType
+  ) -> SimpleBookmark? {
+    return getBookmark(at: time, relativePath: relativePath, type: type, context: dataManager.getContext())
+  }
+
+  func getBookmark(
+    at time: Double,
+    relativePath: String,
+    type: BookmarkType,
+    context: NSManagedObjectContext
+  ) -> SimpleBookmark? {
+    let fetchRequest = Self.simpleBookmarkFetchRequest(
       time: time,
       relativePath: relativePath,
       type: type
     )
     fetchRequest.fetchLimit = 1
 
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
+    let results = try? context.fetch(fetchRequest) as? [[String: Any]]
 
     return parseFetchedBookmarks(from: results)?.first
   }
 
-  public func createBookmark(at time: Double, relativePath: String, type: BookmarkType) -> SimpleBookmark? {
-    let finalTime = floor(time)
+  public func createBookmark(at time: Double, relativePath: String, type: BookmarkType) async -> SimpleBookmark? {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        guard let self else {
+          continuation.resume(returning: nil)
+          return
+        }
 
-    if let bookmark = self.getBookmark(at: finalTime, relativePath: relativePath, type: type) {
-      return bookmark
+        let finalTime = floor(time)
+
+        if let bookmark = self.getBookmark(at: finalTime, relativePath: relativePath, type: type, context: context) {
+          continuation.resume(returning: bookmark)
+          return
+        }
+
+        guard let item = self.getItemReference(with: relativePath, context: context) else {
+          continuation.resume(returning: nil)
+          return
+        }
+
+        let bookmark = Bookmark(with: finalTime, type: type, context: context)
+        item.addToBookmarks(bookmark)
+
+        self.dataManager.saveContext(context)
+
+        continuation.resume(returning: SimpleBookmark(
+          time: finalTime,
+          note: nil,
+          type: type,
+          relativePath: relativePath
+        ))
+      }
     }
-
-    guard let item = self.getItemReference(with: relativePath) else { return nil }
-
-    let bookmark = Bookmark(with: finalTime, type: type, context: self.dataManager.getContext())
-    item.addToBookmarks(bookmark)
-
-    self.dataManager.saveContext()
-
-    return SimpleBookmark(
-      time: finalTime,
-      note: nil,
-      type: type,
-      relativePath: relativePath
-    )
   }
 
-  public func addNote(_ note: String, bookmark: SimpleBookmark) {
-    guard
-      let bookmarkReference = getBookmarkReference(from: bookmark)
-    else { return }
-    bookmarkReference.note = note
-    self.dataManager.saveContext()
+  public func addNote(_ note: String, bookmark: SimpleBookmark) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        if let bookmarkReference = self?.getBookmarkReference(from: bookmark, context: context) {
+          bookmarkReference.note = note
+        }
+
+        self?.dataManager.saveContext(context)
+
+        continuation.resume()
+      }
+    }
   }
 
-  public func deleteBookmark(_ bookmark: SimpleBookmark) {
-    guard
-      let bookmarkReference = getBookmarkReference(from: bookmark)
-    else { return }
+  public func deleteBookmark(_ bookmark: SimpleBookmark) async {
+    return await withCheckedContinuation { continuation in
+      dataManager.performBackgroundTask { [weak self] context in
+        if let bookmarkReference = self?.getBookmarkReference(from: bookmark, context: context) {
+          let itemReference = self?.getItemReference(with: bookmark.relativePath, context: context)
+          itemReference?.removeFromBookmarks(bookmarkReference)
+          self?.dataManager.delete(bookmarkReference, context: context)
+        }
 
-    let item = getItemReference(with: bookmark.relativePath)
-    item?.removeFromBookmarks(bookmarkReference)
-    self.dataManager.delete(bookmarkReference)
+        continuation.resume()
+      }
+    }
   }
 }


### PR DESCRIPTION
## Purpose

- There's been random crashes from CoreData, after looking into it, it's because the main context from CoreData is being accessed from different threads, and this overtime can cause random crashes. 
- Our current approach was serializing the `NSManagedObject` into a separate in-memory struct, to avoid relying on directly the DB objects for displaying the screens, and when we need to update objects, we would fetch them from the DB by id and make the updates and store them. The problem is that CoreData's `NSManagedObjectContext` are restrained to the Queue they were created on, so the main context that there's only one, it's tied to the main thread

## Approach

- Rework all the interface with an `async / await` wrapper, so we can fetch the context on the correct queue, to either fetch or update from the DB
- Use `Task` where needed to make use of the new `async` functions

## Things to be aware of / Things to focus on

- There are functions that are already executed on the main thread, so in theory we don't need the `async` wrapper, these will be identified as we continue to test these changes
- These changes are too big to go into the next release without proper testing, so I'll keep these separate, while I look into the import issues