### PR TITLE
Improve upload tasks - Part 2

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -993,7 +993,8 @@ extension ItemListViewModel {
     )?.filter({ $0.type == .folder }) ?? []
 
     showOperationCompletedAlert(
-      with: itemIdentifiers,
+      itemIdentifiers: itemIdentifiers,
+      hasOnlyBooks: processedItems.allSatisfy({ $0.type == .book }),
       availableFolders: availableFolders,
       suggestedFolderName: suggestedFolderName
     )
@@ -1001,7 +1002,8 @@ extension ItemListViewModel {
 
   // swiftlint:disable:next function_body_length
   func showOperationCompletedAlert(
-    with items: [String],
+    itemIdentifiers: [String],
+    hasOnlyBooks: Bool,
     availableFolders: [SimpleLibraryItem],
     suggestedFolderName: String?
   ) {
@@ -1010,7 +1012,7 @@ extension ItemListViewModel {
     var firstTitle: String?
     if let suggestedFolderName {
       firstTitle = suggestedFolderName
-    } else if let relativePath = items.first {
+    } else if let relativePath = itemIdentifiers.first {
       firstTitle = libraryService.getItemProperty(#keyPath(LibraryItem.title), relativePath: relativePath) as? String
     }
 
@@ -1022,10 +1024,10 @@ extension ItemListViewModel {
 
     actions.append(BPActionItem(
       title: "library_title".localized,
-      handler: { [hasParentFolder, items, weak self] in
+      handler: { [hasParentFolder, itemIdentifiers, weak self] in
         guard hasParentFolder else { return }
 
-        self?.importIntoLibrary(items)
+        self?.importIntoLibrary(itemIdentifiers)
       }
     ))
 
@@ -1036,7 +1038,7 @@ extension ItemListViewModel {
 
         self?.showCreateFolderAlert(
           placeholder: placeholder,
-          with: items,
+          with: itemIdentifiers,
           type: .folder
         )
       }
@@ -1045,11 +1047,11 @@ extension ItemListViewModel {
     actions.append(BPActionItem(
       title: "existing_playlist_button".localized,
       isEnabled: !availableFolders.isEmpty,
-      handler: { [items, availableFolders, weak self] in
+      handler: { [itemIdentifiers, availableFolders, weak self] in
         self?.onTransition?(.showItemSelectionScreen(
           availableItems: availableFolders,
           selectionHandler: { selectedFolder in
-            self?.importIntoFolder(selectedFolder, items: items, type: .folder)
+            self?.importIntoFolder(selectedFolder, items: itemIdentifiers, type: .folder)
           }
         ))
       }
@@ -1057,11 +1059,11 @@ extension ItemListViewModel {
 
     actions.append(BPActionItem(
       title: "bound_books_create_button".localized,
-      isEnabled: items is [Book],
+      isEnabled: hasOnlyBooks,
       handler: { [firstTitle, weak self] in
         let placeholder = firstTitle ?? "bound_books_new_title_placeholder".localized
 
-        self?.showCreateFolderAlert(placeholder: placeholder, with: items, type: .bound)
+        self?.showCreateFolderAlert(placeholder: placeholder, with: itemIdentifiers, type: .bound)
       }
     ))
 

--- a/BookPlayerTests/Mocks/NetworkClientMock.swift
+++ b/BookPlayerTests/Mocks/NetworkClientMock.swift
@@ -17,7 +17,7 @@ class NetworkClientMock: NetworkClientProtocol {
     remoteURL: URL,
     taskDescription: String?,
     delegate: URLSessionTaskDelegate
-  ) -> URLSessionUploadTask {
+  ) async -> URLSessionTask {
     return URLSession.shared.uploadTask(with: URLRequest(url: URL(string: "https://google.com")!), from: Data())
   }
 

--- a/Shared/Network/NetworkClient.swift
+++ b/Shared/Network/NetworkClient.swift
@@ -32,7 +32,7 @@ public protocol NetworkClientProtocol {
     remoteURL: URL,
     taskDescription: String?,
     delegate: URLSessionTaskDelegate
-  ) -> URLSessionUploadTask
+  ) async -> URLSessionTask
 
   func download(
     url: URL,
@@ -118,7 +118,7 @@ public class NetworkClient: NetworkClientProtocol, BPLogger {
     remoteURL: URL,
     taskDescription: String?,
     delegate: URLSessionTaskDelegate
-  ) -> URLSessionUploadTask {
+  ) async -> URLSessionTask {
     var request = URLRequest(url: remoteURL)
     request.cachePolicy = .reloadIgnoringLocalCacheData
     request.httpMethod = HTTPMethod.put.rawValue
@@ -133,13 +133,23 @@ public class NetworkClient: NetworkClientProtocol, BPLogger {
       delegateQueue: OperationQueue()
     )
 
-    Self.logger.trace("[Request] PUT \(remoteURL.path)")
+    let allTasks = await session.allTasks
 
-    let task = session.uploadTask(with: request, fromFile: fileURL)
-    task.taskDescription = taskDescription
-    task.resume()
+    /// Avoid creating a new task if one exists already to avoid double uploads
+    if let existingTask = allTasks.first(where: { task in
+      task.taskDescription == taskDescription
+    }) {
+      Self.logger.trace("Existing request for: \(remoteURL.path)")
+      return existingTask
+    } else {
+      Self.logger.trace("[Request] PUT \(remoteURL.path)")
 
-    return task
+      let task = session.uploadTask(with: request, fromFile: fileURL)
+      task.taskDescription = taskDescription
+      task.resume()
+
+      return task
+    }
   }
 
   func executeRequest<T: Decodable>(


### PR DESCRIPTION
## Purpose

- Fix restarting background upload task, and avoid duplicate uploads (it's only necessary to recreate the URLSession, no need to resume the task)
- Mark item as synced after the upload has finished (this is so the endpoint /v1/library/keys returns the proper keys that haven't been uploaded yet)
- Unrelated: Fix volume option not enabled when importing single folders