### PR TITLE
Refresh remote URL when it expires for playback streaming

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -138,7 +138,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     if let sharedSyncService = AppDelegate.shared?.syncService {
       syncService = sharedSyncService
     } else {
-      syncService = SyncService(libraryService: libraryService)
+      syncService = SyncService(
+        isActive: accountService.hasActiveSubscription(),
+        libraryService: libraryService
+      )
       AppDelegate.shared?.syncService = syncService
     }
 

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -60,9 +60,8 @@ class FolderListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
-      case .libraryDidAppear:
-        /// Only the library list coordinator handle these events
-        break
+      case .listDidAppear:
+        self?.syncList()
       }
     }
     viewModel.coordinator = self
@@ -71,7 +70,6 @@ class FolderListCoordinator: ItemListCoordinator {
     navigationController.pushViewController(vc, animated: true)
 
     documentPickerDelegate = vc
-    syncList()
   }
 
   override func syncList() {

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -60,7 +60,7 @@ class FolderListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
-      case .bindImportObservers:
+      case .libraryDidAppear:
         /// Only the library list coordinator handle these events
         break
       }

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -67,7 +67,7 @@ class LibraryListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
-      case .libraryDidAppear:
+      case .listDidAppear:
         self?.handleLibraryLoaded()
       }
     }

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -239,8 +239,8 @@ class LibraryListCoordinator: ItemListCoordinator {
 
     /// Check to update current time or not
     if item.relativePath == localLastItem.relativePath {
-      /// Add a padding of 5 mins to local time
-      if item.currentTime > (localLastItem.currentTime + 300) {
+      /// Add a padding of 1 min to local time
+      if item.currentTime > (localLastItem.currentTime + 60) {
         /// Continue playback after time sync
         let wasPlaying = playerManager.isPlaying
         playerManager.stop()

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -67,8 +67,8 @@ class LibraryListCoordinator: ItemListCoordinator {
         self?.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self?.showMiniPlayer(flag: flag)
-      case .bindImportObservers:
-        self?.bindImportObserverIfNeeded()
+      case .libraryDidAppear:
+        self?.handleLibraryLoaded()
       }
     }
     viewModel.coordinator = self
@@ -89,8 +89,6 @@ class LibraryListCoordinator: ItemListCoordinator {
       tabBarController.setViewControllers(newControllersArray, animated: false)
     }
 
-    self.loadLastBookIfNeeded()
-
     if let appDelegate = AppDelegate.shared {
       for action in appDelegate.pendingURLActions {
         ActionParserService.handleAction(action)
@@ -100,7 +98,12 @@ class LibraryListCoordinator: ItemListCoordinator {
     self.documentPickerDelegate = vc
 
     AppDelegate.shared?.watchConnectivityService?.startSession()
+  }
+
+  func handleLibraryLoaded() {
+    loadLastBookIfNeeded()
     syncList()
+    bindImportObserverIfNeeded()
   }
 
   func bindImportObserverIfNeeded() {

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -41,7 +41,6 @@ class MainCoordinator: Coordinator {
 
     super.init(navigationController: navigationController, flowType: .modal)
 
-    accountService.setDelegate(self)
     setUpTheming()
   }
 
@@ -70,7 +69,7 @@ class MainCoordinator: Coordinator {
 
     bindObservers()
 
-    accountService.loginIfUserExists()
+    accountService.loginIfUserExists(delegate: self)
 
     startLibraryCoordinator(with: tabBarController)
 
@@ -147,6 +146,7 @@ class MainCoordinator: Coordinator {
           self.socketService.disconnectSocket()
            */
           self.syncService.isActive = false
+          self.syncService.cancelAllJobs()
         }
 
       })

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -133,13 +133,9 @@ class MainCoordinator: Coordinator {
           /** Disable socket lifecycle events
           self.socketService.connectSocket()
            */
-          let libraryCoordinator = self.getLibraryCoordinator()
-
           if !self.syncService.isActive {
             self.syncService.isActive = true
-            libraryCoordinator?.syncLibrary()
-          } else if !self.playerManager.hasLoadedBook() {
-            libraryCoordinator?.loadLastBookIfNeeded()
+            self.getLibraryCoordinator()?.syncLibrary()
           }
         } else {
           /** Disable socket lifecycle events

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -27,6 +27,9 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, ItemListVi
 
   @IBOutlet weak var tableView: UITableView!
 
+  /// This is required to know if the initial Library layout is presented, and other screens can be presented on top
+  private var didAppearForFirstTime = true
+
   private lazy var searchButton: UIBarButtonItem = {
     return UIBarButtonItem(systemItem: .search, primaryAction: UIAction { [weak self] _ in
       self?.navigationItem.backButtonDisplayMode = .minimal
@@ -98,7 +101,10 @@ class ItemListViewController: BaseViewController<ItemListCoordinator, ItemListVi
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
-    viewModel.bindImportObserverIfNeeded()
+    if didAppearForFirstTime {
+      didAppearForFirstTime = false
+      viewModel.viewDidAppear()
+    }
   }
 
   func addSubviews() {

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -26,7 +26,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
       selectionHandler: (SimpleLibraryItem) -> Void
     )
     case showMiniPlayer(flag: Bool)
-    case bindImportObservers
+    case libraryDidAppear
   }
 
   enum Events {
@@ -119,8 +119,12 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     bindDownloadObservers()
   }
 
-  func bindImportObserverIfNeeded() {
-    onTransition?(.bindImportObservers)
+  /// Notify that the UI is presented and ready
+  func viewDidAppear() {
+    /// Only pass for the root Library screen
+    if folderRelativePath == nil {
+      onTransition?(.libraryDidAppear)
+    }
   }
 
   func bindBookObservers() {

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -26,7 +26,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
       selectionHandler: (SimpleLibraryItem) -> Void
     )
     case showMiniPlayer(flag: Bool)
-    case libraryDidAppear
+    case listDidAppear
   }
 
   enum Events {
@@ -121,10 +121,7 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
 
   /// Notify that the UI is presented and ready
   func viewDidAppear() {
-    /// Only pass for the root Library screen
-    if folderRelativePath == nil {
-      onTransition?(.libraryDidAppear)
-    }
+    onTransition?(.listDidAppear)
   }
 
   func bindBookObservers() {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -59,6 +59,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   private var periodicTimeObserver: Any?
   /// Flag determining if it should resume playback after finishing up loading an item
   @Published private var playbackQueued: Bool?
+  /// Flag determining if it's in the process of fetching the URL for playback
+  @Published private var isFetchingRemoteURL: Bool?
   private var hasObserverRegistered = false
   private var observeStatus: Bool = false {
     didSet {
@@ -133,10 +135,11 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
   }
 
-  func loadRemoteURLAsset(for chapter: PlayableChapter) async throws -> AVURLAsset {
+  func loadRemoteURLAsset(for chapter: PlayableChapter, forceRefresh: Bool) async throws -> AVURLAsset {
     let fileURL: URL
 
-    if let chapterURL = chapter.remoteURL {
+    if !forceRefresh,
+       let chapterURL = chapter.remoteURL {
       fileURL = chapterURL
     } else {
       fileURL = try await syncService
@@ -183,14 +186,16 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     return asset
   }
 
-  func loadPlayerItem(for chapter: PlayableChapter) async throws {
+  func loadPlayerItem(for chapter: PlayableChapter, forceRefreshURL: Bool) async throws {
     let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(chapter.relativePath)
 
     let asset: AVURLAsset
 
     if syncService.isActive,
       !FileManager.default.fileExists(atPath: fileURL.path) {
-      asset = try await loadRemoteURLAsset(for: chapter)
+      isFetchingRemoteURL = true
+      asset = try await loadRemoteURLAsset(for: chapter, forceRefresh: forceRefreshURL)
+      isFetchingRemoteURL = false
     } else {
       asset = AVURLAsset(url: fileURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
     }
@@ -206,6 +211,10 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   }
 
   func load(_ item: PlayableItem, autoplay: Bool) {
+    load(item, autoplay: autoplay, forceRefreshURL: false)
+  }
+
+  private func load(_ item: PlayableItem, autoplay: Bool, forceRefreshURL: Bool) {
     /// Cancel in case there's an ongoing load task
     loadChapterTask?.cancel()
 
@@ -238,22 +247,23 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       NotificationCenter.default.post(name: .chapterChange, object: nil, userInfo: nil)
     }
 
-    loadChapterMetadata(item.currentChapter, autoplay: autoplay)
+    loadChapterMetadata(item.currentChapter, autoplay: autoplay, forceRefreshURL: forceRefreshURL)
   }
 
-  func loadChapterMetadata(_ chapter: PlayableChapter, autoplay: Bool? = nil) {
+  func loadChapterMetadata(_ chapter: PlayableChapter, autoplay: Bool? = nil, forceRefreshURL: Bool = false) {
     if let autoplay {
       playbackQueued = autoplay
     }
 
     loadChapterTask = Task { [unowned self] in
       do {
-        try await self.loadPlayerItem(for: chapter)
+        try await self.loadPlayerItem(for: chapter, forceRefreshURL: forceRefreshURL)
         self.loadChapterOperation(chapter)
       } catch BookPlayerError.cancelledTask {
         /// Do nothing, as it was cancelled to load another item
       } catch {
         self.playbackQueued = nil
+        self.isFetchingRemoteURL = nil
         self.observeStatus = false
         self.showErrorAlert(error.localizedDescription)
         return
@@ -270,6 +280,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       else {
         DispatchQueue.main.async {
           self.currentItem = nil
+          self.isFetchingRemoteURL = nil
           NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["loaded": false])
         }
         return
@@ -277,6 +288,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
       self.audioPlayer.replaceCurrentItem(with: nil)
       self.observeStatus = true
+      self.isFetchingRemoteURL = nil
       self.audioPlayer.replaceCurrentItem(with: playerItem)
 
       // Update UI on main thread
@@ -387,12 +399,17 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   }
 
   func isPlayingPublisher() -> AnyPublisher<Bool, Never> {
-    return Publishers.CombineLatest(
+    return Publishers.CombineLatest3(
       audioPlayer.publisher(for: \.timeControlStatus),
-      $playbackQueued
+      $playbackQueued,
+      $isFetchingRemoteURL
     )
-    .map({ (timeControlStatus, playbackQueued) in
-      return timeControlStatus != .paused || playbackQueued == true
+    .map({ (timeControlStatus, playbackQueued, isFetchingRemoteURL) -> Bool in
+      let controlStatusFlag = timeControlStatus != .paused
+      let playbackQueuedFlag = playbackQueued == true
+      return controlStatusFlag
+      || playbackQueuedFlag
+      || (isFetchingRemoteURL == true && playbackQueuedFlag)
     })
     .eraseToAnyPublisher()
   }
@@ -571,7 +588,11 @@ extension PlayerManager {
     guard let playerItem else {
       /// Check if the playbable item is in the process of being set
       if observeStatus == false {
-        load(currentItem, autoplay: true)
+        if isFetchingRemoteURL == true {
+          playbackQueued = true
+        } else {
+          load(currentItem, autoplay: true)
+        }
       }
       return
     }
@@ -670,9 +691,14 @@ extension PlayerManager {
 
     guard item.status == .readyToPlay else {
       if item.status == .failed {
-        playbackQueued = nil
-        observeStatus = false
-        showErrorAlert(item.error?.localizedDescription)
+        if (item.error as? NSError)?.code == NSURLErrorResourceUnavailable,
+           let currentItem {
+          loadAndRefreshURL(item: currentItem)
+        } else {
+          playbackQueued = nil
+          observeStatus = false
+          showErrorAlert(item.error?.localizedDescription)
+        }
       }
       return
     }
@@ -841,6 +867,10 @@ extension PlayerManager {
        let parentFolder = item.parentFolder {
       libraryService.recursiveFolderProgressUpdate(from: parentFolder)
     }
+  }
+
+  private func loadAndRefreshURL(item: PlayableItem) {
+    load(item, autoplay: playbackQueued == true, forceRefreshURL: true)
   }
 }
 

--- a/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
+++ b/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
@@ -142,7 +142,7 @@ class ProfileViewModel: ProfileViewModelProtocol {
   }
 
   func refreshSyncStatusMessage() {
-    let timestamp = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp)
+    let timestamp = UserDefaults.standard.double(forKey: "\(Constants.UserDefaults.lastSyncTimestamp)_library")
 
     guard timestamp > 0 else { return }
 

--- a/BookPlayer/SceneDelegate.swift
+++ b/BookPlayer/SceneDelegate.swift
@@ -85,6 +85,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     if let libraryCoordinator = mainCoordinator.getLibraryCoordinator() {
       /// Sync list when app is active again
       libraryCoordinator.syncList()
+      /// Sync currently shown list
+      let listCoordinator = libraryCoordinator.getLastItemListCoordinator(from: libraryCoordinator)
+      if listCoordinator != libraryCoordinator {
+        listCoordinator.syncList()
+      }
       /// Register import observer in case it's not up already
       libraryCoordinator.bindImportObserverIfNeeded()
     }

--- a/BookPlayerTests/Mocks/AccountServiceMock.swift
+++ b/BookPlayerTests/Mocks/AccountServiceMock.swift
@@ -11,6 +11,10 @@ import Foundation
 import RevenueCat
 
 class AccountServiceMock: AccountServiceProtocol {
+  func hasActiveSubscription() -> Bool {
+    return account?.hasSubscription == true
+  }
+
   var account: Account?
 
   init(account: Account?) {
@@ -82,7 +86,7 @@ class AccountServiceMock: AccountServiceProtocol {
     return try await Purchases.shared.customerInfo()
   }
 
-  func loginIfUserExists() {}
+  func loginIfUserExists(delegate: PurchasesDelegate) {}
 
   func login(with token: String, userId: String) async throws -> Account? {
     self.account?.id = userId

--- a/Shared/CoreData/CoreDataStack.swift
+++ b/Shared/CoreData/CoreDataStack.swift
@@ -51,7 +51,6 @@ public class CoreDataStack {
   public func loadStore(completionHandler: ((NSPersistentStoreDescription, Error?) -> Void)?) {
     self.storeContainer.loadPersistentStores { storeDescription, error in
       self.storeContainer.viewContext.undoManager = nil
-      self.storeContainer.viewContext.automaticallyMergesChangesFromParent = true
       completionHandler?(storeDescription, error)
     }
   }
@@ -71,9 +70,5 @@ public class CoreDataStack {
 
   public func getBackgroundContext() -> NSManagedObjectContext {
     return self.storeContainer.newBackgroundContext()
-  }
-
-  public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
-    storeContainer.performBackgroundTask(block)
   }
 }

--- a/Shared/CoreData/CoreDataStack.swift
+++ b/Shared/CoreData/CoreDataStack.swift
@@ -51,14 +51,19 @@ public class CoreDataStack {
   public func loadStore(completionHandler: ((NSPersistentStoreDescription, Error?) -> Void)?) {
     self.storeContainer.loadPersistentStores { storeDescription, error in
       self.storeContainer.viewContext.undoManager = nil
+      self.storeContainer.viewContext.automaticallyMergesChangesFromParent = true
       completionHandler?(storeDescription, error)
     }
   }
 
   public func saveContext() {
-    guard self.managedContext.hasChanges else { return }
+    saveContext(managedContext)
+  }
+
+  public func saveContext(_ context: NSManagedObjectContext) {
+    guard context.hasChanges else { return }
     do {
-      try self.managedContext.save()
+      try context.save()
     } catch let error as NSError {
       fatalError("Unresolved error \(error), \(error.userInfo)")
     }
@@ -66,5 +71,9 @@ public class CoreDataStack {
 
   public func getBackgroundContext() -> NSManagedObjectContext {
     return self.storeContainer.newBackgroundContext()
+  }
+
+  public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+    storeContainer.performBackgroundTask(block)
   }
 }

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -93,18 +93,24 @@ public class DataManager {
     self.coreDataStack.saveContext()
   }
 
-  public func saveSyncContext() {
-    coreDataStack.managedContext.performAndWait { [weak self] in
-      self?.coreDataStack.saveContext()
-    }
+  public func saveSyncContext(_ context: NSManagedObjectContext) {
+    coreDataStack.saveContext(context)
   }
 
   public func getBackgroundContext() -> NSManagedObjectContext {
     return self.coreDataStack.getBackgroundContext()
   }
 
+  public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+    coreDataStack.performBackgroundTask(block)
+  }
+
+  public func delete(_ item: NSManagedObject, context: NSManagedObjectContext) {
+    context.delete(item)
+    saveSyncContext(context)
+  }
+
   public func delete(_ item: NSManagedObject) {
-    self.coreDataStack.managedContext.delete(item)
-    self.saveContext()
+    delete(item, context: coreDataStack.managedContext)
   }
 }

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -101,10 +101,6 @@ public class DataManager {
     return self.coreDataStack.getBackgroundContext()
   }
 
-  public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
-    coreDataStack.performBackgroundTask(block)
-  }
-
   public func delete(_ item: NSManagedObject, context: NSManagedObjectContext) {
     context.delete(item)
     saveSyncContext(context)

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -16,13 +16,14 @@ public protocol LibrarySyncProtocol {
 
   func getItem(with relativePath: String) -> LibraryItem?
   func getItemsToSync(remoteIdentifiers: [String]) -> [SyncableItem]?
-  func getItemIdentifiers(in parentFolder: String?) -> [String]?
+  func getStoredItemIdentifiers(in parentFolder: String?) async -> [String]?
   func removeItems(notIn relativePaths: [String], parentFolder: String?) throws
   func fetchSyncableNestedContents(at relativePath: String) -> [SyncableItem]?
   func getMaxItemsCount(at relativePath: String?) -> Int
   func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]?
 
   func updateInfo(from items: [SyncableItem]) async
+  func updateLastPlayedInfo(_ item: SyncableItem) async
   func addBook(from item: SyncableItem, parentFolder: String?) async
   func addFolder(from item: SyncableItem, type: SimpleItemType, parentFolder: String?) async
   func addBookmark(from bookmark: SimpleBookmark) async
@@ -31,7 +32,8 @@ public protocol LibrarySyncProtocol {
 extension LibraryService: LibrarySyncProtocol {
   public func updateInfo(from items: [SyncableItem]) async {
     return await withCheckedContinuation { continuation in
-      dataManager.performBackgroundTask { [unowned self] context in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
         for item in items {
           guard let localItem = getItem(with: item.relativePath, context: context) else { continue }
 
@@ -59,9 +61,41 @@ extension LibraryService: LibrarySyncProtocol {
     }
   }
 
+  public func updateLastPlayedInfo(_ item: SyncableItem) async {
+    return await withCheckedContinuation { continuation in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
+        guard let localItem = getItem(with: item.relativePath, context: context) else {
+          continuation.resume()
+          return
+        }
+
+        if let remoteURL = item.remoteURL {
+          localItem.remoteURL = remoteURL
+        }
+
+        if let artworkURL = item.artworkURL {
+          localItem.artworkURL = artworkURL
+        }
+
+        if let timestamp = item.lastPlayDateTimestamp {
+          localItem.lastPlayDate = Date(timeIntervalSince1970: timestamp)
+        }
+
+        if let speed = item.speed {
+          localItem.speed = Float(speed)
+        }
+
+        dataManager.saveSyncContext(context)
+        continuation.resume()
+      }
+    }
+  }
+
   public func addBook(from item: SyncableItem, parentFolder: String?) async {
     return await withCheckedContinuation { continuation in
-      dataManager.performBackgroundTask { [unowned self] context in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
         let newBook = Book(
           syncItem: item,
           context: context
@@ -83,7 +117,8 @@ extension LibraryService: LibrarySyncProtocol {
 
   public func addFolder(from item: SyncableItem, type: SimpleItemType, parentFolder: String?) async {
     return await withCheckedContinuation { continuation in
-      dataManager.performBackgroundTask { [unowned self] context in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
         // This shouldn't fail
         try? createFolderOnDisk(title: item.title, inside: parentFolder, context: context)
 
@@ -109,7 +144,8 @@ extension LibraryService: LibrarySyncProtocol {
 
   public func addBookmark(from bookmark: SimpleBookmark) async {
     return await withCheckedContinuation { continuation in
-      dataManager.performBackgroundTask { [unowned self] context in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
         if let fetchedBookmark = getBookmarkReference(from: bookmark, context: context) {
           fetchedBookmark.note = bookmark.note
         } else if let item = getItemReference(with: bookmark.relativePath, context: context) {
@@ -140,17 +176,14 @@ extension LibraryService: LibrarySyncProtocol {
     return parseSyncableItems(from: results)
   }
 
-  public func getItemIdentifiers(in parentFolder: String?) -> [String]? {
-    let fetchRequest = buildListContentsFetchRequest(
-      properties: ["relativePath"],
-      relativePath: parentFolder,
-      limit: nil,
-      offset: nil
-    )
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return results?.compactMap({ $0["relativePath"] as? String })
+  public func getStoredItemIdentifiers(in parentFolder: String?) async -> [String]? {
+    return await withCheckedContinuation { continuation in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
+        let identifiers = getItemIdentifiers(in: parentFolder, context: context)
+        continuation.resume(returning: identifiers)
+      }
+    }
   }
 
   public func fetchSyncableNestedContents(at relativePath: String) -> [SyncableItem]? {
@@ -214,28 +247,5 @@ extension LibraryService: LibrarySyncProtocol {
     else { return }
 
     try delete(items, mode: .deep)
-  }
-
-  func getItems(in relativePaths: [String], parentFolder: String?) -> [LibraryItem]? {
-    let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
-
-    if let parentFolder = parentFolder {
-      fetchRequest.predicate = NSPredicate(
-        format: "%K == %@ AND (%K IN %@)",
-        #keyPath(LibraryItem.folder.relativePath),
-        parentFolder,
-        #keyPath(LibraryItem.relativePath),
-        relativePaths
-      )
-    } else {
-      fetchRequest.predicate = NSPredicate(
-        format: "%K != nil AND (%K IN %@)",
-        #keyPath(LibraryItem.library),
-        #keyPath(LibraryItem.relativePath),
-        relativePaths
-      )
-    }
-
-    return try? self.dataManager.getContext().fetch(fetchRequest)
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -202,7 +202,7 @@ public final class LibraryService: LibraryServiceProtocol {
     }
   }
 
-  func getItemReference(with relativePath: String) -> LibraryItem? {
+  func getItemReference(with relativePath: String, context: NSManagedObjectContext) -> LibraryItem? {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
     fetchRequest.fetchLimit = 1
@@ -211,7 +211,11 @@ public final class LibraryService: LibraryServiceProtocol {
       #keyPath(LibraryItem.originalFileName)
     ]
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
+  }
+
+  func getItemReference(with relativePath: String) -> LibraryItem? {
+    return getItemReference(with: relativePath, context: dataManager.getContext())
   }
 
   public func hasItemProperty(_ property: String, relativePath: String) -> Bool {
@@ -387,13 +391,16 @@ extension LibraryService {
     return (try? context.fetch(fetch).first) ?? self.createLibrary()
   }
 
-  public func getLibraryReference() -> Library {
-    let context = self.dataManager.getContext()
+  func getLibraryReference(context: NSManagedObjectContext) -> Library {
     let fetch: NSFetchRequest<Library> = Library.fetchRequest()
     fetch.includesPropertyValues = false
     fetch.fetchLimit = 1
 
     return (try? context.fetch(fetch).first)!
+  }
+
+  public func getLibraryReference() -> Library {
+    return getLibraryReference(context: dataManager.getContext())
   }
 
   private func createLibrary() -> Library {
@@ -771,12 +778,16 @@ extension LibraryService {
     return parseFetchedItems(from: results)?.first
   }
 
-  public func getItem(with relativePath: String) -> LibraryItem? {
+  func getItem(with relativePath: String, context: NSManagedObjectContext) -> LibraryItem? {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
     fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
     fetchRequest.fetchLimit = 1
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
+  }
+
+  public func getItem(with relativePath: String) -> LibraryItem? {
+    return getItem(with: relativePath, context: dataManager.getContext())
   }
 
   public func getItems(notIn relativePaths: [String], parentFolder: String?) -> [SimpleLibraryItem]? {
@@ -986,7 +997,7 @@ extension LibraryService {
     dataManager.saveContext()
   }
 
-  func createFolderOnDisk(title: String, inside relativePath: String?) throws {
+  func createFolderOnDisk(title: String, inside relativePath: String?, context: NSManagedObjectContext) throws {
     let processedFolder = DataManager.getProcessedFolderURL()
     let destinationURL: URL
 
@@ -996,11 +1007,15 @@ extension LibraryService {
       destinationURL = processedFolder.appendingPathComponent(title)
     }
 
-    try? removeFolderIfNeeded(destinationURL)
+    try? removeFolderIfNeeded(destinationURL, context: context)
     try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: false, attributes: nil)
   }
 
-  func hasLibraryLinked(item: LibraryItem) -> Bool {
+  func createFolderOnDisk(title: String, inside relativePath: String?) throws {
+    try createFolderOnDisk(title: title, inside: relativePath, context: dataManager.getContext())
+  }
+
+  func hasLibraryLinked(item: LibraryItem, context: NSManagedObjectContext) -> Bool {
     var keyPath = item.relativePath.split(separator: "/")
       .dropLast()
       .map({ _ in return "folder" })
@@ -1012,25 +1027,33 @@ extension LibraryService {
 
     fetchRequest.predicate = NSPredicate(format: "relativePath == %@ && \(keyPath) != nil", item.relativePath)
 
-    return (try? self.dataManager.getContext().fetch(fetchRequest).first) != nil
+    return (try? context.fetch(fetchRequest).first) != nil
   }
 
-  func removeFolderIfNeeded(_ fileURL: URL) throws {
+  func hasLibraryLinked(item: LibraryItem) -> Bool {
+    hasLibraryLinked(item: item, context: dataManager.getContext())
+  }
+
+  func removeFolderIfNeeded(_ fileURL: URL, context: NSManagedObjectContext) throws {
     guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
 
     let folderPath = fileURL.relativePath(to: DataManager.getProcessedFolderURL())
 
     // Delete folder if it belongs to an orphaned folder
-    if let existingFolder = getItemReference(with: folderPath) as? Folder {
-      if !self.hasLibraryLinked(item: existingFolder) {
+    if let existingFolder = getItemReference(with: folderPath, context: context) as? Folder {
+      if !self.hasLibraryLinked(item: existingFolder, context: context) {
         // Delete folder if it doesn't belong to active folder
         try FileManager.default.removeItem(at: fileURL)
-        self.dataManager.delete(existingFolder)
+        self.dataManager.delete(existingFolder, context: context)
       }
     } else {
       // Delete folder if it doesn't belong to active folder
       try FileManager.default.removeItem(at: fileURL)
     }
+  }
+
+  func removeFolderIfNeeded(_ fileURL: URL) throws {
+    try removeFolderIfNeeded(fileURL, context: dataManager.getContext())
   }
 
   public func createFolder(with title: String, inside relativePath: String?) throws -> SimpleLibraryItem {
@@ -1611,8 +1634,7 @@ extension LibraryService {
     })
   }
 
-  func getBookmarkReference(from bookmark: SimpleBookmark) -> Bookmark? {
-
+  func getBookmarkReference(from bookmark: SimpleBookmark, context: NSManagedObjectContext) -> Bookmark? {
     let fetchRequest: NSFetchRequest<Bookmark> = Bookmark.fetchRequest()
     fetchRequest.predicate = NSPredicate(
       format: "%K == %@ && type == %d && time == %f",
@@ -1628,7 +1650,11 @@ extension LibraryService {
       #keyPath(Bookmark.type),
     ]
 
-    return try? self.dataManager.getContext().fetch(fetchRequest).first
+    return try? context.fetch(fetchRequest).first
+  }
+
+  func getBookmarkReference(from bookmark: SimpleBookmark) -> Bookmark? {
+    return getBookmarkReference(from: bookmark, context: dataManager.getContext())
   }
 
   public func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]? {

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -118,21 +118,19 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
       throw BookPlayerError.networkError("Sync is not enabled")
     }
 
+    let userDefaultsKey = "\(Constants.UserDefaults.lastSyncTimestamp)_\(relativePath ?? "library")"
     let now = Date().timeIntervalSince1970
-
-    let lastSync = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp)
+    let lastSync = UserDefaults.standard.double(forKey: userDefaultsKey)
 
     /// Do not sync if one minute hasn't passed since last sync
     guard now - lastSync > 60 else {
       throw BookPlayerError.networkError("Throttled sync operation")
     }
 
-    if relativePath == nil {
-      UserDefaults.standard.set(
-        Date().timeIntervalSince1970,
-        forKey: Constants.UserDefaults.lastSyncTimestamp
-      )
-    }
+    UserDefaults.standard.set(
+      Date().timeIntervalSince1970,
+      forKey: userDefaultsKey
+    )
 
     let (fetchedItems, lastItemPlayed) = try await fetchContents(at: relativePath)
 
@@ -185,7 +183,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
     UserDefaults.standard.set(
       Date().timeIntervalSince1970,
-      forKey: Constants.UserDefaults.lastSyncTimestamp
+      forKey: "\(Constants.UserDefaults.lastSyncTimestamp)_library"
     )
 
     let (fetchedItems, lastItemPlayed) = try await fetchContents(at: nil)

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -67,13 +67,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   let libraryService: LibrarySyncProtocol
   var jobManager: JobSchedulerProtocol
   let client: NetworkClientProtocol
-  public var isActive = false {
-    didSet {
-      if isActive == false {
-        jobManager.cancelAllJobs()
-      }
-    }
-  }
+  public var isActive: Bool
 
   public var queuedJobsCount: Int { jobManager.queuedJobsCount }
 
@@ -82,10 +76,12 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   private var disposeBag = Set<AnyCancellable>()
 
   public init(
+    isActive: Bool,
     libraryService: LibrarySyncProtocol,
     jobManager: JobSchedulerProtocol = SyncJobScheduler(),
     client: NetworkClientProtocol = NetworkClient()
   ) {
+    self.isActive = isActive
     self.libraryService = libraryService
     self.jobManager = jobManager
     self.client = client

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -120,7 +120,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
     let now = Date().timeIntervalSince1970
 
-    let lastSync = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp.rawValue)
+    let lastSync = UserDefaults.standard.double(forKey: Constants.UserDefaults.lastSyncTimestamp)
 
     /// Do not sync if one minute hasn't passed since last sync
     guard now - lastSync > 60 else {

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -156,7 +156,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     }
     /// Update data or store
     if !itemsToUpdate.isEmpty {
-      libraryService.updateInfo(from: itemsToUpdate)
+      await libraryService.updateInfo(from: itemsToUpdate)
     }
 
     return (fetchedItems, lastItemPlayed)
@@ -205,12 +205,12 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     for item in syncedItems {
       switch item.type {
       case .book:
-        libraryService.addBook(from: item, parentFolder: nil)
+        await libraryService.addBook(from: item, parentFolder: nil)
       case .bound:
-        libraryService.addFolder(from: item, type: .bound, parentFolder: nil)
+        await libraryService.addFolder(from: item, type: .bound, parentFolder: nil)
         try await fetchBoundContents(for: item)
       case .folder:
-        libraryService.addFolder(from: item, type: .folder, parentFolder: nil)
+        await libraryService.addFolder(from: item, type: .folder, parentFolder: nil)
       }
     }
   }
@@ -226,7 +226,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     let bookmarks = try await fetchBookmarks(for: relativePath)
 
     for bookmark in bookmarks {
-      libraryService.addBookmark(from: bookmark)
+      await libraryService.addBookmark(from: bookmark)
     }
 
     return libraryService.getBookmarks(of: .user, relativePath: relativePath)
@@ -241,7 +241,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
     /// All fetched items inside a bound folder are always books
     for fetchedItem in fetchedItems {
-      libraryService.addBook(from: fetchedItem, parentFolder: item.relativePath)
+      await libraryService.addBook(from: fetchedItem, parentFolder: item.relativePath)
     }
   }
 
@@ -252,12 +252,12 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     for item in syncedItems {
       switch item.type {
       case .book:
-        self.libraryService.addBook(from: item, parentFolder: parentFolder)
+        await libraryService.addBook(from: item, parentFolder: parentFolder)
       case .bound:
-        self.libraryService.addFolder(from: item, type: .bound, parentFolder: parentFolder)
+        await libraryService.addFolder(from: item, type: .bound, parentFolder: parentFolder)
         _ = try await syncListContents(at: item.relativePath)
       case .folder:
-        self.libraryService.addFolder(from: item, type: .folder, parentFolder: parentFolder)
+        await libraryService.addFolder(from: item, type: .folder, parentFolder: parentFolder)
       }
     }
   }


### PR DESCRIPTION
## Bugfix

- The remote URLs have a 7-day expiration date, the server is returning the renewed URL, but the app is not updating, nor recovering after getting the resource unavailable error when attempting playback streaming

## Approach

- Parse the 404 error at the PlayerManager, and force refresh the remote URL, and resume playback if it was initiated
- Improve loading the last played book on launch, we now have the library screen report when the UI is ready, so we don't try to present anything or load something that could potentially show an alert, without the UI being ready for it
- Update the last played info with the sync response (while the player can recover from a expired URL, this shouldn't need to be the case)
- Set a throttle of 1 min to the list sync requests
