### PR TITLE
simplify enum constants; remove unused code

### DIFF
--- a/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerTests.xcscheme
+++ b/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "418B6D0D1D2707F800F974FB"
+               BuildableName = "BookPlayerTests.xctest"
+               BlueprintName = "BookPlayerTests"
+               ReferencedContainer = "container:BookPlayer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -57,11 +57,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let defaults: UserDefaults = UserDefaults.standard
 
     // Perfrom first launch setup
-    if !defaults.bool(forKey: Constants.UserDefaults.completedFirstLaunch.rawValue) {
+    if !defaults.bool(forKey: Constants.UserDefaults.completedFirstLaunch) {
       // Set default settings
-      defaults.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-      defaults.set(true, forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
-      defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch.rawValue)
+      defaults.set(true, forKey: Constants.UserDefaults.chapterContextEnabled)
+      defaults.set(true, forKey: Constants.UserDefaults.smartRewindEnabled)
+      defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch)
     }
 
     try? AVAudioSession.sharedInstance().setCategory(
@@ -337,7 +337,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
       var newTime = event.positionTime
 
-      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue),
+      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled),
          let currentChapter = currentItem.currentChapter {
         newTime += currentChapter.start
       }
@@ -473,7 +473,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       let playerManager,
       playerManager.hasLoadedBook()
     else {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.showPlayer.rawValue)
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.showPlayer)
       return
     }
 

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -158,29 +158,29 @@ class DataInitializerCoordinator: BPLogger {
 
     // Migrate user defaults app icon
     if userDefaults?
-        .string(forKey: Constants.UserDefaults.appIcon.rawValue) == nil {
-      let storedIconId = UserDefaults.standard.string(forKey: Constants.UserDefaults.appIcon.rawValue)
-      userDefaults?.set(storedIconId, forKey: Constants.UserDefaults.appIcon.rawValue)
+        .string(forKey: Constants.UserDefaults.appIcon) == nil {
+      let storedIconId = UserDefaults.standard.string(forKey: Constants.UserDefaults.appIcon)
+      userDefaults?.set(storedIconId, forKey: Constants.UserDefaults.appIcon)
     } else if let sharedAppIcon = userDefaults?
-                .string(forKey: Constants.UserDefaults.appIcon.rawValue),
-              let localAppIcon = UserDefaults.standard.string(forKey: Constants.UserDefaults.appIcon.rawValue),
+                .string(forKey: Constants.UserDefaults.appIcon),
+              let localAppIcon = UserDefaults.standard.string(forKey: Constants.UserDefaults.appIcon),
               sharedAppIcon != localAppIcon {
-      userDefaults?.set(localAppIcon, forKey: Constants.UserDefaults.appIcon.rawValue)
-      UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.appIcon.rawValue)
+      userDefaults?.set(localAppIcon, forKey: Constants.UserDefaults.appIcon)
+      UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.appIcon)
     }
 
     // Migrate protection for Processed folder
     if !(userDefaults?
-          .bool(forKey: Constants.UserDefaults.fileProtectionMigration.rawValue) ?? false) {
+          .bool(forKey: Constants.UserDefaults.fileProtectionMigration) ?? false) {
       DataManager.getProcessedFolderURL().disableFileProtection()
-      userDefaults?.set(true, forKey: Constants.UserDefaults.fileProtectionMigration.rawValue)
+      userDefaults?.set(true, forKey: Constants.UserDefaults.fileProtectionMigration)
     }
 
     // Default to include Processed folder in phone backups,
     // when migrating between phones, having the folder excluded have generated issues for users,
     // this can be set to false from within the app settings
-    if UserDefaults.standard.object(forKey: Constants.UserDefaults.iCloudBackupsEnabled.rawValue) == nil {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.iCloudBackupsEnabled.rawValue)
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.iCloudBackupsEnabled) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.iCloudBackupsEnabled)
 
       var resourceValues = URLResourceValues()
       resourceValues.isExcludedFromBackup = false
@@ -190,20 +190,20 @@ class DataInitializerCoordinator: BPLogger {
     }
 
     // Set system theme as default
-    if UserDefaults.standard.object(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) == nil {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue)
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.systemThemeVariantEnabled) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.systemThemeVariantEnabled)
     }
     // Set autoplay enabled as default
-    if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayEnabled.rawValue) == nil {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayEnabled) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayEnabled)
     }
     // Set autoplay finished enabled as default
-    if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue) == nil {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.autoplayRestartEnabled) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.autoplayRestartEnabled)
     }
     // Set remaining time as default
-    if UserDefaults.standard.object(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue) == nil {
-      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    if UserDefaults.standard.object(forKey: Constants.UserDefaults.remainingTimeEnabled) == nil {
+      UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled)
     }
 
     setupDefaultTheme(libraryService: libraryService)
