### PR TITLE
Fix showing the import screen

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -419,6 +419,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     SentrySDK.start { options in
       options.dsn = "https://\(sentryDSN)"
       options.debug = false
+      options.enableCoreDataTracing = false
+      options.enableFileIOTracing = false
       options.tracesSampleRate = 0.5
     }
   }

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -60,6 +60,9 @@ class FolderListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
+      case .bindImportObservers:
+        /// Only the library list coordinator handle these events
+        break
       }
     }
     viewModel.coordinator = self

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -35,8 +35,6 @@ class LibraryListCoordinator: ItemListCoordinator {
       playbackService: playbackService,
       syncService: syncService
     )
-
-    bindImportObserver()
   }
 
   // swiftlint:disable:next function_body_length
@@ -69,6 +67,8 @@ class LibraryListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
+      case .bindImportObservers:
+        self?.bindImportObserverIfNeeded()
       }
     }
     viewModel.coordinator = self
@@ -103,9 +103,11 @@ class LibraryListCoordinator: ItemListCoordinator {
     syncList()
   }
 
-  func bindImportObserver() {
-    self.fileSubscription?.cancel()
-    self.importOperationSubscription?.cancel()
+  func bindImportObserverIfNeeded() {
+    guard
+      fileSubscription == nil,
+      AppDelegate.shared?.activeSceneDelegate != nil
+    else { return }
 
     self.fileSubscription = self.importManager.observeFiles().sink { [weak self] files in
       guard let self = self,

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -92,6 +92,13 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, ItemListVi
     self.bindTransitionActions()
     self.configureInitialState()
     self.bindNetworkObserver()
+    self.viewModel.bindObservers()
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    viewModel.bindImportObserverIfNeeded()
   }
 
   func addSubviews() {

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -26,6 +26,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
       selectionHandler: (SimpleLibraryItem) -> Void
     )
     case showMiniPlayer(flag: Bool)
+    case bindImportObservers
   }
 
   enum Events {
@@ -89,9 +90,6 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     self.playbackService = playbackService
     self.syncService = syncService
     self.defaultArtwork = ArtworkService.generateDefaultArtwork(from: themeAccent)?.pngData()
-    super.init()
-
-    self.bindObservers()
   }
 
   func getEmptyStateImageName() -> String {
@@ -119,6 +117,10 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
   func bindObservers() {
     bindBookObservers()
     bindDownloadObservers()
+  }
+
+  func bindImportObserverIfNeeded() {
+    onTransition?(.bindImportObservers)
   }
 
   func bindBookObservers() {

--- a/BookPlayer/SceneDelegate.swift
+++ b/BookPlayer/SceneDelegate.swift
@@ -82,8 +82,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
       NotificationCenter.default.post(name: .requestReview, object: nil)
     }
 
-    /// Sync list when app is active again
-    mainCoordinator.getLibraryCoordinator()?.syncList()
+    if let libraryCoordinator = mainCoordinator.getLibraryCoordinator() {
+      /// Sync list when app is active again
+      libraryCoordinator.syncList()
+      /// Register import observer in case it's not up already
+      libraryCoordinator.bindImportObserverIfNeeded()
+    }
   }
 
   func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {

--- a/Shared/BPLogger.swift
+++ b/Shared/BPLogger.swift
@@ -18,4 +18,41 @@ extension BPLogger {
       category: String(describing: Self.self)
     )
   }
+
+  public static func logFile(message: String) {
+    let debugLogFileURL = DataManager.getProcessedFolderURL().appendingPathComponent("debug_log_file.txt")
+
+    do {
+      try message.appendLineToURL(fileURL: debugLogFileURL)
+    }
+    catch {
+      logger.debug("Could not write to log file")
+    }
+  }
+}
+
+private extension Data {
+  func append(fileURL: URL) throws {
+    if let fileHandle = FileHandle(forWritingAtPath: fileURL.path) {
+      defer {
+        fileHandle.closeFile()
+      }
+      fileHandle.seekToEndOfFile()
+      fileHandle.write(self)
+    }
+    else {
+      try write(to: fileURL, options: .atomic)
+    }
+  }
+}
+
+private extension String {
+  func appendLineToURL(fileURL: URL) throws {
+    try (">>> " + self + "\n").appendToURL(fileURL: fileURL)
+  }
+
+  func appendToURL(fileURL: URL) throws {
+    let data = self.data(using: String.Encoding.utf8)!
+    try data.append(fileURL: fileURL)
+  }
 }

--- a/Shared/BPLogger.swift
+++ b/Shared/BPLogger.swift
@@ -19,18 +19,19 @@ extension BPLogger {
     )
   }
 
+  /// This is only used for debug purposes in Betas, do not use in Prod build
   public static func logFile(message: String) {
     let debugLogFileURL = DataManager.getProcessedFolderURL().appendingPathComponent("debug_log_file.txt")
 
     do {
       try message.appendLineToURL(fileURL: debugLogFileURL)
-    }
-    catch {
+    } catch {
       logger.debug("Could not write to log file")
     }
   }
 }
 
+/// Helper extensions to write to debug file
 private extension Data {
   func append(fileURL: URL) throws {
     if let fileHandle = FileHandle(forWritingAtPath: fileURL.path) {
@@ -39,8 +40,7 @@ private extension Data {
       }
       fileHandle.seekToEndOfFile()
       fileHandle.write(self)
-    }
-    else {
+    } else {
       try write(to: fileURL, options: .atomic)
     }
   }


### PR DESCRIPTION
## Purpose

- Fix showing the import screen

## Related tasks

#929

## Approach

- Move import observers to register after the screen is presented
- Add a check on the active scene delegate that could still be nil at the initial state of presentation
- Add a file handler to BPLogger to write and append new Strings to `debug_log_file.txt` in the Processed folder

## Things to be aware of / Things to focus on

- The debug file will not go into the prod build, this is only for the beta and help figure out what's happening

## Screenshots


![IMG_8711](https://github.com/TortugaPower/BookPlayer/assets/14112819/bc9391b3-8914-45a0-aebc-c2833d331401)
