### PR TITLE
Use previously set duration for custom sleep timer option

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		9F4A33E0292B0C710034CD4C /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4A33DF292B0C710034CD4C /* ShareViewController.swift */; };
 		9F4A33E3292B0C710034CD4C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F4A33E1292B0C710034CD4C /* MainInterface.storyboard */; };
 		9F4A33E7292B0C710034CD4C /* BookPlayerShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9F4A33DD292B0C700034CD4C /* BookPlayerShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		9F5011F72A620D140075FEBA /* PlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5011F62A620D140075FEBA /* PlayerViewModelTests.swift */; };
 		9F56C84D287B734C00EA9751 /* BPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56C84C287B734C00EA9751 /* BPLogger.swift */; };
 		9F56C84E287B734C00EA9751 /* BPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56C84C287B734C00EA9751 /* BPLogger.swift */; };
 		9F588DBF2902C798000DA799 /* ComposedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F588DBE2902C798000DA799 /* ComposedButton.swift */; };
@@ -1035,6 +1036,7 @@
 		9F5011F32A62027C0075FEBA /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nb; path = nb.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		9F5011F42A62027C0075FEBA /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F5011F52A62027C0075FEBA /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9F5011F62A620D140075FEBA /* PlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModelTests.swift; sourceTree = "<group>"; };
 		9F56C84C287B734C00EA9751 /* BPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPLogger.swift; sourceTree = "<group>"; };
 		9F588DBE2902C798000DA799 /* ComposedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposedButton.swift; sourceTree = "<group>"; };
 		9F5F12DA2976E8CD00F061A0 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
@@ -1518,6 +1520,7 @@
 				41C2340B27324AB7006BC7B8 /* ItemListViewModelTests.swift */,
 				416A9D4A2743D51E00463621 /* StorageViewModelTests.swift */,
 				62AAE2242749283F001EB9FF /* MiniPlayerViewModelTests.swift */,
+				9F5011F62A620D140075FEBA /* PlayerViewModelTests.swift */,
 				9F646005283AD6B700710D3C /* PlayerSettingsViewModelTests.swift */,
 				9F8A9A5D27AC3F8C0093AA1C /* PlayableItemTests.swift */,
 				9FB7C48C2835A2C1003B917E /* PlayerManagerTests.swift */,
@@ -3195,6 +3198,7 @@
 				6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */,
 				6279361F272D0D110097837D /* MainCoordinatorTests.swift in Sources */,
 				9FBDDBA427DD1A00005FB447 /* ProfileCoordinatorTests.swift in Sources */,
+				9F5011F72A620D140075FEBA /* PlayerViewModelTests.swift in Sources */,
 				9FC1E4632814F80000522FA8 /* AccountServiceMock.swift in Sources */,
 				9FC1E4672815091A00522FA8 /* AccountServiceTests.swift in Sources */,
 				9FC1E4772815F97E00522FA8 /* KeychainServiceTests.swift in Sources */,

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -479,13 +479,16 @@ extension PlayerViewController {
 
     let datePicker = UIDatePicker()
     datePicker.datePickerMode = .countDownTimer
+    if let customTimerDuration = viewModel.getLastCustomSleepTimerDuration() {
+      datePicker.countDownDuration = customTimerDuration
+    }
     customTimerAlert.view.addSubview(datePicker)
     customTimerAlert.addAction(
       UIAlertAction(
         title: "ok_button".localized,
         style: .default,
         handler: { [weak self] _ in
-          self?.viewModel.handleSleepTimerOptions(seconds: datePicker.countDownDuration)
+          self?.viewModel.handleCustomSleepTimerOption(seconds: datePicker.countDownDuration)
         }
       )
     )

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -394,6 +394,19 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
 
     SleepTimer.shared.sleep(in: option)
   }
+
+  func handleCustomSleepTimerOption(seconds: Double) {
+    UserDefaults.standard.set(seconds, forKey: Constants.UserDefaults.customSleepTimerDuration)
+    handleSleepTimerOptions(seconds: seconds)
+  }
+
+  func getLastCustomSleepTimerDuration() -> Double? {
+    let storedTime = UserDefaults.standard.double(forKey: Constants.UserDefaults.customSleepTimerDuration)
+
+    guard storedTime > 0 else { return nil }
+
+    return storedTime
+  }
 }
 
 extension PlayerViewModel {

--- a/BookPlayerTests/PlayerViewModelTests.swift
+++ b/BookPlayerTests/PlayerViewModelTests.swift
@@ -1,0 +1,54 @@
+//
+//  PlayerViewModelTests.swift
+//  BookPlayerTests
+//
+//  Created by gianni.carlo on 14/7/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import XCTest
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+
+final class PlayerViewModelTests: XCTestCase {
+
+  var sut: PlayerViewModel!
+
+  override func setUpWithError() throws {
+    sut = PlayerViewModel(
+      playerManager: PlayerManagerProtocolMock(),
+      libraryService: LibraryServiceProtocolMock(),
+      syncService: SyncServiceProtocolMock()
+    )
+  }
+
+  override func tearDownWithError() throws {
+    sut = nil
+    UserDefaults.standard.removeObject(forKey: Constants.UserDefaults.customSleepTimerDuration)
+  }
+
+  func testSettingLastCustomSleepTimerDuration() {
+    let initialValue = UserDefaults.standard.double(forKey: Constants.UserDefaults.customSleepTimerDuration)
+
+    XCTAssert(initialValue == 0)
+
+    sut.handleCustomSleepTimerOption(seconds: 20)
+
+    let newValue = UserDefaults.standard.double(forKey: Constants.UserDefaults.customSleepTimerDuration)
+
+    XCTAssert(newValue == 20)
+  }
+
+  func testFetchingLastCustomSleepTimerDuration() {
+    let initialValue = sut.getLastCustomSleepTimerDuration()
+
+    XCTAssertNil(initialValue)
+
+    UserDefaults.standard.set(30, forKey: Constants.UserDefaults.customSleepTimerDuration)
+
+    let storedValue = sut.getLastCustomSleepTimerDuration()
+
+    XCTAssert(storedValue == 30)
+  }
+}

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -32,6 +32,7 @@ public enum Constants {
     public static let autolockDisabledOnlyWhenPowered = "userSettingsAutolockOnlyWhenPowered"
     public static let playerListPrefersBookmarks = "userSettingsPlayerListPrefersBookmarks"
     public static let storageFilesSortOrder = "userSettingsStorageFilesSortOrder"
+    public static let customSleepTimerDuration = "userSettingsCustomSleepTimerDuration"
 
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"


### PR DESCRIPTION
## Purpose

- Store and retrieve the last custom duration from the sleep timer so we can present that the next time

## Approach

- Use `UserDefaults` to store the value in seconds and retrieve it when opening the date picker
- Add tests

## Screenshots

https://github.com/TortugaPower/BookPlayer/assets/14112819/752f153e-84b0-40e4-850e-b3e46da3f990