@@ -226,9 +226,9 @@ class DataInitializerCoordinator: BPLogger {
     guard !accountService.hasAccount() else { return }
 
     accountService.createAccount(
-      donationMade: UserDefaults.standard.bool(forKey: Constants.UserDefaults.donationMade.rawValue)
+      donationMade: UserDefaults.standard.bool(forKey: Constants.UserDefaults.donationMade)
     )
 
-    UserDefaults.standard.set(nil, forKey: Constants.UserDefaults.donationMade.rawValue)
+    UserDefaults.standard.set(nil, forKey: Constants.UserDefaults.donationMade)
   }
 }

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -150,8 +150,8 @@ class LibraryListCoordinator: ItemListCoordinator {
           self?.playerManager.play()
         }
 
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.showPlayer.rawValue) {
-          UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.showPlayer.rawValue)
+        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.showPlayer) {
+          UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.showPlayer)
           self?.showPlayer()
         }
       },

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -234,7 +234,7 @@ extension MainCoordinator: PurchasesDelegate {
 extension MainCoordinator: Themeable {
   func applyTheme(_ theme: SimpleTheme) {
     guard
-      !UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue)
+      !UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled)
     else {
       AppDelegate.shared?.activeSceneDelegate?.window?.overrideUserInterfaceStyle = .unspecified
       return

--- a/BookPlayer/Coordinators/PlayerCoordinator.swift
+++ b/BookPlayer/Coordinators/PlayerCoordinator.swift
@@ -116,13 +116,13 @@ class PlayerCoordinator: Coordinator {
       return
     }
 
-    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue) else {
+    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled) else {
       UIApplication.shared.isIdleTimerDisabled = false
       UIDevice.current.isBatteryMonitoringEnabled = false
       return
     }
 
-    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue) else {
+    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered) else {
       UIApplication.shared.isIdleTimerDisabled = true
       UIDevice.current.isBatteryMonitoringEnabled = false
       return

--- a/BookPlayer/Player/ButtonFree Screen/ButtonFreeViewModel.swift
+++ b/BookPlayer/Player/ButtonFree Screen/ButtonFreeViewModel.swift
@@ -28,7 +28,7 @@ class ButtonFreeViewModel: BaseViewModel<ButtonFreeCoordinator> {
 
   func disableTimer(_ flag: Bool) {
     // Disregard if it's already handled by setting
-    guard !UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue) else {
+    guard !UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled) else {
       return
     }
 

--- a/BookPlayer/Player/Controls Screen/PlayerControlsViewModel.swift
+++ b/BookPlayer/Player/Controls Screen/PlayerControlsViewModel.swift
@@ -37,11 +37,11 @@ class PlayerControlsViewModel: BaseViewModel<PlayerControlsCoordinator> {
   }
 
   func getBoostVolumeFlag() -> Bool {
-    return UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+    return UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
   }
 
   func handleBoostVolumeToggle(flag: Bool) {
-    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.boostVolumeEnabled)
 
     self.playerManager.setBoostVolume(flag)
   }

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -20,8 +20,8 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   private let libraryService: LibraryServiceProtocol
   private let syncService: SyncServiceProtocol
   private var chapterBeforeSliderValueChange: PlayableChapter?
-  private var prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-  private var prefersRemainingTime = UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+  private var prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled)
+  private var prefersRemainingTime = UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled)
 
   var eventsPublisher = InterfaceUpdater<PlayerViewModel.Events>()
 
