### PR TITLE
Fix upload-queued jobs being terminated suddenly

### DIFF
--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -90,9 +90,6 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
   }
 
   private func createHardLink(for item: SyncableItem) {
-    /// Hard links only apply to files and not folders
-    guard item.type == .book else { return }
-
     let hardLinkURL = FileManager.default.temporaryDirectory.appendingPathComponent(item.relativePath)
 
     let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(item.relativePath)
@@ -102,6 +99,7 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
       try? FileManager.default.removeItem(at: hardLinkURL)
     }
 
+    /// Don't throw and let the rest of the items queue up
     try? FileManager.default.linkItem(at: fileURL, to: hardLinkURL)
   }
 


### PR DESCRIPTION
## Bugfix

- When uploading the contents of a folder, and the folder is renamed, the process of uploading is interrupted

## Related tasks

#942

## Approach

- Remove check if it's a book when creating a hard link, this also works for folders, and per [the docs](https://developer.apple.com/documentation/foundation/filemanager/1414456-linkitem), it creates a hard link for the contents as well

## Things to be aware of / Things to focus on

- The hard link is what lets us reference the file, and the user is free to move it anywhere they want in the library, we'll still be able to find the contents and upload it when the queued task runs. There's still one scenario (given that we queue the tasks and run them async) where the hard link could fail to create, and the user moved the file from the original place, and we won't find the contents of that particular file. We have to work on a way to let the user know that one of the items is not uploaded, and only the metadata is up
