### PR TITLE
Fix progress sync events

### DIFF
--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -131,8 +131,9 @@ class MainCoordinator: Coordinator {
         else { return }
 
         if account.hasSubscription, !account.id.isEmpty {
+          /** Disable socket lifecycle events
           self.socketService.connectSocket()
-
+           */
           let libraryCoordinator = self.getLibraryCoordinator()
 
           if !self.syncService.isActive {
@@ -142,18 +143,22 @@ class MainCoordinator: Coordinator {
             libraryCoordinator?.loadLastBookIfNeeded()
           }
         } else {
+          /** Disable socket lifecycle events
           self.socketService.disconnectSocket()
+           */
           self.syncService.isActive = false
         }
 
       })
       .store(in: &disposeBag)
 
+    /** Disable socket lifecycle events
     NotificationCenter.default.publisher(for: .logout, object: nil)
       .sink(receiveValue: { [weak self] _ in
         self?.socketService.disconnectSocket()
       })
       .store(in: &disposeBag)
+     */
   }
 
   func loadPlayer(_ relativePath: String, autoplay: Bool, showPlayer: Bool) {

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -74,6 +74,11 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         set(value) { underlyingMetadataUpdatePublisher = value }
     }
     var underlyingMetadataUpdatePublisher: AnyPublisher<[String: Any], Never>!
+    var progressUpdatePublisher: AnyPublisher<[String: Any], Never> {
+        get { return underlyingProgressUpdatePublisher }
+        set(value) { underlyingProgressUpdatePublisher = value }
+    }
+    var underlyingProgressUpdatePublisher: AnyPublisher<[String: Any], Never>!
     //MARK: - getLibrary
 
     var getLibraryCallsCount = 0

--- a/BookPlayer/Library/MiniPlayer/MiniPlayerViewModel.swift
+++ b/BookPlayer/Library/MiniPlayer/MiniPlayerViewModel.swift
@@ -17,7 +17,7 @@ class MiniPlayerViewModel {
     let author: String
     let relativePath: String
   }
-//  typealias Data = (title: String, author: String, relativePath: String)
+
   /// Available routes
   enum Routes {
     case showPlayer

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -482,6 +482,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = playbackDuration
     self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackProgress] = itemProgress
 
+    /** Disable socket events to test updating via regular network requests
     socketService.sendEvent(
       .timeUpdate,
       payload: [
@@ -491,6 +492,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
         "lastPlayDateTimestamp": Date().timeIntervalSince1970,
       ]
     )
+     */
   }
 }
 
@@ -505,8 +507,6 @@ extension PlayerManager {
     guard let currentItem = self.currentItem else { return }
 
     let boundedTime = min(max(time, 0), currentItem.duration)
-
-    updatePlaybackTime(item: currentItem, time: boundedTime)
 
     let newTime = currentItem.isBoundBook
     ? currentItem.getChapterTime(in: currentItem.currentChapter, for: boundedTime)
@@ -681,8 +681,6 @@ extension PlayerManager {
 
     if self.playbackQueued == true {
       self.play()
-    } else {
-      self.updateTime()
     }
     // Clean up flag
     self.playbackQueued = nil

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -12,6 +12,7 @@ import Combine
 
 public protocol LibrarySyncProtocol {
   var metadataUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
+  var progressUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
 
   func getItem(with relativePath: String) -> LibraryItem?
   func getItemsToSync(remoteIdentifiers: [String]) -> [SyncableItem]?

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -105,6 +105,11 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
       self?.scheduleMetadataUpdate(params: params)
     }
     .store(in: &disposeBag)
+
+    libraryService.progressUpdatePublisher.sink { [weak self] params in
+      self?.scheduleMetadataUpdate(params: params)
+    }
+    .store(in: &disposeBag)
   }
 
   public func syncListContents(


### PR DESCRIPTION
## Bugfix

- The socket client is not always connecting, and the currently playing item progress is not being synced reliably 

## Approach

- Switch to HTTP network calls for the progress update requests for the progress
  - These calls are throttled so there's only one network call every 10 secs with the latest value reported during playback
- Disable socket setup code, and event emitters