@@ -143,14 +143,14 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
 
   func processToggleMaxTime() -> ProgressObject {
     self.prefersRemainingTime = !self.prefersRemainingTime
-    UserDefaults.standard.set(self.prefersRemainingTime, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.set(self.prefersRemainingTime, forKey: Constants.UserDefaults.remainingTimeEnabled)
 
     return self.getCurrentProgressState()
   }
 
   func processToggleProgressState() -> ProgressObject {
     self.prefersChapterContext = !self.prefersChapterContext
-    UserDefaults.standard.set(self.prefersChapterContext, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.set(self.prefersChapterContext, forKey: Constants.UserDefaults.chapterContextEnabled)
 
     return self.getCurrentProgressState()
   }
@@ -295,7 +295,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func showList() {
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks) {
       self.coordinator.showBookmarks()
     } else {
       self.coordinator.showChapters()
@@ -303,7 +303,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func showListFromMoreAction() {
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks) {
       self.coordinator.showChapters()
     } else {
       self.coordinator.showBookmarks()
@@ -311,7 +311,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func getListTitleForMoreAction() -> String {
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks) {
       return "chapters_title".localized
     } else {
       return "bookmarks_title".localized

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -400,22 +400,22 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   var boostVolume: Bool = false {
     didSet {
       self.audioPlayer.volume = self.boostVolume
-      ? Constants.Volume.boosted.rawValue
-      : Constants.Volume.normal.rawValue
+      ? Constants.Volume.boosted
+      : Constants.Volume.normal
     }
   }
 
   static var rewindInterval: TimeInterval {
     get {
-      if UserDefaults.standard.object(forKey: Constants.UserDefaults.rewindInterval.rawValue) == nil {
+      if UserDefaults.standard.object(forKey: Constants.UserDefaults.rewindInterval) == nil {
         return 30.0
       }
 
-      return UserDefaults.standard.double(forKey: Constants.UserDefaults.rewindInterval.rawValue)
+      return UserDefaults.standard.double(forKey: Constants.UserDefaults.rewindInterval)
     }
 
     set {
-      UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.rewindInterval.rawValue)
+      UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.rewindInterval)
 
       MPRemoteCommandCenter.shared().skipBackwardCommand.preferredIntervals = [newValue] as [NSNumber]
     }
@@ -423,15 +423,15 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
   static var forwardInterval: TimeInterval {
     get {
-      if UserDefaults.standard.object(forKey: Constants.UserDefaults.forwardInterval.rawValue) == nil {
+      if UserDefaults.standard.object(forKey: Constants.UserDefaults.forwardInterval) == nil {
         return 30.0
       }
 
-      return UserDefaults.standard.double(forKey: Constants.UserDefaults.forwardInterval.rawValue)
+      return UserDefaults.standard.double(forKey: Constants.UserDefaults.forwardInterval)
     }
 
     set {
-      UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.forwardInterval.rawValue)
+      UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.forwardInterval)
 
       MPRemoteCommandCenter.shared().skipForwardCommand.preferredIntervals = [newValue] as [NSNumber]
     }
@@ -448,8 +448,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   func setNowPlayingBookTime() {
     guard let currentItem = self.currentItem else { return }
 
-    let prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-    let prefersRemainingTime = UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    let prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled)
+    let prefersRemainingTime = UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled)
     let currentTimeInContext = currentItem.currentTimeInContext(prefersChapterContext)
     let maxTimeInContext = currentItem.maxTimeInContext(
       prefersChapterContext: prefersChapterContext,
@@ -611,7 +611,7 @@ extension PlayerManager {
     self.handleSmartRewind(currentItem)
 
     self.fadeTimer?.invalidate()
-    self.boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+    self.boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
     // Set play state on player and control center
     self.audioPlayer.playImmediately(atRate: self.currentSpeed)
 
@@ -625,17 +625,17 @@ extension PlayerManager {
   }
 
   func handleSmartRewind(_ item: PlayableItem) {
-    let smartRewindEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
+    let smartRewindEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled)
 
     if smartRewindEnabled,
        let lastPlayTime = item.lastPlayDate {
       let timePassed = Date().timeIntervalSince(lastPlayTime)
-      let timePassedLimited = min(max(timePassed, 0), Constants.SmartRewind.threshold.rawValue)
+      let timePassedLimited = min(max(timePassed, 0), Constants.SmartRewind.threshold)
 
-      let delta = timePassedLimited / Constants.SmartRewind.threshold.rawValue
+      let delta = timePassedLimited / Constants.SmartRewind.threshold
 
       // Using a cubic curve to soften the rewind effect for lower values and strengthen it for higher
-      let rewindTime = pow(delta, 3) * Constants.SmartRewind.maxTime.rawValue
+      let rewindTime = pow(delta, 3) * Constants.SmartRewind.maxTime
 
       let newPlayerTime = max(CMTimeGetSeconds(self.audioPlayer.currentTime()) - rewindTime, 0)
 
@@ -779,11 +779,11 @@ extension PlayerManager {
   func playNextItem(autoPlayed: Bool = false) {
     /// If it's autoplayed, check if setting is enabled
     if autoPlayed,
-       !UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled.rawValue) {
+       !UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled) {
       return
     }
 
-    let restartFinished = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
+    let restartFinished = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled)
 
     guard
       let currentItem = self.currentItem,

--- a/BookPlayer/Player/SpeedService.swift
+++ b/BookPlayer/Player/SpeedService.swift
@@ -31,7 +31,7 @@ class SpeedService: SpeedServiceProtocol {
     }
 
     // set global speed
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled) {
       UserDefaults.standard.set(newValue, forKey: "global_speed")
     }
 
@@ -41,7 +41,7 @@ class SpeedService: SpeedServiceProtocol {
   public func getSpeed(relativePath: String?) -> Float {
     let speed: Float
 
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled) {
       speed = UserDefaults.standard.float(forKey: "global_speed")
     } else if let relativePath = relativePath {
       speed = self.libraryService.getItemSpeed(at: relativePath)

--- a/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
+++ b/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
@@ -142,7 +142,7 @@ class ProfileViewModel: ProfileViewModelProtocol {
   }
 
   func refreshSyncStatusMessage() {
-    let timestamp = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp.rawValue)
+    let timestamp = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp)
 
     guard timestamp > 0 else { return }
 

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -112,7 +112,7 @@ class ActionParserService {
 
     UserDefaults.standard.set(
       isOn,
-      forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue
+      forKey: Constants.UserDefaults.boostVolumeEnabled
     )
     playerManager.setBoostVolume(isOn)
   }

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -85,7 +85,7 @@ class CarPlayManager: NSObject {
       .store(in: &disposeBag)
 
     self.boostVolumeItem.handler = { [weak self] (_, completion) in
-      let flag = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+      let flag = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
 
       NotificationCenter.default.post(
         name: .messageReceived,
@@ -133,7 +133,7 @@ class CarPlayManager: NSObject {
     let listButton = CPNowPlayingImageButton(
       image: UIImage(named: "carplay.list.bullet")!
     ) { [weak self] _ in
-      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue) {
+      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks) {
         self?.showBookmarkListTemplate()
       } else {
         self?.showChapterListTemplate()
@@ -451,7 +451,7 @@ extension CarPlayManager {
 
 extension CarPlayManager {
   func showPlaybackControlsTemplate() {
-    let boostTitle = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+    let boostTitle = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
     ? "\("settings_boostvolume_title".localized): \("active_title".localized)"
     : "\("settings_boostvolume_title".localized): \("sleep_off_title".localized)"
 

--- a/BookPlayer/Services/PhoneWatchConnectivityService.swift
+++ b/BookPlayer/Services/PhoneWatchConnectivityService.swift
@@ -151,7 +151,7 @@ public class PhoneWatchConnectivityService: NSObject, WCSessionDelegate {
       rate: self.playerManager.currentSpeed,
       rewindInterval: Int(PlayerManager.rewindInterval),
       forwardInterval: Int(PlayerManager.forwardInterval),
-      boostVolume: UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+      boostVolume: UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
     )
   }
 

--- a/BookPlayer/Settings/Icons Screen/IconsViewController.swift
+++ b/BookPlayer/Settings/Icons Screen/IconsViewController.swift
@@ -125,7 +125,7 @@ class IconsViewController: UIViewController, Storyboarded {
             return
         }
 
-        self.userDefaults?.set(iconName, forKey: Constants.UserDefaults.appIcon.rawValue)
+        self.userDefaults?.set(iconName, forKey: Constants.UserDefaults.appIcon)
 
         let icon = iconName == "Default" ? nil : iconName
 
@@ -156,7 +156,7 @@ extension IconsViewController: UITableViewDataSource {
         cell.iconImage = UIImage(named: item.imageName)
         cell.isLocked = item.isLocked && !self.viewModel.hasMadeDonation()
 
-        let currentAppIcon = self.userDefaults?.string(forKey: Constants.UserDefaults.appIcon.rawValue) ?? "Default"
+        let currentAppIcon = self.userDefaults?.string(forKey: Constants.UserDefaults.appIcon) ?? "Default"
 
         cell.accessoryType = item.id == currentAppIcon
             ? .checkmark

--- a/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
+++ b/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
@@ -48,9 +48,9 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
     self.globalSpeedSwitch.addTarget(self, action: #selector(self.globalSpeedToggleDidChange), for: .valueChanged)
 
     // Set initial switch positions
-    self.smartRewindSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled.rawValue), animated: false)
-    self.boostVolumeSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue), animated: false)
-    self.globalSpeedSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue), animated: false)
+    self.smartRewindSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled), animated: false)
+    self.boostVolumeSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled), animated: false)
+    self.globalSpeedSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled), animated: false)
     self.chapterTimeSwitch.setOn(self.viewModel.prefersChapterContext, animated: false)
     self.remainingTimeSwitch.setOn(self.viewModel.prefersRemainingTime, animated: false)
 
@@ -184,11 +184,11 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
   }
 
     @objc func rewindToggleDidChange() {
-        UserDefaults.standard.set(self.smartRewindSwitch.isOn, forKey: Constants.UserDefaults.smartRewindEnabled.rawValue)
+        UserDefaults.standard.set(self.smartRewindSwitch.isOn, forKey: Constants.UserDefaults.smartRewindEnabled)
     }
 
     @objc func boostVolumeToggleDidChange() {
-      UserDefaults.standard.set(self.boostVolumeSwitch.isOn, forKey: Constants.UserDefaults.boostVolumeEnabled.rawValue)
+      UserDefaults.standard.set(self.boostVolumeSwitch.isOn, forKey: Constants.UserDefaults.boostVolumeEnabled)
 
       guard let playerManager = AppDelegate.shared?.playerManager else { return }
 
@@ -196,7 +196,7 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
     }
 
     @objc func globalSpeedToggleDidChange() {
-        UserDefaults.standard.set(self.globalSpeedSwitch.isOn, forKey: Constants.UserDefaults.globalSpeedEnabled.rawValue)
+        UserDefaults.standard.set(self.globalSpeedSwitch.isOn, forKey: Constants.UserDefaults.globalSpeedEnabled)
     }
 }
 

--- a/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewModel.swift
+++ b/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewModel.swift
@@ -18,14 +18,14 @@ final class PlayerSettingsViewModel {
   @Published var playerListPrefersBookmarks: Bool
 
   var prefersChapterContext: Bool {
-    UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled)
   }
   var prefersRemainingTime: Bool {
-    UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled)
   }
 
   init() {
-    self.playerListPrefersBookmarks = UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue)
+    self.playerListPrefersBookmarks = UserDefaults.standard.bool(forKey: Constants.UserDefaults.playerListPrefersBookmarks)
   }
 
   func getTitleForPlayerListPreference(_ prefersBookmarks: Bool) -> String {
@@ -36,16 +36,16 @@ final class PlayerSettingsViewModel {
   func handleOptionSelected(_ option: PlayerListDisplayOption) {
     let prefersBookmarks = option == .bookmarks
 
-    UserDefaults.standard.set(prefersBookmarks, forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue)
+    UserDefaults.standard.set(prefersBookmarks, forKey: Constants.UserDefaults.playerListPrefersBookmarks)
 
     self.playerListPrefersBookmarks = prefersBookmarks
   }
 
   func handlePrefersChapterContext(_ flag: Bool) {
-    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.chapterContextEnabled)
   }
 
   func handlePrefersRemainingTime(_ flag: Bool) {
-    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.remainingTimeEnabled)
   }
 }

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -89,10 +89,10 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
   func bindObservers() {
     let userDefaults = UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)
 
