### PR TITLE
display remaining time by default

### DIFF
--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -201,6 +201,10 @@ class DataInitializerCoordinator: BPLogger {
     if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue) == nil {
       UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
     }
+    // Set remaining time as default
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    }
 
     setupDefaultTheme(libraryService: libraryService)
 


### PR DESCRIPTION
## Purpose

Users are used to see remaining time on the progress bar of the player. This PR changes default behaviour of the app and sets UserDefaults value for `remainingTimeEnabled` to `true` by default, whereas before, it was `false`, and total book time was displayed.

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/642

## Approach

Set default value for `Constants.UserDefaults.remainingTimeEnabled` in `DataInitializerCoordinator.setupDefaultState` function
