### PR TITLE
Improve initial sync on sign in - Part 1

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -351,6 +351,8 @@
 		9F2DC9DB2A008B28006CDF1F /* PricingRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2DC9DA2A008B28006CDF1F /* PricingRowView.swift */; };
 		9F2DC9E52A014BB5006CDF1F /* PricingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2DC9E32A01313C006CDF1F /* PricingModel.swift */; };
 		9F2DC9E62A014BB5006CDF1F /* PricingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2DC9E32A01313C006CDF1F /* PricingModel.swift */; };
+		9F2E00922A568F800001FE20 /* IdentifiersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2E00912A568F800001FE20 /* IdentifiersResponse.swift */; };
+		9F2E00932A568F800001FE20 /* IdentifiersResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2E00912A568F800001FE20 /* IdentifiersResponse.swift */; };
 		9F3C436A284181690066D99A /* DataInitializerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C435B28413C070066D99A /* DataInitializerCoordinator.swift */; };
 		9F3C436B284181C70066D99A /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3C4357284132640066D99A /* AlertPresenter.swift */; };
 		9F3D0CE528C2BF5C00E9E8A3 /* ButtonFreeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3D0CE428C2BF5C00E9E8A3 /* ButtonFreeViewController.swift */; };
@@ -1012,6 +1014,7 @@
 		9F2DC9D82A008B19006CDF1F /* PricingOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingOptionsView.swift; sourceTree = "<group>"; };
 		9F2DC9DA2A008B28006CDF1F /* PricingRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingRowView.swift; sourceTree = "<group>"; };
 		9F2DC9E32A01313C006CDF1F /* PricingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PricingModel.swift; sourceTree = "<group>"; };
+		9F2E00912A568F800001FE20 /* IdentifiersResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiersResponse.swift; sourceTree = "<group>"; };
 		9F3C4357284132640066D99A /* AlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresenter.swift; sourceTree = "<group>"; };
 		9F3C435B28413C070066D99A /* DataInitializerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataInitializerCoordinator.swift; sourceTree = "<group>"; };
 		9F3D0CE428C2BF5C00E9E8A3 /* ButtonFreeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFreeViewController.swift; sourceTree = "<group>"; };
@@ -2109,6 +2112,7 @@
 				9F9C7B5229F9672700E257B0 /* SyncableBookmark.swift */,
 				9FBDBC7F2879C6C900D315A2 /* UploadItemResponse.swift */,
 				9FBDBC7C287940D900D315A2 /* ContentsResponse.swift */,
+				9F2E00912A568F800001FE20 /* IdentifiersResponse.swift */,
 				9F9C7B4F29F9670100E257B0 /* BookmarksResponse.swift */,
 				9F0872DA2A19867C00B7FD4A /* ArtworkResponse.swift */,
 				9FAFC9F32995BB5C00FD531E /* RemoteFileURLResponse.swift */,
@@ -2955,6 +2959,7 @@
 				4140EA75227289B20009F794 /* Theme+CoreDataProperties.swift in Sources */,
 				9FBDBC812879C6C900D315A2 /* UploadItemResponse.swift in Sources */,
 				41A90C4627563F5A00C30394 /* ItemType.swift in Sources */,
+				9F2E00932A568F800001FE20 /* IdentifiersResponse.swift in Sources */,
 				4140EA7E227289CE0009F794 /* Library+CoreDataClass.swift in Sources */,
 				41C233FE272E1958006BC7B8 /* SimpleLibraryItem.swift in Sources */,
 				416AAC3523F515B0005AD04F /* String+BookPlayer.swift in Sources */,
@@ -3259,6 +3264,7 @@
 				41A1B123226F88C500EA0400 /* Book+CoreDataClass.swift in Sources */,
 				41A1B105226E9DBD00EA0400 /* UIColor+Sweetercolor.swift in Sources */,
 				9FF383D32A40F97000BBAC11 /* MappingModel_v8_to_v9.xcmappingmodel in Sources */,