-    self.appIconLabel.text = userDefaults?.string(forKey: Constants.UserDefaults.appIcon.rawValue) ?? "Default"
+    self.appIconLabel.text = userDefaults?.string(forKey: Constants.UserDefaults.appIcon) ?? "Default"
 
     self.iconObserver = userDefaults?.observe(\.userSettingsAppIcon) { [weak self] _, _ in
-        self?.appIconLabel.text = userDefaults?.string(forKey: Constants.UserDefaults.appIcon.rawValue) ?? "Default"
+        self?.appIconLabel.text = userDefaults?.string(forKey: Constants.UserDefaults.appIcon) ?? "Default"
     }
 
     if self.viewModel.hasMadeDonation() {
@@ -119,17 +119,17 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
     self.iCloudBackupsSwitch.addTarget(self, action: #selector(self.iCloudBackupsDidChange), for: .valueChanged)
 
     // Set initial switch positions
-    self.iCloudBackupsSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.iCloudBackupsEnabled.rawValue), animated: false)
-    let isAutoplayEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
+    self.iCloudBackupsSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.iCloudBackupsEnabled), animated: false)
+    let isAutoplayEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled)
     self.autoplayLibrarySwitch.setOn(isAutoplayEnabled, animated: false)
-    autoplayRestartSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue), animated: false)
+    autoplayRestartSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayRestartEnabled), animated: false)
     if !isAutoplayEnabled {
       autoplayRestartSwitch.isEnabled = false
     }
