### PR TITLE
Fix end of chapter sleep timer, and add shake-to-snooze

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		9F4A33E3292B0C710034CD4C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9F4A33E1292B0C710034CD4C /* MainInterface.storyboard */; };
 		9F4A33E7292B0C710034CD4C /* BookPlayerShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 9F4A33DD292B0C700034CD4C /* BookPlayerShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9F5011F72A620D140075FEBA /* PlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5011F62A620D140075FEBA /* PlayerViewModelTests.swift */; };
+		9F5011F92A6580800075FEBA /* ShakeMotionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F5011F82A6580800075FEBA /* ShakeMotionService.swift */; };
 		9F56C84D287B734C00EA9751 /* BPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56C84C287B734C00EA9751 /* BPLogger.swift */; };
 		9F56C84E287B734C00EA9751 /* BPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F56C84C287B734C00EA9751 /* BPLogger.swift */; };
 		9F588DBF2902C798000DA799 /* ComposedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F588DBE2902C798000DA799 /* ComposedButton.swift */; };
@@ -1037,6 +1038,7 @@
 		9F5011F42A62027C0075FEBA /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F5011F52A62027C0075FEBA /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F5011F62A620D140075FEBA /* PlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModelTests.swift; sourceTree = "<group>"; };
+		9F5011F82A6580800075FEBA /* ShakeMotionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeMotionService.swift; sourceTree = "<group>"; };
 		9F56C84C287B734C00EA9751 /* BPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPLogger.swift; sourceTree = "<group>"; };
 		9F588DBE2902C798000DA799 /* ComposedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposedButton.swift; sourceTree = "<group>"; };
 		9F5F12DA2976E8CD00F061A0 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
@@ -2301,6 +2303,7 @@
 				9F64C6222793C37C00B2493C /* Controls Screen */,
 				9F3D0CE328C2BF2A00E9E8A3 /* ButtonFree Screen */,
 				410D0FF01EDF659900A52EB9 /* PlayerManager.swift */,
+				9F5011F82A6580800075FEBA /* ShakeMotionService.swift */,
 				C3EC372D206EE0650094B4E8 /* SleepTimer.swift */,
 				4151A6A526E3A40600E49DBE /* SpeedService.swift */,
 				419B373B23B8D0C600128A8F /* Player.storyboard */,
@@ -3057,6 +3060,7 @@
 				410D00E426DAB97700D11A45 /* Combine+BookPlayer.swift in Sources */,
 				C375AF1920DD99E000AC034D /* ArtworkControl.swift in Sources */,
 				41544A1421BAF41400740AD2 /* ItemSelectionViewController.swift in Sources */,
+				9F5011F92A6580800075FEBA /* ShakeMotionService.swift in Sources */,
 				9F64C6242793C3DA00B2493C /* PlayerControlsViewModel.swift in Sources */,
 				410D00FE26DDD2A900D11A45 /* ProgressObject.swift in Sources */,
 				C3A479152094CA3800D92122 /* UIImage+BookPlayer.swift in Sources */,

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -162,7 +162,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         libraryService: libraryService,
         playbackService: playbackService,
         syncService: syncService,
-        speedService: SpeedService(libraryService: libraryService)
+        speedService: SpeedService(libraryService: libraryService),
+        shakeMotionService: ShakeMotionService()
       )
       AppDelegate.shared?.playerManager = playerManager
     }
