### PR TITLE
Fix tab bar and navigation title theming

### DIFF
--- a/BookPlayer/AppNavigationController.swift
+++ b/BookPlayer/AppNavigationController.swift
@@ -80,16 +80,24 @@ extension AppNavigationController: Themeable {
 
     navigationBar.barTintColor = theme.systemBackgroundColor
     navigationBar.tintColor = theme.linkColor
-    navigationBar.titleTextAttributes = [
-      NSAttributedString.Key.foregroundColor: theme.primaryColor
-    ]
-    navigationBar.largeTitleTextAttributes = [
-      NSAttributedString.Key.foregroundColor: theme.primaryColor
-    ]
+
     self.separatorView.backgroundColor = theme.separatorColor
     navigationBar.scrollEdgeAppearance?.backgroundColor = theme.systemBackgroundColor
     navigationBar.compactAppearance?.backgroundColor = theme.systemBackgroundColor
     navigationBar.standardAppearance.backgroundColor = theme.systemBackgroundColor
+
+    let titleTextAttributes: [NSAttributedString.Key: Any] = [
+      NSAttributedString.Key.foregroundColor: theme.primaryColor
+    ]
+    navigationBar.titleTextAttributes = titleTextAttributes
+    navigationBar.largeTitleTextAttributes = titleTextAttributes
+    navigationBar.scrollEdgeAppearance?.titleTextAttributes = titleTextAttributes
+    navigationBar.scrollEdgeAppearance?.largeTitleTextAttributes = titleTextAttributes
+    navigationBar.compactAppearance?.titleTextAttributes = titleTextAttributes
+    navigationBar.compactAppearance?.largeTitleTextAttributes = titleTextAttributes
+    navigationBar.standardAppearance.titleTextAttributes = titleTextAttributes
+    navigationBar.standardAppearance.largeTitleTextAttributes = titleTextAttributes
+
     self.view.backgroundColor = theme.systemBackgroundColor
   }
 }

--- a/BookPlayer/AppTabBarController.swift
+++ b/BookPlayer/AppTabBarController.swift
@@ -112,6 +112,7 @@ extension AppTabBarController: Themeable {
       : .default
     setNeedsStatusBarAppearanceUpdate()
     self.tabBar.backgroundColor = theme.systemBackgroundColor
+    self.tabBar.barTintColor = theme.systemBackgroundColor
     self.tabBar.tintColor = theme.linkColor
 
     self.miniPlayer.layer.shadowColor = theme.primaryColor.cgColor


### PR DESCRIPTION
## Bugfix

- The app will sometimes show the tab bar white when the theme is dark, and the navigation title also had the coloring for a light theme

## Related tasks

#916

## Approach

- Set the `barTintColor` as well to fix the tab bar
- Set the navigation title attributes on all the available nav appearances (`scrollEdgeAppearance`, `compactAppearance`, `standardAppearance`)