-    self.disableAutolockSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue), animated: false)
-    self.autolockDisabledOnlyWhenPoweredSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue), animated: false)
-    self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue)
-    self.autolockDisabledOnlyWhenPoweredLabel.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled.rawValue)
+    self.disableAutolockSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled), animated: false)
+    self.autolockDisabledOnlyWhenPoweredSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered), animated: false)
+    self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled)
+    self.autolockDisabledOnlyWhenPoweredLabel.isEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.autolockDisabled)
   }
 
     @objc func donationMade() {
@@ -137,22 +137,22 @@ class SettingsViewController: BaseTableViewController<SettingsCoordinator, Setti
     }
 
     @objc func autoplayToggleDidChange() {
-        UserDefaults.standard.set(self.autoplayLibrarySwitch.isOn, forKey: Constants.UserDefaults.autoplayEnabled.rawValue)
+        UserDefaults.standard.set(self.autoplayLibrarySwitch.isOn, forKey: Constants.UserDefaults.autoplayEnabled)
       self.autoplayRestartSwitch.isEnabled = autoplayLibrarySwitch.isOn
     }
 
     @objc func autoplayRestartToggleDidChange() {
-      UserDefaults.standard.set(self.autoplayRestartSwitch.isOn, forKey: Constants.UserDefaults.autoplayRestartEnabled.rawValue)
+      UserDefaults.standard.set(self.autoplayRestartSwitch.isOn, forKey: Constants.UserDefaults.autoplayRestartEnabled)
     }
 
     @objc func disableAutolockDidChange() {
-        UserDefaults.standard.set(self.disableAutolockSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabled.rawValue)
+        UserDefaults.standard.set(self.disableAutolockSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabled)
         self.autolockDisabledOnlyWhenPoweredSwitch.isEnabled = self.disableAutolockSwitch.isOn
         self.autolockDisabledOnlyWhenPoweredLabel.isEnabled = self.disableAutolockSwitch.isOn
     }
 
     @objc func autolockOnlyWhenPoweredDidChange() {
-        UserDefaults.standard.set(self.autolockDisabledOnlyWhenPoweredSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered.rawValue)
+        UserDefaults.standard.set(self.autolockDisabledOnlyWhenPoweredSwitch.isOn, forKey: Constants.UserDefaults.autolockDisabledOnlyWhenPowered)
     }
 
   @objc func iCloudBackupsDidChange() {

--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -43,7 +43,7 @@ class SettingsViewModel: BaseViewModel<SettingsCoordinator> {
   }
 
   func toggleFileBackupsPreference(_ flag: Bool) {
-    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.iCloudBackupsEnabled.rawValue)
+    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.iCloudBackupsEnabled)
 
     // Modify the processed folder to be considered for backups
     var resourceValues = URLResourceValues()

--- a/BookPlayer/Settings/Themes Screen/ThemeManager.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemeManager.swift
@@ -34,20 +34,20 @@ final class ThemeManager: ThemeProvider {
   }
 
   public func checkSystemMode() {
-    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) else { return }
+    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled) else { return }
 
     self.useDarkVariant = UIScreen.main.traitCollection.userInterfaceStyle == .dark
   }
 
   private init() {
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue) {
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled) {
       self.useDarkVariant = UIScreen.main.traitCollection.userInterfaceStyle == .dark
     } else {
-      self.useDarkVariant = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
+      self.useDarkVariant = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled)
     }
 
-    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) {
-      let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
+    if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled) {
+      let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold)
       let brightness = (UIScreen.main.brightness * 100).rounded() / 100
       self.useDarkVariant = brightness <= CGFloat(threshold)
     }
@@ -71,9 +71,9 @@ final class ThemeManager: ThemeProvider {
   }
 
   @objc private func brightnessChanged(_ notification: Notification) {
-    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) else { return }
+    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled) else { return }
 
-    let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
+    let threshold = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold)
     let brightness = (UIScreen.main.brightness * 100).rounded() / 100
     let shouldUseDarkVariant = brightness <= CGFloat(threshold)
 

--- a/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
+++ b/BookPlayer/Settings/Themes Screen/ThemesViewController.swift
@@ -79,10 +79,10 @@ class ThemesViewController: UIViewController, Storyboarded {
 
     self.extractedThemesTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: self.extractedThemesTableView.frame.size.width, height: 1))
 