@@ -269,7 +270,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     switch type {
     case .began:
       if playerManager.isPlaying {
-        playerManager.pause(fade: false)
+        playerManager.pause()
       }
     case .ended:
       guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
@@ -325,7 +326,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     MPRemoteCommandCenter.shared().pauseCommand.addTarget { [weak self] (_) -> MPRemoteCommandHandlerStatus in
       guard let playerManager = self?.playerManager else { return .commandFailed }
 
-      playerManager.pause(fade: false)
+      playerManager.pause()
       return .success
     }
 

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1082,18 +1082,18 @@ class PlayerManagerProtocolMock: PlayerManagerProtocol {
     }
     //MARK: - playNextItem
 
-    var playNextItemAutoPlayedCallsCount = 0
-    var playNextItemAutoPlayedCalled: Bool {
-        return playNextItemAutoPlayedCallsCount > 0
+    var playNextItemAutoPlayedShouldAutoplayCallsCount = 0
+    var playNextItemAutoPlayedShouldAutoplayCalled: Bool {
+        return playNextItemAutoPlayedShouldAutoplayCallsCount > 0
     }
-    var playNextItemAutoPlayedReceivedAutoPlayed: Bool?
-    var playNextItemAutoPlayedReceivedInvocations: [Bool] = []
-    var playNextItemAutoPlayedClosure: ((Bool) -> Void)?
-    func playNextItem(autoPlayed: Bool) {
-        playNextItemAutoPlayedCallsCount += 1
-        playNextItemAutoPlayedReceivedAutoPlayed = autoPlayed
-        playNextItemAutoPlayedReceivedInvocations.append(autoPlayed)
-        playNextItemAutoPlayedClosure?(autoPlayed)
+    var playNextItemAutoPlayedShouldAutoplayReceivedArguments: (autoPlayed: Bool, shouldAutoplay: Bool)?
+    var playNextItemAutoPlayedShouldAutoplayReceivedInvocations: [(autoPlayed: Bool, shouldAutoplay: Bool)] = []
+    var playNextItemAutoPlayedShouldAutoplayClosure: ((Bool, Bool) -> Void)?
+    func playNextItem(autoPlayed: Bool, shouldAutoplay: Bool) {
+        playNextItemAutoPlayedShouldAutoplayCallsCount += 1
+        playNextItemAutoPlayedShouldAutoplayReceivedArguments = (autoPlayed: autoPlayed, shouldAutoplay: shouldAutoplay)
+        playNextItemAutoPlayedShouldAutoplayReceivedInvocations.append((autoPlayed: autoPlayed, shouldAutoplay: shouldAutoplay))
+        playNextItemAutoPlayedShouldAutoplayClosure?(autoPlayed, shouldAutoplay)
     }
     //MARK: - play
 
@@ -1119,18 +1119,14 @@ class PlayerManagerProtocolMock: PlayerManagerProtocol {
     }
     //MARK: - pause
 
-    var pauseFadeCallsCount = 0
-    var pauseFadeCalled: Bool {
-        return pauseFadeCallsCount > 0
+    var pauseCallsCount = 0
+    var pauseCalled: Bool {
+        return pauseCallsCount > 0
     }
-    var pauseFadeReceivedFade: Bool?
-    var pauseFadeReceivedInvocations: [Bool] = []
-    var pauseFadeClosure: ((Bool) -> Void)?
-    func pause(fade: Bool) {
-        pauseFadeCallsCount += 1
-        pauseFadeReceivedFade = fade
-        pauseFadeReceivedInvocations.append(fade)
-        pauseFadeClosure?(fade)
+    var pauseClosure: (() -> Void)?
+    func pause() {
+        pauseCallsCount += 1
+        pauseClosure?()
     }
     //MARK: - stop
 
@@ -1287,6 +1283,34 @@ class PlayerManagerProtocolMock: PlayerManagerProtocol {
         } else {
             return currentItemPublisherReturnValue
         }
+    }
+}
+class ShakeMotionServiceProtocolMock: ShakeMotionServiceProtocol {
+    //MARK: - observeFirstShake
+
+    var observeFirstShakeCompletionCallsCount = 0
+    var observeFirstShakeCompletionCalled: Bool {
+        return observeFirstShakeCompletionCallsCount > 0
+    }
+    var observeFirstShakeCompletionReceivedCompletion: (() -> Void)?
+    var observeFirstShakeCompletionReceivedInvocations: [(() -> Void)] = []
+    var observeFirstShakeCompletionClosure: ((@escaping () -> Void) -> Void)?
+    func observeFirstShake(completion: @escaping () -> Void) {
+        observeFirstShakeCompletionCallsCount += 1
+        observeFirstShakeCompletionReceivedCompletion = completion
+        observeFirstShakeCompletionReceivedInvocations.append(completion)
+        observeFirstShakeCompletionClosure?(completion)
+    }
+    //MARK: - stopMotionUpdates
+
+    var stopMotionUpdatesCallsCount = 0
+    var stopMotionUpdatesCalled: Bool {
+        return stopMotionUpdatesCallsCount > 0
+    }
+    var stopMotionUpdatesClosure: (() -> Void)?
+    func stopMotionUpdates() {
+        stopMotionUpdatesCallsCount += 1
+        stopMotionUpdatesClosure?()
     }
 }
 class SpeedServiceProtocolMock: SpeedServiceProtocol {

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -126,7 +126,7 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
        let nextChapter = self.playerManager.currentItem?.nextChapter(after: currentChapter) {
       self.playerManager.jumpToChapter(nextChapter)
     } else {
-      self.playerManager.playNextItem(autoPlayed: false)
+      self.playerManager.playNextItem(autoPlayed: false, shouldAutoplay: true)
     }
   }
 
@@ -175,12 +175,12 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   }
 
   func handleJumpToStart() {
-    self.playerManager.pause(fade: false)
+    self.playerManager.pause()
     self.playerManager.jumpTo(0.0, recordBookmark: false)
   }
 
   func handleMarkCompletion() {
-    self.playerManager.pause(fade: false)
+    self.playerManager.pause()
     self.playerManager.markAsCompleted(!self.isBookFinished())
   }
 

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -23,6 +23,15 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
   private var prefersChapterContext = UserDefaults.standard.bool(forKey: Constants.UserDefaults.chapterContextEnabled)
   private var prefersRemainingTime = UserDefaults.standard.bool(forKey: Constants.UserDefaults.remainingTimeEnabled)
 
+  /// Formatter for the sleep timer duration
+  private lazy var durationFormatter: DateComponentsFormatter = {
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .positional
+    formatter.allowedUnits = [.minute, .second]
+    formatter.collapsesLargestUnit = true
+    return formatter
+  }()
+
   var eventsPublisher = InterfaceUpdater<PlayerViewModel.Events>()
 
   init(
@@ -49,6 +58,40 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
 
   func isPlayingObserver() -> AnyPublisher<Bool, Never> {
     return self.playerManager.isPlayingPublisher()
+  }
+
+  func toolbarSleepDescriptionPublisher() -> AnyPublisher<String?, Never> {
+    return SleepTimer.shared.$state
+      .map { [weak self] state -> String? in
+        switch state {
+        case .off:
+          return nil
+        case .endOfChapter:
+          return "active_title".localized
+        case .countdown(let seconds):
+          return self?.durationFormatter.string(from: seconds)
+        }
+      }
+      .eraseToAnyPublisher()
+  }
+
+  func sleepAlertMessagePublisher() -> AnyPublisher<String, Never> {
+    return SleepTimer.shared.$state
+      .map { [weak self] state -> String in
+        switch state {
+        case .off:
+          return "player_sleep_title".localized
+        case .endOfChapter:
+          return "sleep_alert_description".localized
+        case .countdown(let seconds):
+          let formattedTime = self?.durationFormatter.string(from: seconds) ?? ""
+          return String.localizedStringWithFormat(
+            "sleep_time_description".localized,
+            formattedTime
+          )
+        }
+      }
+      .eraseToAnyPublisher()
   }
 
   func hasLoadedBook() -> Bool {
@@ -328,8 +371,8 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     actions.append(
       BPActionItem(
         title: "sleep_off_title".localized,
-        handler: { [weak self] in
-          self?.handleSleepTimerOptions(seconds: -1)
+        handler: {
+          SleepTimer.shared.setTimer(.off)
         }
       )
     )
@@ -345,8 +388,8 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
       actions.append(
         BPActionItem(
           title: String.localizedStringWithFormat("sleep_interval_title".localized, formattedDuration),
-          handler: { [weak self] in
-            self?.handleSleepTimerOptions(seconds: interval)
+          handler: {
+            SleepTimer.shared.setTimer(.countdown(interval))
           }
         )
       )
@@ -355,8 +398,8 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     actions.append(
       BPActionItem(
         title: "sleep_chapter_option_title".localized,
-        handler: { [weak self] in
-          self?.handleSleepTimerOptions(seconds: -2)
+        handler: {
+          SleepTimer.shared.setTimer(.endOfChapter)
         }
       )
     )
@@ -375,29 +418,34 @@ class PlayerViewModel: BaseViewModel<PlayerCoordinator> {
     sendEvent(.sleepTimerAlert(
       content: BPAlertContent(
         title: nil,
-        message: SleepTimer.shared.getAlertMessage(),
+        message: getSleepTimerAlertMessage(),
         style: .actionSheet,
         actionItems: actions
       )
     ))
   }
 
+  func getSleepTimerAlertMessage() -> String {
+    switch SleepTimer.shared.state {
+    case .off:
+      return "player_sleep_title".localized
+    case .endOfChapter:
+      return "sleep_alert_description".localized
+    case .countdown(let seconds):
+      return String.localizedStringWithFormat(
+        "sleep_time_description".localized,
+        durationFormatter.string(from: seconds)!
+      )
+    }
+  }
+
   func showCustomSleepTimerOption() {
     sendEvent(.customSleepTimer(title: "sleeptimer_custom_alert_title".localized))
   }
 
-  func handleSleepTimerOptions(seconds: Double) {
-    guard let option = TimeParser.getTimerOption(from: seconds) else {
-      SleepTimer.shared.sleep(in: seconds)
-      return
-    }
-
-    SleepTimer.shared.sleep(in: option)
-  }
-
   func handleCustomSleepTimerOption(seconds: Double) {
     UserDefaults.standard.set(seconds, forKey: Constants.UserDefaults.customSleepTimerDuration)
-    handleSleepTimerOptions(seconds: seconds)
+    SleepTimer.shared.setTimer(.countdown(seconds))
   }
 
   func getLastCustomSleepTimerDuration() -> Double? {

--- a/BookPlayer/Player/Player Screen/ProgressObject.swift
+++ b/BookPlayer/Player/Player Screen/ProgressObject.swift
@@ -25,6 +25,12 @@ struct ProgressObject {
   var formattedMaxTime: String? {
     guard let maxTime = self.maxTime else { return nil }
 
-    return TimeParser.formatTime(maxTime)
+    let formattedTime = TimeParser.formatTime(abs(maxTime))
+
+    if maxTime < 0 {
+      return "-".appending(formattedTime)
+    } else {
+      return formattedTime
+    }
   }
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -24,10 +24,10 @@ public protocol PlayerManagerProtocol {
   func hasLoadedBook() -> Bool
 
   func playPreviousItem()
-  func playNextItem(autoPlayed: Bool)
+  func playNextItem(autoPlayed: Bool, shouldAutoplay: Bool)
   func play()
   func playPause()
-  func pause(fade: Bool)
+  func pause()
   func stop()
   func rewind()
   func forward()
@@ -48,6 +48,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   private let syncService: SyncServiceProtocol
   private let speedService: SpeedServiceProtocol
   private let userActivityManager: UserActivityManager
+  private let shakeMotionService: ShakeMotionServiceProtocol
 
   private var audioPlayer = AVPlayer()
 
@@ -58,6 +59,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   private var playableChapterSubscription: AnyCancellable?
   private var isPlayingSubscription: AnyCancellable?
   private var periodicTimeObserver: Any?
+  private var disposeBag = Set<AnyCancellable>()
   /// Flag determining if it should resume playback after finishing up loading an item
   @Published private var playbackQueued: Bool?
   /// Flag determining if it's in the process of fetching the URL for playback
@@ -90,17 +92,22 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol,
     syncService: SyncServiceProtocol,
-    speedService: SpeedServiceProtocol
+    speedService: SpeedServiceProtocol,
+    shakeMotionService: ShakeMotionServiceProtocol
   ) {
     self.libraryService = libraryService
     self.playbackService = playbackService
     self.syncService = syncService
     self.speedService = speedService
     self.userActivityManager = UserActivityManager(libraryService: libraryService)
+    self.shakeMotionService = shakeMotionService
     super.init()
 
     setupPlayerInstance()
+    bindObservers()
+  }
 
+  func bindObservers() {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(playerDidFinishPlaying(_:)),
@@ -114,6 +121,14 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       name: AVAudioSession.mediaServicesWereResetNotification,
       object: nil
     )
+
+    SleepTimer.shared.countDownThresholdPublisher.sink { [weak self] _ in
+      self?.handleSleepTimerThresholdEvent()
+    }.store(in: &disposeBag)
+
+    SleepTimer.shared.timerEndedPublisher.sink { [weak self] state in
+      self?.handleSleepTimerEndEvent(state)
+    }.store(in: &disposeBag)
   }
 
   func setupPlayerInstance() {
@@ -641,6 +656,7 @@ extension PlayerManager {
     self.handleSmartRewind(currentItem)
 
     self.fadeTimer?.invalidate()
+    self.shakeMotionService.stopMotionUpdates()
     self.boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
     // Set play state on player and control center
     self.audioPlayer.playImmediately(atRate: self.currentSpeed)
@@ -722,7 +738,7 @@ extension PlayerManager {
   }
   // swiftlint:enable block_based_kvo
 
-  func pause(fade: Bool) {
+  func pause() {
     guard let currentItem = self.currentItem else { return }
 
     self.observeStatus = false
@@ -731,32 +747,23 @@ extension PlayerManager {
 
     self.libraryService.setLibraryLastBook(with: currentItem.relativePath)
 
-    let pauseActionBlock: () -> Void = { [weak self] in
-      self?.bindPauseObserver()
-      // Set pause state on player and control center
-      self?.audioPlayer.pause()
-      self?.playbackQueued = nil
-      self?.loadChapterTask?.cancel()
-      self?.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
-      self?.setNowPlayingBookTime()
-      MPNowPlayingInfoCenter.default().nowPlayingInfo = self?.nowPlayingInfo
-    }
-
     NotificationCenter.default.post(name: .bookPaused, object: nil)
 
-    guard fade else {
-      pauseActionBlock()
-      return
-    }
-
-    self.fadeTimer = self.audioPlayer.fadeVolume(from: 1, to: 0, duration: 5, completion: pauseActionBlock)
+    bindPauseObserver()
+    // Set pause state on player and control center
+    audioPlayer.pause()
+    playbackQueued = nil
+    loadChapterTask?.cancel()
+    nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
+    setNowPlayingBookTime()
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
   }
 
   // Toggle play/pause of book
   func playPause() {
     // Pause player if it's playing
     if self.audioPlayer.timeControlStatus == .playing || playbackQueued == true {
-      self.pause(fade: false)
+      self.pause()
     } else {
       self.play()
     }
@@ -811,7 +818,7 @@ extension PlayerManager {
     load(previousBook, autoplay: true)
   }
 
-  func playNextItem(autoPlayed: Bool = false) {
+  func playNextItem(autoPlayed: Bool = false, shouldAutoplay: Bool = true) {
     /// If it's autoplayed, check if setting is enabled
     if autoPlayed,
        !UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoplayEnabled) {
@@ -837,32 +844,29 @@ extension PlayerManager {
       updatePlaybackTime(item: nextBook, time: 0)
     }
 
-    load(nextBook, autoplay: true)
+    load(nextBook, autoplay: shouldAutoplay)
   }
 
   @objc
   func playerDidFinishPlaying(_ notification: Notification) {
     guard let currentItem = self.currentItem else { return }
 
-    // Stop book/chapter change if the EOC sleep timer is active
-    if SleepTimer.shared.state == .endOfChapter {
-      NotificationCenter.default.post(name: .bookEnd, object: nil)
-      return
-    }
+    let endOfChapterActive = SleepTimer.shared.state == .endOfChapter
 
     if currentItem.chapters.last == currentItem.currentChapter {
       self.libraryService.setLibraryLastBook(with: nil)
 
       self.markAsCompleted(true)
 
-      self.playNextItem(autoPlayed: true)
-      return
+      self.playNextItem(autoPlayed: true, shouldAutoplay: !endOfChapterActive)
+
+      NotificationCenter.default.post(name: .bookEnd, object: nil)
     } else if currentItem.isBoundBook {
       updatePlaybackTime(item: currentItem, time: currentItem.currentTime)
       /// Load next chapter
       guard let nextChapter = self.playbackService.getNextChapter(from: currentItem) else { return }
       currentItem.currentChapter = nextChapter
-      loadChapterMetadata(nextChapter, autoplay: true)
+      loadChapterMetadata(nextChapter, autoplay: !endOfChapterActive)
     }
   }
 
@@ -921,6 +925,29 @@ extension PlayerManager {
       AppDelegate.shared?.activeSceneDelegate?.coordinator.getMainCoordinator()?
         .getTopController()?
         .showAlert("error_title".localized, message: message)
+    }
+  }
+}
+
+// MARK: - Sleep timer
+extension PlayerManager {
+  private func handleSleepTimerThresholdEvent() {
+    fadeTimer = audioPlayer.fadeVolume(from: 1, to: 0, duration: 5, completion: {})
+    bindShakeObserver()
+  }
+
+  private func handleSleepTimerEndEvent(_ state: SleepTimerState) {
+    pause()
+
+    if state == .endOfChapter {
+      bindShakeObserver()
+    }
+  }
+
+  private func bindShakeObserver() {
+    shakeMotionService.observeFirstShake { [weak self] in
+      SleepTimer.shared.restartTimer()
+      self?.play()
     }
   }
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -845,7 +845,7 @@ extension PlayerManager {
     guard let currentItem = self.currentItem else { return }
 
     // Stop book/chapter change if the EOC sleep timer is active
-    if SleepTimer.shared.isEndChapterActive() {
+    if SleepTimer.shared.state == .endOfChapter {
       NotificationCenter.default.post(name: .bookEnd, object: nil)
       return
     }

--- a/BookPlayer/Player/ShakeMotionService.swift
+++ b/BookPlayer/Player/ShakeMotionService.swift
@@ -1,0 +1,74 @@
+//
+//  ShakeMotionService.swift
+//  BookPlayer
+//
+//  Created by gianni.carlo on 17/7/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import CoreMotion
+import Foundation
+
+/// sourcery: AutoMockable
+protocol ShakeMotionServiceProtocol {
+  func observeFirstShake(completion: @escaping () -> Void)
+  func stopMotionUpdates()
+}
+
+class ShakeMotionService: ShakeMotionServiceProtocol {
+  /// Reference to cleanup task
+  private var timeoutWorkItem: DispatchWorkItem?
+  /// Manager to start monitoring motions
+  private lazy var manager: CMMotionManager = {
+    let manager = CMMotionManager()
+    manager.deviceMotionUpdateInterval = 0.02
+    return manager
+  }()
+  /// Start observing motion updates for 1 minute, and call the completion callback when a shake motion is detected
+  func observeFirstShake(completion: @escaping () -> Void) {
+    var xInPositiveDirection = 0.0
+    var xInNegativeDirection = 0.0
+    var shakeCount = 0
+
+    timeoutWorkItem?.cancel()
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.stopMotionUpdates()
+    }
+    timeoutWorkItem = workItem
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(60), execute: workItem)
+
+    /// Taken from: https://stackoverflow.com/a/55264779
+    manager.startDeviceMotionUpdates(to: OperationQueue.main, withHandler: { [weak self] (data, _) in
+      guard
+        let data,
+        data.userAcceleration.x > 1.0 || data.userAcceleration.x < -1.0
+      else { return }
+
+      if data.userAcceleration.x > 1.0 {
+        xInPositiveDirection = data.userAcceleration.x
+      }
+
+      if data.userAcceleration.x < -1.0 {
+        xInNegativeDirection = data.userAcceleration.x
+      }
+
+      if xInPositiveDirection != 0.0 && xInNegativeDirection != 0.0 {
+        shakeCount += 1
+        xInPositiveDirection = 0.0
+        xInNegativeDirection = 0.0
+      }
+
+      if shakeCount > 1 {
+        self?.timeoutWorkItem?.cancel()
+        self?.stopMotionUpdates()
+        completion()
+      }
+    })
+  }
+
+  /// Stop monitoring motion updates
+  func stopMotionUpdates() {
+    manager.stopDeviceMotionUpdates()
+  }
+}

--- a/BookPlayer/Player/SleepTimer.swift
+++ b/BookPlayer/Player/SleepTimer.swift
@@ -111,12 +111,13 @@ final class SleepTimer {
   }
 
   @objc private func end() {
+    let wasEndChapterActive = isEndChapterActive()
     self.reset()
     self.subscription?.cancel()
 
     guard let playerManager = AppDelegate.shared?.playerManager else { return }
 
-    playerManager.pause(fade: true)
+    playerManager.pause(fade: !wasEndChapterActive)
   }
 
   private func startEndOfChapterOption() {

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -138,11 +138,11 @@ class ActionParserService {
 
     switch seconds {
     case -1:
-      SleepTimer.shared.reset()
+      SleepTimer.shared.setTimer(.off)
     case -2:
-      SleepTimer.shared.sleep(in: .endChapter)
+      SleepTimer.shared.setTimer(.endOfChapter)
     default:
-      SleepTimer.shared.sleep(in: seconds)
+      SleepTimer.shared.setTimer(.countdown(seconds))
     }
   }
 

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -147,13 +147,7 @@ class ActionParserService {
   }
 
   private class func handlePauseAction(_ action: Action) {
-    guard
-      let playerManager = AppDelegate.shared?.playerManager
-    else {
-      return
-    }
-
-    playerManager.pause(fade: false)
+    AppDelegate.shared?.playerManager?.pause()
   }
 
   private class func handlePlayAction(_ action: Action) {

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -332,7 +332,7 @@ extension CarPlayManager {
          let nextChapter = playerManager.currentItem?.nextChapter(after: currentChapter) {
         playerManager.jumpToChapter(nextChapter)
       } else {
-        playerManager.playNextItem(autoPlayed: false)
+        playerManager.playNextItem(autoPlayed: false, shouldAutoplay: true)
       }
     }
   }

--- a/BookPlayerTests/PlayerManagerTests.swift
+++ b/BookPlayerTests/PlayerManagerTests.swift
@@ -25,7 +25,8 @@ class PlayerManagerTests: XCTestCase {
       libraryService: LibraryServiceProtocolMock(),
       playbackService: PlaybackServiceProtocolMock(),
       syncService: SyncServiceProtocolMock(),
-      speedService: SpeedServiceProtocolMock()
+      speedService: SpeedServiceProtocolMock(),
+      shakeMotionService: ShakeMotionServiceProtocolMock()
     )
   }
 


### PR DESCRIPTION
## Purpose

Fix sleep timer going over chapter (due to the fade-out volume)

## Related tasks

#885 
#880 
#764 
#869
#341

## Approach

- Rework the `SleepTimer` singleton:
  - Add new enum `SleepTimerState` with the available states of the sleep timer
  - Add publishers to send event when the timer ends, or when it hits the countdown threshold
  - Move the alert reference to the player screen related components
- Create new `ShakeMotionService` to observe shake events, with a timeout of 60 seconds to disable motion updates
- Setup player to listen to new sleep timer events, and use the new shake motion service to reset timer and playback

## Things to be aware of / Things to focus on

- Shake detection may need some fine tuning, right now its only considering the x axis (left-right), but I can see someone trying a shake on the z axis (front-back)

