### PR TITLE
VoiceOver: Include duration value to be read for items on the library

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "No Title";
 "voiceover_no_author" = "No Author";
-"voiceover_book_progress" = "%@ by %@, %d percent completed";
+"voiceover_book_progress" = "%@ by %@, %d percent completed, duration: %@";
 "voiceover_no_file_title" = "No File Title";
 "voiceover_no_file_subtitle" = "No File Subtitle";
 "voiceover_no_playlist_title" = "No Folder Title";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "New Book Volume";
 "bound_books_create_alert_description" = "Make sure items are in correct order. To reorder chapters later you need convert the volume back into a folder, reorder items and then re-create the volume.";
 "bound_books_create_alert_title" = "Create a volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed";
+"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed, duration %@";
 "voiceover_no_bound_books_title" = "No Volume Title";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Set default speed";

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -472,7 +472,8 @@ extension ItemListViewController: UITableViewDataSource {
         options: [.targetCache(ArtworkService.cache)]
       )
     }
-    cell.setAccessibilityLabels()
+    let label = viewModel.getAccessibilityLabel(for: item)
+    cell.setAccessibilityLabel(label)
     return cell
   }
 }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -472,7 +472,7 @@ extension ItemListViewController: UITableViewDataSource {
         options: [.targetCache(ArtworkService.cache)]
       )
     }
-    let label = viewModel.getAccessibilityLabel(for: item)
+    let label = VoiceOverService.getAccessibilityLabel(for: item)
     cell.setAccessibilityLabel(label)
     return cell
   }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -309,6 +309,30 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     return index
   }
 
+  func getAccessibilityLabel(for item: SimpleLibraryItem) -> String {
+    switch item.type {
+    case .book:
+      return String.localizedStringWithFormat(
+        "voiceover_book_progress".localized,
+        item.title,
+        item.details,
+        Int(item.percentCompleted)
+      )
+    case .folder:
+      return String.localizedStringWithFormat(
+        "voiceover_playlist_progress".localized,
+        item.title,
+        Int(item.percentCompleted)
+      )
+    case .bound:
+      return String.localizedStringWithFormat(
+        "voiceover_bound_books_progress".localized,
+        item.title,
+        Int(item.percentCompleted)
+      )
+    }
+  }
+
   private func playNextBook(in item: SimpleLibraryItem) {
     guard item.type == .folder else { return }
 

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -309,30 +309,6 @@ class ItemListViewModel: BaseViewModel<ItemListCoordinator> {
     return index
   }
 
-  func getAccessibilityLabel(for item: SimpleLibraryItem) -> String {
-    switch item.type {
-    case .book:
-      return String.localizedStringWithFormat(
-        "voiceover_book_progress".localized,
-        item.title,
-        item.details,
-        Int(item.percentCompleted)
-      )
-    case .folder:
-      return String.localizedStringWithFormat(
-        "voiceover_playlist_progress".localized,
-        item.title,
-        Int(item.percentCompleted)
-      )
-    case .bound:
-      return String.localizedStringWithFormat(
-        "voiceover_bound_books_progress".localized,
-        item.title,
-        Int(item.percentCompleted)
-      )
-    }
-  }
-
   private func playNextBook(in item: SimpleLibraryItem) {
     guard item.type == .folder else { return }
 

--- a/BookPlayer/Library/ItemList Screen/Views/BookCellView.swift
+++ b/BookPlayer/Library/ItemList Screen/Views/BookCellView.swift
@@ -212,13 +212,9 @@ class BookCellView: UITableViewCell {
 // MARK: - Voiceover
 
 extension BookCellView {
-  public func setAccessibilityLabels() {
-    let voiceOverService = VoiceOverService()
+  public func setAccessibilityLabel(_ label: String) {
     isAccessibilityElement = true
-    accessibilityLabel = voiceOverService.bookCellView(type: self.type,
-                                                       title: self.title,
-                                                       subtitle: self.subtitle,
-                                                       progress: self.progress)
+    accessibilityLabel = label
   }
 }
 

--- a/BookPlayer/Library/SearchList Screen/SearchListViewController.swift
+++ b/BookPlayer/Library/SearchList Screen/SearchListViewController.swift
@@ -187,7 +187,8 @@ extension SearchListViewController: UITableViewDataSource {
       placeholder: self.defaultArtwork,
       options: [.targetCache(ArtworkService.cache)]
     )
-    cell.setAccessibilityLabels()
+    let label = VoiceOverService.getAccessibilityLabel(for: item)
+    cell.setAccessibilityLabel(label)
     return cell
   }
 }

--- a/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
@@ -170,7 +170,7 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
       }
     )
     self.artworkOverlay.isAccessibilityElement = true