-    self.darkModeSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
-    self.systemModeSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue)
-    self.brightnessSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue)
-    self.brightnessSlider.value = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
+    self.darkModeSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled)
+    self.systemModeSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled)
+    self.brightnessSwitch.isOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled)
+    self.brightnessSlider.value = UserDefaults.standard.float(forKey: Constants.UserDefaults.themeBrightnessThreshold)
 
     if self.brightnessSwitch.isOn {
       self.toggleAutomaticBrightness(animated: false)
@@ -190,7 +190,7 @@ class ThemesViewController: UIViewController, Storyboarded {
             sender.setValue(0.25, animated: false)
         }
 
-        UserDefaults.standard.set(sender.value, forKey: Constants.UserDefaults.themeBrightnessThreshold.rawValue)
+        UserDefaults.standard.set(sender.value, forKey: Constants.UserDefaults.themeBrightnessThreshold)
     }
 
     @IBAction func sliderUp(_ sender: UISlider) {
@@ -209,7 +209,7 @@ class ThemesViewController: UIViewController, Storyboarded {
     }
 
     @IBAction func toggleSystemMode(_ sender: UISwitch) {
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.systemThemeVariantEnabled.rawValue)
+        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.systemThemeVariantEnabled)
         self.brightnessSwitch.isEnabled = !sender.isOn
         self.darkModeSwitch.isEnabled = !sender.isOn
 
@@ -219,9 +219,9 @@ class ThemesViewController: UIViewController, Storyboarded {
         }
 
         // handle switching variant if the other toggle is enabled
-        let darkVariantEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
+        let darkVariantEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled)
 
-        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue) {
+        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeBrightnessEnabled) {
             self.sliderUp(self.brightnessSlider)
         } else if ThemeManager.shared.useDarkVariant != darkVariantEnabled {
             ThemeManager.shared.useDarkVariant = darkVariantEnabled
@@ -229,18 +229,18 @@ class ThemesViewController: UIViewController, Storyboarded {
     }
 
     @IBAction func toggleDarkMode(_ sender: UISwitch) {
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
+        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.themeDarkVariantEnabled)
         ThemeManager.shared.useDarkVariant = sender.isOn
     }
 
     @IBAction func toggleAutomaticBrightness(_ sender: UISwitch) {
-        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.themeBrightnessEnabled.rawValue)
+        UserDefaults.standard.set(sender.isOn, forKey: Constants.UserDefaults.themeBrightnessEnabled)
         self.toggleAutomaticBrightness(animated: true)
         self.sliderUp(self.brightnessSlider)
 
         guard !sender.isOn else { return }
         // handle switching variant if the other toggle is enabled
-        let darkVariantEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled.rawValue)
+        let darkVariantEnabled = UserDefaults.standard.bool(forKey: Constants.UserDefaults.themeDarkVariantEnabled)
 
         guard ThemeManager.shared.useDarkVariant != darkVariantEnabled else { return }
 

--- a/BookPlayer/Utils/Extensions/UserDefaults+BookPlayer.swift
+++ b/BookPlayer/Utils/Extensions/UserDefaults+BookPlayer.swift
@@ -11,10 +11,10 @@ import Foundation
 
 extension UserDefaults {
   @objc dynamic var userSettingsAppIcon: String? {
-    return string(forKey: Constants.UserDefaults.appIcon.rawValue)
+    return string(forKey: Constants.UserDefaults.appIcon)
   }
 
   @objc dynamic var userSettingsHasQueuedJobs: Bool {
-    return bool(forKey: Constants.UserDefaults.hasQueuedJobs.rawValue)
+    return bool(forKey: Constants.UserDefaults.hasQueuedJobs)
   }
 }

--- a/BookPlayerTests/PlayerManagerTests.swift
+++ b/BookPlayerTests/PlayerManagerTests.swift
@@ -19,8 +19,8 @@ class PlayerManagerTests: XCTestCase {
 
   override func setUp() {
     // Clean up stored configs
-    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.chapterContextEnabled)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.remainingTimeEnabled)
     self.sut = PlayerManager(
       libraryService: LibraryServiceProtocolMock(),
       playbackService: PlaybackServiceProtocolMock(),
@@ -92,7 +92,7 @@ class PlayerManagerTests: XCTestCase {
   func testUpdatingGlobalRemainingNowPlayingBookTime() {
     // playback speed should affect duration time set
     self.sut.setSpeed(2)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled)
     // mocked playable item
     let playableItem = generatePlayableItem()
     playableItem.currentTime = 20
@@ -109,7 +109,7 @@ class PlayerManagerTests: XCTestCase {
   func testUpdatingChapterNowPlayingBookTime() {
     // playback speed shouldn't affect duration time set
     self.sut.setSpeed(2)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled)
     // mocked playable item
     let playableItem = generatePlayableItem()
     playableItem.currentTime = 10
@@ -126,8 +126,8 @@ class PlayerManagerTests: XCTestCase {
   func testUpdatingChapterRemainingNowPlayingBookTime() {
     // playback speed should affect duration time set
     self.sut.setSpeed(2)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled)
     // mocked playable item
     let playableItem = generatePlayableItem()
     playableItem.currentTime = 10

--- a/BookPlayerTests/PlayerSettingsViewModelTests.swift
+++ b/BookPlayerTests/PlayerSettingsViewModelTests.swift
@@ -17,9 +17,9 @@ class PlayerSettingsViewModelTests: XCTestCase {
   var sut: PlayerSettingsViewModel!
 
   override func setUp() {
-    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue)
-    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.playerListPrefersBookmarks)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.chapterContextEnabled)
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.remainingTimeEnabled)
 
     self.sut = PlayerSettingsViewModel()
   }
@@ -29,9 +29,9 @@ class PlayerSettingsViewModelTests: XCTestCase {
     XCTAssertFalse(self.sut.prefersChapterContext)
     XCTAssertFalse(self.sut.prefersRemainingTime)
 
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.playerListPrefersBookmarks.rawValue)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled.rawValue)
-    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled.rawValue)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.playerListPrefersBookmarks)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.chapterContextEnabled)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.remainingTimeEnabled)
 
     let secondViewModel = PlayerSettingsViewModel()
     XCTAssertTrue(secondViewModel.playerListPrefersBookmarks)

