### PR TITLE
Handle mediaServicesWereReset Notification

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     try? AVAudioSession.sharedInstance().setCategory(
       AVAudioSession.Category.playback,
-      mode: AVAudioSession.Mode(rawValue: convertFromAVAudioSessionMode(AVAudioSession.Mode.spokenAudio)),
+      mode: .spokenAudio,
       options: []
     )
 
@@ -474,9 +474,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       mainCoordinator.showPlayer()
     }
   }
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-private func convertFromAVAudioSessionMode(_ input: AVAudioSession.Mode) -> String {
-  return input.rawValue
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -53,6 +53,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
   private var fadeTimer: Timer?
 
+  private var timeControlPassthroughPublisher = CurrentValueSubject<AVPlayer.TimeControlStatus, Never>(.paused)
+  private var timeControlSubscription: AnyCancellable?
   private var playableChapterSubscription: AnyCancellable?
   private var isPlayingSubscription: AnyCancellable?
   private var periodicTimeObserver: Any?
@@ -97,17 +99,32 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     self.userActivityManager = UserActivityManager(libraryService: libraryService)
     super.init()
 
-    self.setupPlayerInstance()
+    setupPlayerInstance()
 
-    NotificationCenter.default.addObserver(self,
-                                           selector: #selector(playerDidFinishPlaying(_:)),
-                                           name: .AVPlayerItemDidPlayToEndTime,
-                                           object: nil)
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(playerDidFinishPlaying(_:)),
+      name: .AVPlayerItemDidPlayToEndTime,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleMediaServicesWereReset),
+      name: AVAudioSession.mediaServicesWereResetNotification,
+      object: nil
+    )
   }
 
   func setupPlayerInstance() {
+    if let observer = periodicTimeObserver {
+      audioPlayer.removeTimeObserver(observer)
+    }
+
+    audioPlayer = AVPlayer()
+
     let interval = CMTime(seconds: 1.0, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-    self.periodicTimeObserver = self.audioPlayer.addPeriodicTimeObserver(
+    periodicTimeObserver = audioPlayer.addPeriodicTimeObserver(
       forInterval: interval,
       queue: DispatchQueue.main
     ) { [weak self] _ in
@@ -117,7 +134,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
 
     // Only route audio for AirPlay
-    self.audioPlayer.allowsExternalPlayback = false
+    audioPlayer.allowsExternalPlayback = false
+
+    bindTimeControlPassthroughPublisher()
   }
 
   func currentItemPublisher() -> AnyPublisher<PlayableItem?, Never> {
@@ -216,13 +235,8 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     loadChapterTask?.cancel()
 
     // Recover in case of failure
-    if self.audioPlayer.status == .failed {
-      if let observer = self.periodicTimeObserver {
-        self.audioPlayer.removeTimeObserver(observer)
-      }
-
-      self.audioPlayer = AVPlayer()
-      self.setupPlayerInstance()
+    if audioPlayer.status == .failed {
+      setupPlayerInstance()
     }
 
     // Preload item
@@ -383,9 +397,19 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     return self.audioPlayer.timeControlStatus == .playing
   }
 
+  /// We need an intermediate publisher for the `timeControlStatus`, as the `AVPlayer` instance can be recreated,
+  /// thus invalidating the registered observers for `isPlaying`
+  func bindTimeControlPassthroughPublisher() {
+    timeControlSubscription?.cancel()
+    timeControlSubscription = audioPlayer.publisher(for: \.timeControlStatus)
+      .sink { [weak self] timeControlStatus in
+        self?.timeControlPassthroughPublisher.send(timeControlStatus)
+      }
+  }
+
   func bindPauseObserver() {
     self.isPlayingSubscription?.cancel()
-    self.isPlayingSubscription = self.audioPlayer.publisher(for: \.timeControlStatus)
+    self.isPlayingSubscription = timeControlPassthroughPublisher
       .delay(for: .seconds(0.1), scheduler: RunLoop.main, options: .none)
       .sink { timeControlStatus in
         if timeControlStatus == .paused {
@@ -397,7 +421,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
   func isPlayingPublisher() -> AnyPublisher<Bool, Never> {
     return Publishers.CombineLatest3(
-      audioPlayer.publisher(for: \.timeControlStatus),
+      timeControlPassthroughPublisher,
       $playbackQueued,
       $isFetchingRemoteURL
     )
@@ -856,6 +880,22 @@ extension PlayerManager {
 
   private func loadAndRefreshURL(item: PlayableItem) {
     load(item, autoplay: playbackQueued == true, forceRefreshURL: true)
+  }
+
+  @objc
+  private func handleMediaServicesWereReset() {
+    /// Playback should be stopped, and wait for the user to activate it again
+    if isPlaying {
+      stopPlayback()
+    }
+
+    try? AVAudioSession.sharedInstance().setCategory(
+      AVAudioSession.Category.playback,
+      mode: .spokenAudio,
+      options: []
+    )
+
+    setupPlayerInstance()
   }
 }
 


### PR DESCRIPTION
## Purpose

There's a unrecoverable state that can happen at the OS level, and we need to handle it by recreating the audio components for playback

## Related tasks

#914

## Approach

- Register observer for `AVAudioSession.mediaServicesWereResetNotification`
  - Stop playback when this happens
  - Reset AVAudioSession category
  - Recreate AVPlayer
- Add an intermediate publisher, so observers do not depend directly on the AVPlayer KVO observer, so the publishers are still live after AVPlayer is recreated