-    self.artworkOverlay.accessibilityLabel = VoiceOverService().playerMetaText(
+    self.artworkOverlay.accessibilityLabel = VoiceOverService.playerMetaText(
       title: title,
       author: author
     )

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -2,40 +2,50 @@ import BookPlayerKit
 import Foundation
 
 class VoiceOverService {
-    var title: String?
-    var subtitle: String?
-    var type: SimpleItemType!
-    var progress: Double?
+  var title: String?
+  var subtitle: String?
+  var type: SimpleItemType!
+  var progress: Double?
 
-    // MARK: - BookCellView
+  // MARK: - BookCellView
 
-    public func bookCellView(type: SimpleItemType, title: String?, subtitle: String?, progress: Double?) -> String {
-        self.type = type
-        self.title = title
-        self.subtitle = subtitle
-        self.progress = progress
+  public func bookCellView(
+    type: SimpleItemType,
+    title: String?,
+    subtitle: String?,
+    progress: Double?
+  ) -> String {
+    self.type = type
+    self.title = title
+    self.subtitle = subtitle
+    self.progress = progress
 
-        switch type {
-        case .book:
-          return self.bookText()
-        case .folder:
-          return self.regularFolderText()
-        case .bound:
-          return self.boundFolderText()
-        }
+    switch type {
+    case .book:
+      return self.bookText()
+    case .folder:
+      return self.regularFolderText()
+    case .bound:
+      return self.boundFolderText()
     }
+  }
 
-    fileprivate func bookText() -> String {
-        let voiceOverTitle = self.title ?? "voiceover_no_title".localized
-        let voiceOverSubtitle = self.subtitle ?? "voiceover_no_author".localized
-        return String.localizedStringWithFormat("voiceover_book_progress".localized, voiceOverTitle, voiceOverSubtitle, self.progressPercent())
-    }
+  fileprivate func bookText() -> String {
+    let voiceOverTitle = self.title ?? "voiceover_no_title".localized
+    let voiceOverSubtitle = self.subtitle ?? "voiceover_no_author".localized
+    return String.localizedStringWithFormat(
+      "voiceover_book_progress".localized,
+      voiceOverTitle,
+      voiceOverSubtitle,
+      self.progressPercent()
+    )
+  }
 
-    fileprivate func fileText() -> String {
-        let voiceOverTitle = self.title ?? "voiceover_no_file_title".localized
-        let voiceOverSubtitle = self.subtitle ?? "voiceover_no_file_subtitle".localized
-        return "\(voiceOverTitle) \(voiceOverSubtitle)"
-    }
+  fileprivate func fileText() -> String {
+    let voiceOverTitle = self.title ?? "voiceover_no_file_title".localized
+    let voiceOverSubtitle = self.subtitle ?? "voiceover_no_file_subtitle".localized
+    return "\(voiceOverTitle) \(voiceOverSubtitle)"
+  }
 
   fileprivate func regularFolderText() -> String {
     let voiceOverTitle = self.title ?? "voiceover_no_playlist_title".localized
@@ -43,63 +53,63 @@ class VoiceOverService {
   }
 
   fileprivate func boundFolderText() -> String {
-      let voiceOverTitle = self.title ?? "voiceover_no_bound_books_title".localized
-      return String.localizedStringWithFormat("voiceover_bound_books_progress".localized, voiceOverTitle, self.progressPercent())
+    let voiceOverTitle = self.title ?? "voiceover_no_bound_books_title".localized
+    return String.localizedStringWithFormat("voiceover_bound_books_progress".localized, voiceOverTitle, self.progressPercent())
   }
 
-    fileprivate func progressPercent() -> Int {
-      guard let progress = progress, !progress.isNaN, !progress.isInfinite else {
-        return 0
-      }
-      return Int(progress)
+  fileprivate func progressPercent() -> Int {
+    guard let progress = progress, !progress.isNaN, !progress.isInfinite else {
+      return 0
     }
+    return Int(progress)
+  }
 
-    // MARK: PlayerMetaView
+  // MARK: PlayerMetaView
 
-    public func playerMetaText(
-      title: String,
-      author: String
-    ) -> String {
-      return String(describing: String.localizedStringWithFormat("voiceover_book_info".localized, title, author))
+  public func playerMetaText(
+    title: String,
+    author: String
+  ) -> String {
+    return String(describing: String.localizedStringWithFormat("voiceover_book_info".localized, title, author))
+  }
+
+  // MARK: - ArtworkControl
+
+  public static func rewindText() -> String {
+    return String(describing: String.localizedStringWithFormat("voiceover_rewind_time".localized, self.secondsToMinutes(PlayerManager.rewindInterval.rounded())))
+  }
+
+  public static func fastForwardText() -> String {
+    return String(describing: String.localizedStringWithFormat("voiceover_forward_time".localized, self.secondsToMinutes(PlayerManager.forwardInterval.rounded())))
+  }
+
+  public static func secondsToMinutes(_ interval: TimeInterval) -> String {
+    let absInterval = abs(interval)
+    let hours = (absInterval / 3600.0).rounded(.towardZero)
+    let minutes = (absInterval.truncatingRemainder(dividingBy: 3600) / 60).rounded(.towardZero)
+    let seconds = absInterval.truncatingRemainder(dividingBy: 60).truncatingRemainder(dividingBy: 60).rounded()
+
+    let hoursText = self.pluralization(amount: Int(hours), interval: .hour)
+    let minutesText = self.pluralization(amount: Int(minutes), interval: .minute)
+    let secondsText = self.pluralization(amount: Int(seconds), interval: .second)
+
+    return String("\(hoursText)\(minutesText)\(secondsText)".dropLast())
+  }
+
+  private static func pluralization(amount: Int, interval: TimeUnit) -> String {
+    switch amount {
+    case 1:
+      return "\(amount) \(interval.rawValue) "
+    case amount where amount > 1:
+      return "\(amount) \(interval.rawValue)s "
+    default:
+      return ""
     }
-
-    // MARK: - ArtworkControl
-
-    public static func rewindText() -> String {
-        return String(describing: String.localizedStringWithFormat("voiceover_rewind_time".localized, self.secondsToMinutes(PlayerManager.rewindInterval.rounded())))
-    }
-
-    public static func fastForwardText() -> String {
-        return String(describing: String.localizedStringWithFormat("voiceover_forward_time".localized, self.secondsToMinutes(PlayerManager.forwardInterval.rounded())))
-    }
-
-    public static func secondsToMinutes(_ interval: TimeInterval) -> String {
-        let absInterval = abs(interval)
-        let hours = (absInterval / 3600.0).rounded(.towardZero)
-        let minutes = (absInterval.truncatingRemainder(dividingBy: 3600) / 60).rounded(.towardZero)
-        let seconds = absInterval.truncatingRemainder(dividingBy: 60).truncatingRemainder(dividingBy: 60).rounded()
-
-        let hoursText = self.pluralization(amount: Int(hours), interval: .hour)
-        let minutesText = self.pluralization(amount: Int(minutes), interval: .minute)
-        let secondsText = self.pluralization(amount: Int(seconds), interval: .second)
-
-        return String("\(hoursText)\(minutesText)\(secondsText)".dropLast())
-    }
-
-    private static func pluralization(amount: Int, interval: TimeUnit) -> String {
-        switch amount {
-        case 1:
-            return "\(amount) \(interval.rawValue) "
-        case amount where amount > 1:
-            return "\(amount) \(interval.rawValue)s "
-        default:
-            return ""
-        }
-    }
+  }
 }
 
 private enum TimeUnit: String {
-    case minute
-    case second
-    case hour
+  case minute
+  case second
+  case hour
 }

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -2,7 +2,35 @@ import BookPlayerKit
 import Foundation
 
 class VoiceOverService {
-  // MARK: PlayerMetaView
+  // MARK: - BookCellView
+
+  public static func getAccessibilityLabel(for item: SimpleLibraryItem) -> String {
+    switch item.type {
+    case .book:
+      return String.localizedStringWithFormat(
+        "voiceover_book_progress".localized,
+        item.title,
+        item.details,
+        Int(item.percentCompleted),
+        item.durationFormatted
+      )
+    case .folder:
+      return String.localizedStringWithFormat(
+        "voiceover_playlist_progress".localized,
+        item.title,
+        Int(item.percentCompleted)
+      )
+    case .bound:
+      return String.localizedStringWithFormat(
+        "voiceover_bound_books_progress".localized,
+        item.title,
+        Int(item.percentCompleted),
+        item.durationFormatted
+      )
+    }
+  }
+
+  // MARK: - PlayerMetaView
 
   public static func playerMetaText(
     title: String,

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -2,71 +2,9 @@ import BookPlayerKit
 import Foundation
 
 class VoiceOverService {
-  var title: String?
-  var subtitle: String?
-  var type: SimpleItemType!
-  var progress: Double?
-
-  // MARK: - BookCellView
-
-  public func bookCellView(
-    type: SimpleItemType,
-    title: String?,
-    subtitle: String?,
-    progress: Double?
-  ) -> String {
-    self.type = type
-    self.title = title
-    self.subtitle = subtitle
-    self.progress = progress
-
-    switch type {
-    case .book:
-      return self.bookText()
-    case .folder:
-      return self.regularFolderText()
-    case .bound:
-      return self.boundFolderText()
-    }
-  }
-
-  fileprivate func bookText() -> String {
-    let voiceOverTitle = self.title ?? "voiceover_no_title".localized
-    let voiceOverSubtitle = self.subtitle ?? "voiceover_no_author".localized
-    return String.localizedStringWithFormat(
-      "voiceover_book_progress".localized,
-      voiceOverTitle,
-      voiceOverSubtitle,
-      self.progressPercent()
-    )
-  }
-
-  fileprivate func fileText() -> String {
-    let voiceOverTitle = self.title ?? "voiceover_no_file_title".localized
-    let voiceOverSubtitle = self.subtitle ?? "voiceover_no_file_subtitle".localized
-    return "\(voiceOverTitle) \(voiceOverSubtitle)"
-  }
-
-  fileprivate func regularFolderText() -> String {
-    let voiceOverTitle = self.title ?? "voiceover_no_playlist_title".localized
-    return String.localizedStringWithFormat("voiceover_playlist_progress".localized, voiceOverTitle, self.progressPercent())
-  }
-
-  fileprivate func boundFolderText() -> String {
-    let voiceOverTitle = self.title ?? "voiceover_no_bound_books_title".localized
-    return String.localizedStringWithFormat("voiceover_bound_books_progress".localized, voiceOverTitle, self.progressPercent())
-  }
-
-  fileprivate func progressPercent() -> Int {
-    guard let progress = progress, !progress.isNaN, !progress.isInfinite else {
-      return 0
-    }
-    return Int(progress)
-  }
-
   // MARK: PlayerMetaView
 
-  public func playerMetaText(
+  public static func playerMetaText(
     title: String,
     author: String
   ) -> String {

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "ايقاف";
 "voiceover_no_title" = "لا يوجد عنوان";
 "voiceover_no_author" = "لا يوجد كاتب";
-"voiceover_book_progress" = "%@ من %@ ، اكتمل %d";
+"voiceover_book_progress" = "%@ من %@ ، اكتمل %d في المائة ، المدة: %@";
 "voiceover_no_file_title" = "لا يوجد عنوان ملف";
 "voiceover_no_file_subtitle" = "لا يوجد ملف الترجمة";
 "voiceover_no_playlist_title" = "لا يوجد عنوان مجلد";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "حجم الكتاب الجديد";
 "bound_books_create_alert_description" = "تأكد من أن العناصر في الترتيب الصحيح. لإعادة ترتيب الفصول لاحقًا ، تحتاج إلى تحويل وحدة التخزين مرة أخرى إلى مجلد ، وإعادة ترتيب العناصر ثم إعادة إنشاء المجلد.";
 "bound_books_create_alert_title" = "إنشاء وحدة تخزين";
-"voiceover_bound_books_progress" = "%@ ، حجم الصوت ، اكتمل %d بالمائة";
+"voiceover_bound_books_progress" = "%@ ، وحدة التخزين ، %d مكتمل ، المدة %@";
 "voiceover_no_bound_books_title" = "لا يوجد عنوان وحدة التخزين";
 "default_title" = "محددة مسبقا";
 "voiceover_default_speed_title" = "ضبط السرعة الافتراضية";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pozastavit";
 "voiceover_no_title" = "Žádný název";
 "voiceover_no_author" = "Žádný autor";
-"voiceover_book_progress" = "%@z%@, %d procent Dokončeno";
+"voiceover_book_progress" = "%@ od %@, %d procent dokončeno, trvání: %@";
 "voiceover_no_file_title" = "Žádný název souboru";
 "voiceover_no_file_subtitle" = "Žádný podtitul souboru";
 "voiceover_no_playlist_title" = "Žádný název složky";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nový svazek knihy";
 "bound_books_create_alert_description" = "Ujistěte se, že položky jsou ve správném pořadí. Chcete-li později změnit pořadí kapitol, musíte svazek převést zpět na složku, změnit pořadí položek a poté svazek znovu vytvořit.";
 "bound_books_create_alert_title" = "Vytvořte svazek";
-"voiceover_bound_books_progress" = "%@, objem, %d procent Dokončeno";
+"voiceover_bound_books_progress" = "%@, objem, %d procent dokončeno, trvání %@";
 "voiceover_no_bound_books_title" = "Bez názvu svazku";
 "default_title" = "Výchozí";
 "voiceover_default_speed_title" = "Nastavte výchozí rychlost";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Ingen titel";
 "voiceover_no_author" = "Ingen forfatter";
-"voiceover_book_progress" = "%@ af %@, %d procent fuldført";
+"voiceover_book_progress" = "%@ af %@, %d procent fuldført, varighed: %@";
 "voiceover_no_file_title" = "Ingen filnavn";
 "voiceover_no_file_subtitle" = "Ingen undertekstfil";
 "voiceover_no_playlist_title" = "Ingen mappetitel";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Ny bogbind";
 "bound_books_create_alert_description" = "Sørg for, at elementerne er i den rigtige rækkefølge. Hvis du vil ændre rækkefølgen af kapitler senere skal du konvertere bindet tilbage til en mappe, omarrangere elementer og derefter genskabe bindet.";
 "bound_books_create_alert_title" = "Opret et volumen";
-"voiceover_bound_books_progress" = "%@, Volumen, %d procent fuldført";
+"voiceover_bound_books_progress" = "%@, Volumen, %d procent fuldført, varighed %@";
 "voiceover_no_bound_books_title" = "Ingen bindtitel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Indstil standardhastighed";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Kein Titel angegeben";
 "voiceover_no_author" = "Kein Autor angegeben";
-"voiceover_book_progress" = "%@ von %@, %d% abgeschlossen";
+"voiceover_book_progress" = "%@ von %@, %d% abgeschlossen, Dauer: %@";
 "voiceover_no_file_title" = "Datei ohne Titel";
 "voiceover_no_file_subtitle" = "Datei ohne Untertitel";
 "voiceover_no_playlist_title" = "Kein Ordnertitel";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Neuer Band";
 "bound_books_create_alert_description" = "Achte darauf, dass alle Kapitel in der richtigen Reihenfolge vorliegen. Um Kapitel neu zu sortieren, kannst du den Band wieder in einen Ordner konvertieren, dort die Kapitel neu anordnen und dann wieder einen Band erstellen.";
 "bound_books_create_alert_title" = "Band erstellen";
-"voiceover_bound_books_progress" = "%@, Band, %d Prozent gehört";
+"voiceover_bound_books_progress" = "%@, Band, %d Prozent gehört, Dauer %@";
 "voiceover_no_bound_books_title" = "Band ohne Titel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Standardgeschwindigkeit einstellen";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "No Title";
 "voiceover_no_author" = "No Author";
-"voiceover_book_progress" = "%@ by %@, %d percent completed";
+"voiceover_book_progress" = "%@ by %@, %d percent completed, duration: %@";
 "voiceover_no_file_title" = "No File Title";
 "voiceover_no_file_subtitle" = "No File Subtitle";
 "voiceover_no_playlist_title" = "No Folder Title";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "New Book Volume";
 "bound_books_create_alert_description" = "Make sure items are in correct order. To reorder chapters later you need convert the volume back into a folder, reorder items and then re-create the volume.";
 "bound_books_create_alert_title" = "Create a volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed";
+"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed, duration %@";
 "voiceover_no_bound_books_title" = "No Volume Title";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Set default speed";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pausar";
 "voiceover_no_title" = "Sin título";
 "voiceover_no_author" = "Sin autor";
-"voiceover_book_progress" = "%@ por %@, %d porcentaje completado";
+"voiceover_book_progress" = "%@ por %@, %d porcentaje completado, duración: %@";
 "voiceover_no_file_title" = "Sin título de archivo";
 "voiceover_no_file_subtitle" = "Sin subtítulo de archivo";
 "voiceover_no_playlist_title" = "Sin título de carpeta";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nuevo Volumen";
 "bound_books_create_alert_description" = "Asegúrate de que los libros estén en el orden correcto. Para reordenar los capítulos más adelante, deberás convertir el volumen nuevamente a una carpeta, reordenar los elementos y luego volver a crear el volumen.";
 "bound_books_create_alert_title" = "Crear un volumen";
-"voiceover_bound_books_progress" = "%@, Volumen, %d porcentaje completado";
+"voiceover_bound_books_progress" = "%@, volumen, %d porcentaje completado, duración %@";
 "voiceover_no_bound_books_title" = "Sin título";
 "default_title" = "Predeterminado";
 "voiceover_default_speed_title" = "Establecer velocidad predeterminada";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Keskeytä";
 "voiceover_no_title" = "Ei otsikkoa";
 "voiceover_no_author" = "Ei kirjailijaa";
-"voiceover_book_progress" = "%@ kirjoittaja %@ , %d prosenttia valmis";
+"voiceover_book_progress" = "%@ kirjoittaja %@ , %d prosenttia valmis, kesto: %@";
 "voiceover_no_file_title" = "Ei tiedoston otsikkoa";
 "voiceover_no_file_subtitle" = "Ei tiedoston alaotsikkoa";
 "voiceover_no_playlist_title" = "Ei kansion otsikkoa";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Uusi kirja";
 "bound_books_create_alert_description" = "Varmista, että kohteet ovat oikeassa järjestyksessä. Jos haluat uudelleenjärjestää kappaleet myöhemmin, sinun on muutettava kirja takaisin kansioksi, uudelleenjärjestettävä kohteet ja luotava kirja uudelleen.";
 "bound_books_create_alert_title" = "Luo kirja";
-"voiceover_bound_books_progress" = "Kirja %@, %d prosenttia valmis";
+"voiceover_bound_books_progress" = "%@, määrä, %d prosenttia valmis, kesto %@";
 "voiceover_no_bound_books_title" = "Ei kirjan otsikkoa";
 "default_title" = "Oletus";
 "voiceover_default_speed_title" = "Aseta oletusnopeus";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Sans titre";
 "voiceover_no_author" = "Aucun auteur";
-"voiceover_book_progress" = "%@ par %@, %d pour cent terminés";
+"voiceover_book_progress" = "%@ af %@, %d procent fuldført, varighed: %@";
 "voiceover_no_file_title" = "Fichier sans titre";
 "voiceover_no_file_subtitle" = "Fichier sans sous-titre";
 "voiceover_no_playlist_title" = "Aucun titre de dossier";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nouveau volume de livre";
 "bound_books_create_alert_description" = "Assurez-vous que les éléments sont dans le bon ordre. Pour réorganiser les chapitres ultérieurement, vous devez reconvertir le volume en dossier, réorganiser les éléments, puis recréer le volume.";
 "bound_books_create_alert_title" = "Créer un volume";
-"voiceover_bound_books_progress" = "%@, volume, %d pour cent terminé";
+"voiceover_bound_books_progress" = "%@, Volumen, %d procent fuldført, varighed %@";
 "voiceover_no_bound_books_title" = "Pas de titre de volume";
 "default_title" = "Défaut";
 "voiceover_default_speed_title" = "Définir la vitesse par défaut";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Szünet";
 "voiceover_no_title" = "Nincs cím";
 "voiceover_no_author" = "Nincs szerző";
-"voiceover_book_progress" = "%@ - %@, %d% meghallgatva";
+"voiceover_book_progress" = "%@ – %@, %d százalék kész, időtartam: %@";
 "voiceover_no_file_title" = "A fájlnak nincs címe";
 "voiceover_no_file_subtitle" = "A fájlnak nincsen felirata";
 "voiceover_no_playlist_title" = "Nincs mappa címe";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Új könyvkötet";
 "bound_books_create_alert_description" = "Győződjön meg arról, hogy az elemek megfelelő sorrendben vannak. A fejezetek későbbi átrendezéséhez vissza kell alakítania a kötetet mappává, át kell rendeznie az elemeket, majd újra létre kell hoznia a kötetet.";
 "bound_books_create_alert_title" = "Kötet létrehozása";
-"voiceover_bound_books_progress" = "%@, kötet, %d% kész";
+"voiceover_bound_books_progress" = "%@, kötet, %d százalék kész, időtartam %@";
 "voiceover_no_bound_books_title" = "Nincs kötet címke";
 "default_title" = "Alapértelmezett";
 "voiceover_default_speed_title" = "Állítsa be az alapértelmezett sebességet";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pausa";
 "voiceover_no_title" = "Nessun titolo";
 "voiceover_no_author" = "Nessun autore";
-"voiceover_book_progress" = "%@ di %@, %d% completato";
+"voiceover_book_progress" = "%@ di %@ , %d percento completato, durata: %@";
 "voiceover_no_file_title" = "Nessun titolo del file";
 "voiceover_no_file_subtitle" = "Nessun sottotitolo del file";
 "voiceover_no_playlist_title" = "Nessun titolo della cartella";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nuovo volume del libro";
 "bound_books_create_alert_description" = "Assicurati che gli articoli siano nell'ordine corretto. Per riordinare i capitoli in un secondo momento è necessario riconvertire il volume in una cartella, riordinare gli elementi e quindi ricreare il volume.";
 "bound_books_create_alert_title" = "Crea un volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percento completato";
+"voiceover_bound_books_progress" = "%@, Volume, %d percento completato, durata %@";
 "voiceover_no_bound_books_title" = "Nessun titolo del volume";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Imposta la velocità predefinita";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pauze";
 "voiceover_no_title" = "Geen titel";
 "voiceover_no_author" = "Geen auteur";
-"voiceover_book_progress" = "%@ door %@ , %d procent voltooid";
+"voiceover_book_progress" = "%@ door %@ , %d procent voltooid, duur: %@";
 "voiceover_no_file_title" = "Geen bestandstitel";
 "voiceover_no_file_subtitle" = "Geen ondertitel bestand";
 "voiceover_no_playlist_title" = "Geen maptitel";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nieuw boekvolume";
 "bound_books_create_alert_description" = "Zorg ervoor dat de artikelen in de juiste volgorde staan. Om hoofdstukken later opnieuw te ordenen, moet u het volume weer in een map omzetten, items opnieuw ordenen en vervolgens het volume opnieuw maken.";
 "bound_books_create_alert_title" = "Een volume maken";
-"voiceover_bound_books_progress" = "%@, Volume, %d procent Voltooid";
+"voiceover_bound_books_progress" = "%@, volume, %d procent voltooid, duur %@";
 "voiceover_no_bound_books_title" = "Geen volumetitel";
 "default_title" = "Standaard";
 "voiceover_default_speed_title" = "Standaardsnelheid instellen";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pauza";
 "voiceover_no_title" = "Brak tytułu";
 "voiceover_no_author" = "Brak autora";
-"voiceover_book_progress" = "%@ - %@, ukończono %d procent";
+"voiceover_book_progress" = "%@ do %@, ukończono %d procent, czas trwania: %@";
 "voiceover_no_file_title" = "Brak tytułu pliku";
 "voiceover_no_file_subtitle" = "Brak tytułu pliku";
 "voiceover_no_playlist_title" = "Brak tytułu folderu";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nowy Wolumin Książki";
 "bound_books_create_alert_description" = "Upewnij się, że elementy są we właściwej kolejności. Aby później zmienić kolejność rozdziałów, należy przekonwertować wolumin z powrotem na folder, zmienić kolejność elementów, a następnie ponownie utworzyć wolumin.";
 "bound_books_create_alert_title" = "Utwórz wolumin";
-"voiceover_bound_books_progress" = "%@, Wolumin, %d procent Ukończono";
+"voiceover_bound_books_progress" = "%@, Wolumin, %d procent Ukończono, czas trwania %@";
 "voiceover_no_bound_books_title" = "Brak Nazwy Woluminu";
 "default_title" = "Domyślna";
 "voiceover_default_speed_title" = "Ustaw domyślną prędkość";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pausa";
 "voiceover_no_title" = "Sem Título";
 "voiceover_no_author" = "Autor desconhecido";
-"voiceover_book_progress" = "%@ de %@, %d por cento concluído";
+"voiceover_book_progress" = "%@ por %@, %d por cento concluído, duração: %@";
 "voiceover_no_file_title" = "Arquivo Sem Título";
 "voiceover_no_file_subtitle" = "Sem legenda no Arquivo";
 "voiceover_no_playlist_title" = "Sem título de pasta";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Novo Volume do Livro";
 "bound_books_create_alert_description" = "Certifique-se de que os itens estão na ordem correta. Para reordenar capítulos mais tarde, você precisa converter o volume de volta em uma pasta, reordenar itens e, em seguida, recriar novamente o volume.";
 "bound_books_create_alert_title" = "Criar um volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d por cento Concluído";
+"voiceover_bound_books_progress" = "%@, Volume, %d por cento Concluído, duração %@";
 "voiceover_no_bound_books_title" = "Sem título de Volume";
 "default_title" = "Padrão";
 "voiceover_default_speed_title" = "Definir velocidade padrão";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pauză";
 "voiceover_no_title" = "Fără titlu";
 "voiceover_no_author" = "Fără autor";
-"voiceover_book_progress" = "%@cate%@,%dprocent finalizat";
+"voiceover_book_progress" = "%@ de %@ , %d procente finalizate, durata: %@";
 "voiceover_no_file_title" = "Fără titlu de fișier";
 "voiceover_no_file_subtitle" = "Fără fișier de subtitrare";
 "voiceover_no_playlist_title" = "Fără titlu de folder";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Volum nou de carte";
 "bound_books_create_alert_description" = "Asigurați-vă că articolele sunt în ordinea corectă. Pentru a reordona capitolele mai târziu, trebuie să convertiți volumul înapoi într-un folder, să reordonați articolele și apoi să recreați volumul.";
 "bound_books_create_alert_title" = "Creați un volum";
-"voiceover_bound_books_progress" = "%@, Volum, %d la sută Finalizat";
+"voiceover_bound_books_progress" = "%@, Volum, %d la sută Finalizat, durata %@";
 "voiceover_no_bound_books_title" = "Fără titlu de volum";
 "default_title" = "Mod implicit";
 "voiceover_default_speed_title" = "Setați viteza implicită";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Пауза";
 "voiceover_no_title" = "Без названия";
 "voiceover_no_author" = "Неизвестный автор";
-"voiceover_book_progress" = "%@, %@ %d% прослушано";
+"voiceover_book_progress" = "%@ к %@, %d процентов выполнения, продолжительность: %@";
 "voiceover_no_file_title" = "Нет названия файла";
 "voiceover_no_file_subtitle" = "Подзаголовок файла отсутствует";
 "voiceover_no_playlist_title" = "Нет названия папки";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Новая книга";
 "bound_books_create_alert_description" = "Убедитесь, что файлы расположены в правильном порядке. Чтобы позже изменить порядок глав, нужно преобразовать книгу обратно в папку, изменить порядок файлов, а затем снова создать книгу.";
 "bound_books_create_alert_title" = "Создать книгу";
-"voiceover_bound_books_progress" = "Книга %@, воспроизведено %d процентов";
+"voiceover_bound_books_progress" = "%@, Объем, %d процентов Выполнено, продолжительность %@";
 "voiceover_no_bound_books_title" = "Отсутствует название книги";
 "default_title" = "Дефолт";
 "voiceover_default_speed_title" = "Установить скорость по умолчанию";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Pozastaviť";
 "voiceover_no_title" = "Žiadny názov";
 "voiceover_no_author" = "Žiadny autor";
-"voiceover_book_progress" = "%@ z %@, %d percent dokončených";
+"voiceover_book_progress" = "%@ podľa %@, %d percent dokončených, trvanie: %@";
 "voiceover_no_file_title" = "Žiadny názov súboru";
 "voiceover_no_file_subtitle" = "Žiadny podtitul súboru";
 "voiceover_no_playlist_title" = "Žiadny názov priečinka";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nový zväzok knihy";
 "bound_books_create_alert_description" = "Skontrolujte, či sú položky v správnom poradí. Ak chcete neskôr zmeniť poradie kapitol, musíte zväzok previesť späť na priečinok, zmeniť poradie položiek a potom zväzok znovu vytvoriť.";
 "bound_books_create_alert_title" = "Vytváranie zväzku";
-"voiceover_bound_books_progress" = "%@, Zväzok, %d percent dokončených";
+"voiceover_bound_books_progress" = "%@, Zväzok, %d percent dokončených, trvanie %@";
 "voiceover_no_bound_books_title" = "Žiadny názov zväzku";
 "default_title" = "Predvolené";
 "voiceover_default_speed_title" = "Nastavte predvolenú rýchlosť";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Paus";
 "voiceover_no_title" = "Titel saknas";
 "voiceover_no_author" = "Författare saknas";
-"voiceover_book_progress" = "%@ av %@ %d procent läst";
+"voiceover_book_progress" = "%@ av %@, %d procent läst, varaktighet: %@";
 "voiceover_no_file_title" = "Filtitel saknas";
 "voiceover_no_file_subtitle" = "Undertext för fil saknas";
 "voiceover_no_playlist_title" = "Ingen mapptitel";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Ny boksamling";
 "bound_books_create_alert_description" = "Se till att delarna är i rätt ordning. För att ändra kapitelordning senare måste du konvertera samlingen tillbaka till en mapp, ändra ordning på delarna och sedan återskapa samlingen.";
 "bound_books_create_alert_title" = "Skapa en boksamling";
-"voiceover_bound_books_progress" = "%@, boksamling, %d procent läst";
+"voiceover_bound_books_progress" = "%@, boksamling, %d procent läst, varaktighet %@";
 "voiceover_no_bound_books_title" = "Ingen volymtitel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Ställ in standardhastighet";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Duraklat";
 "voiceover_no_title" = "Başlık Yok";
 "voiceover_no_author" = "Yazar Yok";
-"voiceover_book_progress" = "%@ ( Yazar: %@ ), yüzde %d tamamlandı";
+"voiceover_book_progress" = "%@ tarafından %@, yüzde %d tamamlandı, süre: %@";
 "voiceover_no_file_title" = "Dosya Başlığı Yok";
 "voiceover_no_file_subtitle" = "Dosya Altyazısı Yok";
 "voiceover_no_playlist_title" = "Klasör Başlığı Yok";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Yeni Kitap Hacmi";
 "bound_books_create_alert_description" = "Öğelerin doğru sırada olduğundan emin olun. Bölümleri daha sonra yeniden sıralamak için birimi tekrar bir klasöre dönüştürmeniz, öğeleri yeniden sıralamanız ve ardından birimi yeniden oluşturmanız gerekir.";
 "bound_books_create_alert_title" = "Birim oluştur";
-"voiceover_bound_books_progress" = "%@, Cilt, %d yüzde Tamamlandı";
+"voiceover_bound_books_progress" = "%@, Cilt, %d yüzde Tamamlandı, süre %@";
 "voiceover_no_bound_books_title" = "Cilt Başlığı Yok";
 "default_title" = "Varsayılan";
 "voiceover_default_speed_title" = "Varsayılan hızı ayarla";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "Пауза";
 "voiceover_no_title" = "Без назви";
 "voiceover_no_author" = "Немає автора";
-"voiceover_book_progress" = "%@ з %@, %d завершено";
+"voiceover_book_progress" = "%@ від %@ , виконано %d відсотків, тривалість: %@";
 "voiceover_no_file_title" = "Немає імені файлу";
 "voiceover_no_file_subtitle" = "Відсутній підзаголовок файлу";
 "voiceover_no_playlist_title" = "Назва теки відсутня";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Новий том книги";
 "bound_books_create_alert_description" = "Переконайтеся, що елементи розташовані в правильному порядку. Щоб змінити порядок розділів, вам потрібно перетворити том назад у теку та переставити елементи, а потім знову створити том.";
 "bound_books_create_alert_title" = "Створіть том";
-"voiceover_bound_books_progress" = "%@, Том, %d відсотків прослухано";
+"voiceover_bound_books_progress" = "%@, обсяг, %d відсоток завершено, тривалість %@";
 "voiceover_no_bound_books_title" = "Том без заголовка";
 "default_title" = "За замовчуванням";
 "voiceover_default_speed_title" = "Встановити швидкість за замовчуванням";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -126,7 +126,7 @@
 "pause_title" = "暂停";
 "voiceover_no_title" = "未知标题";
 "voiceover_no_author" = "未知作者";
-"voiceover_book_progress" = "%@之%@ %d已完成";
+"voiceover_book_progress" = "%@之%@ %d已完成，持续时间： %@";
 "voiceover_no_file_title" = "没有文件标题";
 "voiceover_no_file_subtitle" = "没有文件副标题";
 "voiceover_no_playlist_title" = "没有文件夹标题";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "新的书卷";
 "bound_books_create_alert_description" = "确保有声书文件的顺序正确。如果以后要重新安排章节的顺序，你需要把书卷转换回文件夹，重新安排文件顺序，然后重新创建书卷。";
 "bound_books_create_alert_title" = "创建一个卷";
-"voiceover_bound_books_progress" = "%@卷%d已完成";
+"voiceover_bound_books_progress" = "%@, 体积, %d% 已完成, 持续时间 %@";
 "voiceover_no_bound_books_title" = "没有书卷名";
 "default_title" = "默认";
 "voiceover_default_speed_title" = "设置默认速度";


### PR DESCRIPTION
## Purpose

VoiceOver users have to start playback to find out what's the duration of the book. This change includes the duration already available on the cell in the item list screen

## Approach

- Rework VoiceOverService to take in a `SimpleLibraryItem`
- Update translations for books and bound books