--- a/BookPlayerWidgetUI/WidgetUtils.swift
+++ b/BookPlayerWidgetUI/WidgetUtils.swift
@@ -100,7 +100,7 @@ class WidgetUtils {
     }
 
     class func getAppIconName() -> String {
-        return UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)?.string(forKey: Constants.UserDefaults.appIcon.rawValue) ?? "Default"
+        return UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)?.string(forKey: Constants.UserDefaults.appIcon) ?? "Default"
     }
 
     class func getWidgetActionURL(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double) -> URL {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -5,122 +5,49 @@
 import Foundation
 
 public enum Constants {
-    public enum UserDefaults: String {
-        // Application information
-        case completedFirstLaunch = "userSettingsCompletedFirstLaunch"
-        case appIcon = "userSettingsAppIcon"
-        case donationMade = "userSettingsDonationMade"
-        case showPlayer = "userSettingsShowPlayer"
-        case lastSyncTimestamp = "lastSyncTimestamp"
-        case hasQueuedJobs = "userSettingsHasQueuedJobs"
+  public enum UserDefaults {
+    // Application information
+    public static let completedFirstLaunch = "userSettingsCompletedFirstLaunch"
+    public static let appIcon = "userSettingsAppIcon"
+    public static let donationMade = "userSettingsDonationMade"
+    public static let showPlayer = "userSettingsShowPlayer"
+    public static let lastSyncTimestamp = "lastSyncTimestamp"
+    public static let hasQueuedJobs = "userSettingsHasQueuedJobs"
 
-        // User preferences
-        case themeBrightnessEnabled = "userSettingsBrightnessEnabled"
-        case themeBrightnessThreshold = "userSettingsBrightnessThreshold"
-        case themeDarkVariantEnabled = "userSettingsThemeDarkVariant"
-        case systemThemeVariantEnabled = "userSettingsSystemThemeVariant"
-        case chapterContextEnabled = "userSettingsChapterContext"
-        case remainingTimeEnabled = "userSettingsRemainingTime"
-        case smartRewindEnabled = "userSettingsSmartRewind"
-        case boostVolumeEnabled = "userSettingsBoostVolume"
-        case globalSpeedEnabled = "userSettingsGlobalSpeed"
-        case autoplayEnabled = "userSettingsAutoplay"
-        case autoplayRestartEnabled = "userSettingsAutoplayRestart"
-        case iCloudBackupsEnabled = "userSettingsiCloudBackupsEnabled"
-        case autolockDisabled = "userSettingsDisableAutolock"
-        case autolockDisabledOnlyWhenPowered = "userSettingsAutolockOnlyWhenPowered"
-        case playerListPrefersBookmarks = "userSettingsPlayerListPrefersBookmarks"
+    // User preferences
+    public static let themeBrightnessEnabled = "userSettingsBrightnessEnabled"
+    public static let themeBrightnessThreshold = "userSettingsBrightnessThreshold"
+    public static let themeDarkVariantEnabled = "userSettingsThemeDarkVariant"
+    public static let systemThemeVariantEnabled = "userSettingsSystemThemeVariant"
+    public static let chapterContextEnabled = "userSettingsChapterContext"
+    public static let remainingTimeEnabled = "userSettingsRemainingTime"
+    public static let smartRewindEnabled = "userSettingsSmartRewind"
+    public static let boostVolumeEnabled = "userSettingsBoostVolume"
+    public static let globalSpeedEnabled = "userSettingsGlobalSpeed"
+    public static let autoplayEnabled = "userSettingsAutoplay"
+    public static let autoplayRestartEnabled = "userSettingsAutoplayRestart"
+    public static let iCloudBackupsEnabled = "userSettingsiCloudBackupsEnabled"
+    public static let autolockDisabled = "userSettingsDisableAutolock"
+    public static let autolockDisabledOnlyWhenPowered = "userSettingsAutolockOnlyWhenPowered"
+    public static let playerListPrefersBookmarks = "userSettingsPlayerListPrefersBookmarks"
 
-        case rewindInterval = "userSettingsRewindInterval"
-        case forwardInterval = "userSettingsForwardInterval"
+    public static let rewindInterval = "userSettingsRewindInterval"
+    public static let forwardInterval = "userSettingsForwardInterval"
 
-      // One-time migrations
-      case fileProtectionMigration = "userFileProtectionMigration"
-    }
+    // One-time migrations
+    public static let fileProtectionMigration = "userFileProtectionMigration"
+  }
 
-    public enum SmartRewind: TimeInterval {
-        case threshold = 599.0 // 599 = 10 mins
-        case maxTime = 30.0
-    }
+  public enum SmartRewind {
+    public static let threshold: TimeInterval = 599.0 // 599 = 10 mins
+    public static let maxTime: TimeInterval = 30.0
+  }
 
-    public enum Volume: Float {
-        case normal = 1.0
-        case boosted = 2.0
-    }
+  public enum Volume {
+    public static let normal: Float = 1.0
+    public static let boosted: Float = 2.0
+  }
 
-    public static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
-    public static let ApplicationGroupIdentifier = "group.\(Bundle.main.configurationString(for: .bundleIdentifier)).files"
-
-    public enum DefaultArtworkColors {
-        case primary
-        case secondary
-        case accent
-        case separator
-        case systemBackground
-        case secondarySystemBackground
-        case tertiarySystemBackground
-        case systemGroupedBackground
-        case systemFill
-        case secondarySystemFill
-        case tertiarySystemFill
-        case quaternarySystemFill
-
-        var lightColor: String {
-            switch self {
-            case .primary:
-                return "#37454E"
-            case .secondary:
-                return "#3488D1"
-            case .accent:
-                return "#7685B3"
-            case .separator:
-                return "#DCDCDC"
-            case .systemBackground:
-                return "#FAFAFA"
-            case .secondarySystemBackground:
-                return "#FCFBFC"
-            case .tertiarySystemBackground:
-                return "#E8E7E9"
-            case .systemGroupedBackground:
-                return "#EFEEF0"
-            case .systemFill:
-                return "#87A0BA"
-            case .secondarySystemFill:
-                return "#ACAAB1"
-            case .tertiarySystemFill:
-                return "#7685B3"
-            case .quaternarySystemFill:
-                return "#7685B3"
-            }
-        }
-
-        var darkColor: String {
-            switch self {
-            case .primary:
-                return "#EEEEEE"
-            case .secondary:
-                return "#3488D1"
-            case .accent:
-                return "#7685B3"
-            case .separator:
-                return "#434448"
-            case .systemBackground:
-                return "#050505"
-            case .secondarySystemBackground:
-                return "#111113"
-            case .tertiarySystemBackground:
-                return "#333538"
-            case .systemGroupedBackground:
-                return "#2C2D30"
-            case .systemFill:
-                return "#647E98"
-            case .secondarySystemFill:
-                return "#707176"
-            case .tertiarySystemFill:
-                return "#7685B3"
-            case .quaternarySystemFill:
-                return "#7685B3"
-            }
-        }
-    }
+  public static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
+  public static let ApplicationGroupIdentifier = "group.\(Bundle.main.configurationString(for: .bundleIdentifier)).files"
 }

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -306,7 +306,7 @@ extension SyncJobScheduler: JobListener {
 
     UserDefaults.standard.set(
       true,
-      forKey: Constants.UserDefaults.hasQueuedJobs.rawValue
+      forKey: Constants.UserDefaults.hasQueuedJobs
     )
 
     NotificationCenter.default.post(name: .jobScheduled, object: nil)
@@ -325,7 +325,7 @@ extension SyncJobScheduler: JobListener {
 
     UserDefaults.standard.set(
       false,
-      forKey: Constants.UserDefaults.hasQueuedJobs.rawValue
+      forKey: Constants.UserDefaults.hasQueuedJobs
     )
   }
 }

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -117,7 +117,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   ) async throws -> ([SyncableItem], SyncableItem?)? {
     guard
       isActive,
-      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs.rawValue) == false
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs) == false
     else {
       throw BookPlayerError.networkError("Sync is not enabled")
     }