+				9F2E00922A568F800001FE20 /* IdentifiersResponse.swift in Sources */,
 				41A1B10C226E9E9700EA0400 /* DeleteMode.swift in Sources */,
 				9FC1E44A2814C4DE00522FA8 /* NetworkClient.swift in Sources */,
 				9F07B72529B512F1005A939D /* LibraryItemSyncJob.swift in Sources */,

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -73,13 +73,9 @@ class FolderListCoordinator: ItemListCoordinator {
   }
 
   override func syncList() {
-    Task { [weak self] in
-      guard
-        let self = self,
-        let (newItems, _) = try await self.syncService.syncListContents(at: self.folderRelativePath)
-      else { return }
-
-      reloadItemsWithPadding(padding: newItems.count)
+    Task { @MainActor in
+      _ = try await syncService.syncListContents(at: folderRelativePath)
+      reloadItemsWithPadding()
     }
   }
 }

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -130,7 +130,7 @@ class MainCoordinator: Coordinator {
         if account.hasSubscription, !account.id.isEmpty {
           if !self.syncService.isActive {
             self.syncService.isActive = true
-            self.getLibraryCoordinator()?.syncLibrary()
+            self.getLibraryCoordinator()?.syncList()
           }
         } else {
           self.syncService.isActive = false

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1346,9 +1346,9 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     }
     var syncListContentsAtReceivedRelativePath: String?
     var syncListContentsAtReceivedInvocations: [String?] = []
-    var syncListContentsAtReturnValue: ([SyncableItem], SyncableItem?)?
-    var syncListContentsAtClosure: ((String?) async throws -> ([SyncableItem], SyncableItem?)?)?
-    func syncListContents(at relativePath: String?) async throws -> ([SyncableItem], SyncableItem?)? {
+    var syncListContentsAtReturnValue: SyncableItem?
+    var syncListContentsAtClosure: ((String?) async throws -> SyncableItem?)?
+    func syncListContents(at relativePath: String?) async throws -> SyncableItem? {
         if let error = syncListContentsAtThrowableError {
             throw error
         }
@@ -1368,9 +1368,9 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     var syncLibraryContentsCalled: Bool {
         return syncLibraryContentsCallsCount > 0
     }
-    var syncLibraryContentsReturnValue: ([SyncableItem], SyncableItem?)!
-    var syncLibraryContentsClosure: (() async throws -> ([SyncableItem], SyncableItem?))?
-    func syncLibraryContents() async throws -> ([SyncableItem], SyncableItem?) {
+    var syncLibraryContentsReturnValue: SyncableItem?
+    var syncLibraryContentsClosure: (() async throws -> SyncableItem?)?
+    func syncLibraryContents() async throws -> SyncableItem? {
         if let error = syncLibraryContentsThrowableError {
             throw error
         }

--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -29,9 +29,10 @@ final class ImportManager {
   }
 
   public func process(_ fileUrl: URL) {
-    // Avoid processing the creation of the Processed and Inbox folder
+    // Avoid processing the creation of the Processed, Inbox and Backup folder
     if fileUrl.lastPathComponent == DataManager.processedFolderName
-        || fileUrl.lastPathComponent == "Inbox" { return }
+        || fileUrl.lastPathComponent == "Inbox"
+        || fileUrl.lastPathComponent == DataManager.backupFolderName { return }
 
     self.files.value.insert(fileUrl)
   }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -938,6 +938,7 @@ extension ItemListViewModel {
       .filter {
         $0.lastPathComponent != DataManager.processedFolderName
         && $0.lastPathComponent != DataManager.inboxFolderName
+        && $0.lastPathComponent != DataManager.backupFolderName
       }
 
     let sharedURLs = (try? FileManager.default.contentsOfDirectory(

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1224,17 +1224,17 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(fetchedChapters?.last?.index == 2)
   }
 
-  func testGetItemsNotIncluded() throws {
-    let emptyResult = self.sut.getItemsToSync(remoteIdentifiers: [])
+  func testGetItemsNotIncluded() async throws {
+    let emptyResult = await self.sut.getItemsToSync(remoteIdentifiers: [])
     XCTAssert(emptyResult?.isEmpty == true)
 
     _ = try! self.sut.createFolder(with: "test-folder", inside: nil)
     _ = try! self.sut.createFolder(with: "test-folder2", inside: nil)
 
-    let secondResult = self.sut.getItemsToSync(remoteIdentifiers: [])
+    let secondResult = await self.sut.getItemsToSync(remoteIdentifiers: [])
     XCTAssert(secondResult?.count == 2)
 
-    let thirdResult = self.sut.getItemsToSync(remoteIdentifiers: ["test-folder"])
+    let thirdResult = await self.sut.getItemsToSync(remoteIdentifiers: ["test-folder"])
     XCTAssert(thirdResult?.count == 1)
   }
 

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -11,8 +11,9 @@ public enum Constants {
     public static let appIcon = "userSettingsAppIcon"
     public static let donationMade = "userSettingsDonationMade"
     public static let showPlayer = "userSettingsShowPlayer"
-    public static let lastSyncTimestamp = "lastSyncTimestamp"
     public static let hasQueuedJobs = "userSettingsHasQueuedJobs"
+    public static let lastSyncTimestamp = "lastSyncTimestamp"
+    public static let hasScheduledLibraryContents = "hasScheduledLibraryContents"
 
     // User preferences
     public static let themeBrightnessEnabled = "userSettingsBrightnessEnabled"

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -11,6 +11,7 @@ import Foundation
 
 public class DataManager {
   public static let processedFolderName = "Processed"
+  public static let backupFolderName = "BPBackup"
   public static let inboxFolderName = "Inbox"
   public static let sharedFolderName = "SharedBP"
   public static var loadingDataError: Error?
@@ -40,6 +41,22 @@ public class DataManager {
     }
 
     return processedFolderURL
+  }
+
+  public class func getBackupFolderURL() -> URL {
+    let documentsURL = self.getDocumentsFolderURL()
+
+    let backupFolderURL = documentsURL.appendingPathComponent(self.backupFolderName)
+
+    if !FileManager.default.fileExists(atPath: backupFolderURL.path) {
+      do {
+        try FileManager.default.createDirectory(at: backupFolderURL, withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        fatalError("Couldn't create Backup folder")
+      }
+    }
+
+    return backupFolderURL
   }
 
   public class func getInboxFolderURL() -> URL {

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -41,7 +41,8 @@ extension LibraryService: LibrarySyncProtocol {
       let context = dataManager.getContext()
       context.perform { [unowned self, context] in
         guard let storedItems = getItems(in: Array(itemsDict.keys), parentFolder: parentFolder, context: context) else {
-          return continuation.resume()
+          continuation.resume()
+          return
         }
 
         for storedItem in storedItems {
@@ -121,6 +122,7 @@ extension LibraryService: LibrarySyncProtocol {
           }
         }
 
+        dataManager.saveSyncContext(context)
         continuation.resume()
       }
     }
@@ -139,8 +141,6 @@ extension LibraryService: LibrarySyncProtocol {
       let library = getLibraryReference(context: context)
       library.addToItems(newBook)
     }
-
-    dataManager.saveSyncContext(context)
   }
 
   func addFolder(from item: SyncableItem, parentFolder: String?, context: NSManagedObjectContext) {
@@ -160,8 +160,6 @@ extension LibraryService: LibrarySyncProtocol {
       let library = getLibraryReference(context: context)
       library.addToItems(newFolder)
     }
-
-    dataManager.saveSyncContext(context)
   }
 
   public func addBookmark(from bookmark: SimpleBookmark) async {

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -14,44 +14,54 @@ public protocol LibrarySyncProtocol {
   var metadataUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
   var progressUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
 
-  func getItem(with relativePath: String) -> LibraryItem?
-  func getItemsToSync(remoteIdentifiers: [String]) -> [SyncableItem]?
-  func getStoredItemIdentifiers(in parentFolder: String?) async -> [String]?
-  func removeItems(notIn relativePaths: [String], parentFolder: String?) throws
-  func fetchSyncableNestedContents(at relativePath: String) -> [SyncableItem]?
-  func getMaxItemsCount(at relativePath: String?) -> Int
-  func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]?
+  /// Fetch all the stored items in the library that are not in the remote identifiers array
+  func getItemsToSync(remoteIdentifiers: [String]) async -> [SyncableItem]?
+  /// Update local items with synced info
+  func updateInfo(for itemsDict: [String: SyncableItem], parentFolder: String?) async
+  /// Create new items from synced info
+  func storeNewItems(from itemsDict: [String: SyncableItem], parentFolder: String?) async
+  /// Remove local items that were not in the remote identifiers
+  func removeItems(notIn identifiers: [String], parentFolder: String?) async
 
-  func updateInfo(from items: [SyncableItem]) async
+  /// Update last played info
   func updateLastPlayedInfo(_ item: SyncableItem) async
-  func addBook(from item: SyncableItem, parentFolder: String?) async
-  func addFolder(from item: SyncableItem, type: SimpleItemType, parentFolder: String?) async
+
+  /// Fetch all items and folders inside a given folder (Used for newly imported folders)
+  func getAllNestedItems(inside relativePath: String) -> [SyncableItem]?
+
+  /// Get all stored bookmarks of the specified type for a book
+  func getBookmarks(of type: BookmarkType, relativePath: String) -> [SimpleBookmark]?
+  /// Store new synced bookmark
   func addBookmark(from bookmark: SimpleBookmark) async
 }
 
 extension LibraryService: LibrarySyncProtocol {
-  public func updateInfo(from items: [SyncableItem]) async {
+  public func updateInfo(for itemsDict: [String: SyncableItem], parentFolder: String?) async {
     return await withCheckedContinuation { continuation in
       let context = dataManager.getContext()
       context.perform { [unowned self, context] in
-        for item in items {
-          guard let localItem = getItem(with: item.relativePath, context: context) else { continue }
+        guard let storedItems = getItems(in: Array(itemsDict.keys), parentFolder: parentFolder, context: context) else {
+          return continuation.resume()
+        }
 
-          localItem.title = item.title
-          localItem.details = item.details
-          localItem.currentTime = item.currentTime
-          localItem.duration = item.duration
-          localItem.isFinished = item.isFinished
-          localItem.orderRank = Int16(item.orderRank)
-          localItem.percentCompleted = item.percentCompleted
-          localItem.remoteURL = item.remoteURL
-          localItem.artworkURL = item.artworkURL
-          localItem.type = item.type.itemType
-          localItem.speed = Float(item.speed ?? 1.0)
+        for storedItem in storedItems {
+          guard let item = itemsDict[storedItem.relativePath] else { continue }
+
+          storedItem.title = item.title
+          storedItem.details = item.details
+          storedItem.currentTime = item.currentTime
+          storedItem.duration = item.duration
+          storedItem.isFinished = item.isFinished
+          storedItem.orderRank = Int16(item.orderRank)
+          storedItem.percentCompleted = item.percentCompleted
+          storedItem.remoteURL = item.remoteURL
+          storedItem.artworkURL = item.artworkURL
+          storedItem.type = item.type.itemType
+          storedItem.speed = Float(item.speed ?? 1.0)
           if let timestamp = item.lastPlayDateTimestamp {
-            localItem.lastPlayDate = Date(timeIntervalSince1970: timestamp)
+            storedItem.lastPlayDate = Date(timeIntervalSince1970: timestamp)
           } else {
-            localItem.lastPlayDate = nil
+            storedItem.lastPlayDate = nil
           }
         }
 
@@ -92,54 +102,66 @@ extension LibraryService: LibrarySyncProtocol {
     }
   }
 
-  public func addBook(from item: SyncableItem, parentFolder: String?) async {
+  public func storeNewItems(from itemsDict: [String: SyncableItem], parentFolder: String?) async {
     return await withCheckedContinuation { continuation in
       let context = dataManager.getContext()
       context.perform { [unowned self, context] in
-        let newBook = Book(
-          syncItem: item,
-          context: context
-        )
+        let incomingKeys = Set(itemsDict.keys)
+        let storedKeys = Set(getItemIdentifiers(in: parentFolder, context: context) ?? [])
+        let newKeys = incomingKeys.subtracting(storedKeys)
 
-        if let relativePath = parentFolder,
-           let folder = getItem(with: relativePath, context: context) as? Folder {
-          folder.addToItems(newBook)
-        } else {
-          let library = getLibraryReference(context: context)
-          library.addToItems(newBook)
+        for key in newKeys {
+          guard let item = itemsDict[key] else { continue }
+
+          switch item.type {
+          case .book:
+            addBook(from: item, parentFolder: parentFolder, context: context)
+          case .folder, .bound:
+            addFolder(from: item, parentFolder: parentFolder, context: context)
+          }
         }
 
-        dataManager.saveSyncContext(context)
         continuation.resume()
       }
     }
   }
 
-  public func addFolder(from item: SyncableItem, type: SimpleItemType, parentFolder: String?) async {
-    return await withCheckedContinuation { continuation in
-      let context = dataManager.getContext()
-      context.perform { [unowned self, context] in
-        // This shouldn't fail
-        try? createFolderOnDisk(title: item.title, inside: parentFolder, context: context)
+  func addBook(from item: SyncableItem, parentFolder: String?, context: NSManagedObjectContext) {
+    let newBook = Book(
+      syncItem: item,
+      context: context
+    )
 
-        let newFolder = Folder(
-          syncItem: item,
-          context: context
-        )
-
-        // insert into existing folder or library at index
-        if let relativePath = parentFolder,
-           let folder = getItemReference(with: relativePath, context: context) as? Folder {
-          folder.addToItems(newFolder)
-        } else {
-          let library = getLibraryReference(context: context)
-          library.addToItems(newFolder)
-        }
-
-        dataManager.saveSyncContext(context)
-        continuation.resume()
-      }
+    if let relativePath = parentFolder,
+       let folder = getItem(with: relativePath, context: context) as? Folder {
+      folder.addToItems(newBook)
+    } else {
+      let library = getLibraryReference(context: context)
+      library.addToItems(newBook)
     }
+
+    dataManager.saveSyncContext(context)
+  }
+
+  func addFolder(from item: SyncableItem, parentFolder: String?, context: NSManagedObjectContext) {
+    // This shouldn't fail
+    try? createFolderOnDisk(title: item.title, inside: parentFolder, context: context)
+
+    let newFolder = Folder(
+      syncItem: item,
+      context: context
+    )
+
+    // insert into existing folder or library at index
+    if let relativePath = parentFolder,
+       let folder = getItemReference(with: relativePath, context: context) as? Folder {
+      folder.addToItems(newFolder)
+    } else {
+      let library = getLibraryReference(context: context)
+      library.addToItems(newFolder)
+    }
+
+    dataManager.saveSyncContext(context)
   }
 
   public func addBookmark(from bookmark: SimpleBookmark) async {
@@ -160,33 +182,33 @@ extension LibraryService: LibrarySyncProtocol {
     }
   }
 
-  public func getItemsToSync(remoteIdentifiers: [String]) -> [SyncableItem]? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-    fetchRequest.propertiesToFetch = SyncableItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
-    fetchRequest.predicate = NSPredicate(
-      format: "%K != nil AND NOT (%K IN %@)",
-      #keyPath(LibraryItem.library),
-      #keyPath(LibraryItem.relativePath),
-      remoteIdentifiers
-    )
-
-    let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Any]]
-
-    return parseSyncableItems(from: results)
-  }
-
-  public func getStoredItemIdentifiers(in parentFolder: String?) async -> [String]? {
+  public func getItemsToSync(remoteIdentifiers: [String]) async -> [SyncableItem]? {
     return await withCheckedContinuation { continuation in
       let context = dataManager.getContext()
       context.perform { [unowned self, context] in
-        let identifiers = getItemIdentifiers(in: parentFolder, context: context)
-        continuation.resume(returning: identifiers)
+        let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
+        fetchRequest.propertiesToFetch = SyncableItem.fetchRequestProperties
+        fetchRequest.resultType = .dictionaryResultType
+        fetchRequest.predicate = NSPredicate(
+          format: "NOT (%K IN %@)",
+          #keyPath(LibraryItem.relativePath),
+          remoteIdentifiers
+        )
+        let sort = NSSortDescriptor(
+          key: #keyPath(LibraryItem.relativePath),
+          ascending: true,
+          selector: #selector(NSString.localizedStandardCompare(_:))
+        )
+        fetchRequest.sortDescriptors = [sort]
+
+        let results = try? context.fetch(fetchRequest) as? [[String: Any]]
+
+        continuation.resume(returning: parseSyncableItems(from: results))
       }
     }
   }
 
-  public func fetchSyncableNestedContents(at relativePath: String) -> [SyncableItem]? {
+  public func getAllNestedItems(inside relativePath: String) -> [SyncableItem]? {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
     fetchRequest.propertiesToFetch = SyncableItem.fetchRequestProperties
     fetchRequest.resultType = .dictionaryResultType
@@ -241,11 +263,32 @@ extension LibraryService: LibrarySyncProtocol {
     })
   }
 
-  public func removeItems(notIn relativePaths: [String], parentFolder: String?) throws {
-    guard
-      let items = getItems(notIn: relativePaths, parentFolder: parentFolder)
-    else { return }
+  public func removeItems(notIn identifiers: [String], parentFolder: String?) async {
+    return await withCheckedContinuation { continuation in
+      let context = dataManager.getContext()
+      context.perform { [unowned self, context] in
+        guard
+          let items = getItems(notIn: identifiers, parentFolder: parentFolder, context: context)
+        else {
+          continuation.resume()
+          return
+        }
 
-    try delete(items, mode: .deep)
+        let backupFolderURL = DataManager.getBackupFolderURL()
+        let processedFolderURL = DataManager.getProcessedFolderURL()
+
+        /// Try to move files to backup folder before deleting
+        for item in items {
+          let fileURL = processedFolderURL.appendingPathComponent(item.relativePath)
+          if FileManager.default.fileExists(atPath: fileURL.path) {
+            let destinationURL = backupFolderURL.appendingPathComponent(item.relativePath)
+            try? FileManager.default.moveItem(at: fileURL, to: destinationURL)
+          }
+        }
+
+        try? delete(items, mode: .deep)
+        continuation.resume()
+      }
+    }
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -825,6 +825,32 @@ extension LibraryService {
     return getItems(notIn: relativePaths, parentFolder: parentFolder, context: dataManager.getContext())
   }
 
+  public func getItems(
+    in relativePaths: [String],
+    parentFolder: String?,
+    context: NSManagedObjectContext
+  ) -> [LibraryItem]? {
+    let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
+    if let parentFolder = parentFolder {
+      fetchRequest.predicate = NSPredicate(
+        format: "%K == %@ AND (%K IN %@)",
+        #keyPath(LibraryItem.folder.relativePath),
+        parentFolder,
+        #keyPath(LibraryItem.relativePath),
+        relativePaths
+      )
+    } else {
+      fetchRequest.predicate = NSPredicate(
+        format: "%K != nil AND (%K IN %@)",
+        #keyPath(LibraryItem.library),
+        #keyPath(LibraryItem.relativePath),
+        relativePaths
+      )
+    }
+
+    return try? context.fetch(fetchRequest)
+  }
+
   public func getItemProperty(_ property: String, relativePath: String) -> Any? {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
     fetchRequest.propertiesToFetch = [property]

--- a/Shared/Services/Sync/LibraryAPI.swift
+++ b/Shared/Services/Sync/LibraryAPI.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public enum LibraryAPI {
+  case syncedIdentifiers
   case contents(path: String)
   case upload(params: [String: Any])
   case update(params: [String: Any])
@@ -26,6 +27,8 @@ public enum LibraryAPI {
 extension LibraryAPI: Endpoint {
   public var path: String {
     switch self {
+    case .syncedIdentifiers:
+      return "/v1/library/keys"
     case .contents:
       return "/v1/library"
     case .upload:
@@ -55,6 +58,8 @@ extension LibraryAPI: Endpoint {
 
   public var method: HTTPMethod {
     switch self {
+    case .syncedIdentifiers:
+      return .get
     case .contents:
       return .get
     case .upload:
@@ -84,6 +89,8 @@ extension LibraryAPI: Endpoint {
 
   public var parameters: [String: Any]? {
     switch self {
+    case .syncedIdentifiers:
+      return nil
     case .contents(let path):
       return [
         "relativePath": path,

--- a/Shared/Services/Sync/LibraryItemSyncJob.swift
+++ b/Shared/Services/Sync/LibraryItemSyncJob.swift
@@ -33,6 +33,7 @@ class LibraryItemSyncJob: Job, BPLogger {
   let relativePath: String
   let jobType: JobType
   let parameters: [String: Any]
+  weak var uploadTask: URLSessionUploadTask?
 
   /// Initializer
   /// - Parameters:
@@ -240,7 +241,7 @@ class LibraryItemSyncJob: Job, BPLogger {
       }
     }
 
-    _ = self.client.upload(
+    uploadTask = self.client.upload(
       fileURL,
       remoteURL: remoteURL,
       taskDescription: relativePath,
@@ -257,6 +258,7 @@ class LibraryItemSyncJob: Job, BPLogger {
     case .success:
       Self.logger.trace("Finished \(self.jobType.rawValue) for: \(self.relativePath)")
     case .fail(let error):
+      uploadTask?.cancel()
       Self.logger.error("Error on jobType \(self.jobType.rawValue) for \(self.relativePath): \(error.localizedDescription)")
     }
   }

--- a/Shared/Services/Sync/Model/IdentifiersResponse.swift
+++ b/Shared/Services/Sync/Model/IdentifiersResponse.swift
@@ -1,0 +1,13 @@
+//
+//  IdentifiersResponse.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 6/7/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+
+struct IdentifiersResponse: Decodable {
+  let content: [String]
+}


### PR DESCRIPTION
## Approach

- When the user signs in, call new endpoint `v1/library/keys` to get all synced identifiers, and create an upload task for any local item not present in that array
- For regular list syncs, if an item is not present, keep a backup of the removed file just in case

## Things to be aware of

The backup files will be exposed via Settings → Storage Management → Cloud sync deleted items in the next PR