@@ -125,7 +125,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     if relativePath == nil {
       UserDefaults.standard.set(
         Date().timeIntervalSince1970,
-        forKey: Constants.UserDefaults.lastSyncTimestamp.rawValue
+        forKey: Constants.UserDefaults.lastSyncTimestamp
       )
     }
 
@@ -169,14 +169,14 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   public func syncLibraryContents() async throws -> ([SyncableItem], SyncableItem?) {
     guard
       isActive,
-      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs.rawValue) == false
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs) == false
     else {
       throw BookPlayerError.networkError("Sync is not enabled")
     }
 
     UserDefaults.standard.set(
       Date().timeIntervalSince1970,
-      forKey: Constants.UserDefaults.lastSyncTimestamp.rawValue
+      forKey: Constants.UserDefaults.lastSyncTimestamp
     )
 
     let (fetchedItems, lastItemPlayed) = try await fetchContents(at: nil)
@@ -222,7 +222,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   public func syncBookmarksList(relativePath: String) async throws -> [SimpleBookmark]? {
     guard
       isActive,
-      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs.rawValue) == false
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs) == false
     else {
       throw BookPlayerError.networkError("Sync is not enabled")
     }


### PR DESCRIPTION
## Purpose

Simplifies usage of enum constants; removes unused code

## Approach

- convert all read-only enum constants from cases to static let variables, which allows to drop usage of `.rawValue` in all places where that constant is needed
- removed unused constant enum related to artwork theme colours, since everything theme-related was moved to `SimpleTheme`
