### PR TITLE
Beta: Fix crash due to  unescaped % on translations

### DIFF
--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Kein Titel angegeben";
 "voiceover_no_author" = "Kein Autor angegeben";
-"voiceover_book_progress" = "%@ von %@, %d% abgeschlossen, Dauer: %@";
+"voiceover_book_progress" = "%@ von %@, %d%% abgeschlossen, Dauer: %@";
 "voiceover_no_file_title" = "Datei ohne Titel";
 "voiceover_no_file_subtitle" = "Datei ohne Untertitel";
 "voiceover_no_playlist_title" = "Kein Ordnertitel";
-"voiceover_playlist_progress" = "%@, Wiedergabeliste, %d% abgeschlossen";
+"voiceover_playlist_progress" = "%@, Wiedergabeliste, %d%% abgeschlossen";
 "voiceover_unknown_title" = "Unbekannter Titel";
 "voiceover_unknown_author" = "Unbekannter Autor";
 "voiceover_book_info" = "%@ von %@";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 "voiceover_no_file_title" = "A fájlnak nincs címe";
 "voiceover_no_file_subtitle" = "A fájlnak nincsen felirata";
 "voiceover_no_playlist_title" = "Nincs mappa címe";
-"voiceover_playlist_progress" = "%@, lejátszólista, %d% meghallgatva";
+"voiceover_playlist_progress" = "%@, lejátszólista, %d%% meghallgatva";
 "voiceover_unknown_title" = "Ismeretlen cím";
 "voiceover_unknown_author" = "Ismeretlen szerző";
 "voiceover_book_info" = "%@ - %@";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -110,7 +110,7 @@
 "sleep_off_title" = "Spegni";
 "sleep_interval_title" = "In %@";
 "chapter_number_title" = "Capitolo %d";
-"progress_complete_description" = "%d% Completato";
+"progress_complete_description" = "%d%% Completato";
 "chapter_duration_title" = "Durata capitolo:";
 "chapter_time_remaining_title" = "Tempo rimanente del capitolo:";
 "book_time_remaining_title" = "Tempo rimanente del libro:";
@@ -130,7 +130,7 @@
 "voiceover_no_file_title" = "Nessun titolo del file";
 "voiceover_no_file_subtitle" = "Nessun sottotitolo del file";
 "voiceover_no_playlist_title" = "Nessun titolo della cartella";
-"voiceover_playlist_progress" = "%@, Cartella, %d% completato";
+"voiceover_playlist_progress" = "%@, Cartella, %d%% completato";
 "voiceover_unknown_title" = "Titolo sconosciuto";
 "voiceover_unknown_author" = "Autore sconosciuto";
 "voiceover_book_info" = "%@ di %@";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -110,7 +110,7 @@
 "sleep_off_title" = "Отменить";
 "sleep_interval_title" = "Через %@";
 "chapter_number_title" = "Глава %d";
-"progress_complete_description" = "%d% прослушано";
+"progress_complete_description" = "%d%% прослушано";
 "chapter_duration_title" = "Продолжительность главы:";
 "chapter_time_remaining_title" = "Оставшееся время главы:";
 "book_time_remaining_title" = "Оставшееся время:";
@@ -130,7 +130,7 @@
 "voiceover_no_file_title" = "Нет названия файла";
 "voiceover_no_file_subtitle" = "Подзаголовок файла отсутствует";
 "voiceover_no_playlist_title" = "Нет названия папки";
-"voiceover_playlist_progress" = "Плейлист %@ завершен на %d%";
+"voiceover_playlist_progress" = "Плейлист %@ завершен на %d%%";
 "voiceover_unknown_title" = "Без названия";
 "voiceover_unknown_author" = "Неизвестный автор";
 "voiceover_book_info" = "%@, %@";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -130,7 +130,7 @@
 "voiceover_no_file_title" = "Немає імені файлу";
 "voiceover_no_file_subtitle" = "Відсутній підзаголовок файлу";
 "voiceover_no_playlist_title" = "Назва теки відсутня";
-"voiceover_playlist_progress" = "%@, тека, відтворена на %d%";
+"voiceover_playlist_progress" = "%@, тека, відтворена на %d%%";
 "voiceover_unknown_title" = "Невідома назва";
 "voiceover_unknown_author" = "Невідомий автор";
 "voiceover_book_info" = "%@ з %@";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -110,7 +110,7 @@
 "sleep_off_title" = "关闭";
 "sleep_interval_title" = "在%@";
 "chapter_number_title" = "第%d章";
-"progress_complete_description" = "%d% 完成";
+"progress_complete_description" = "%d%% 完成";
 "chapter_duration_title" = "章节持续时间：";
 "chapter_time_remaining_title" = "剩余章节时间：";
 "book_time_remaining_title" = "有声书剩余时间：";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "新的书卷";
 "bound_books_create_alert_description" = "确保有声书文件的顺序正确。如果以后要重新安排章节的顺序，你需要把书卷转换回文件夹，重新安排文件顺序，然后重新创建书卷。";
 "bound_books_create_alert_title" = "创建一个卷";
-"voiceover_bound_books_progress" = "%@, 体积, %d% 已完成, 持续时间 %@";
+"voiceover_bound_books_progress" = "%@, 体积, %d%% 已完成, 持续时间 %@";
 "voiceover_no_bound_books_title" = "没有书卷名";
 "default_title" = "默认";
 "voiceover_default_speed_title" = "设置默认速度";


### PR DESCRIPTION
## Bugfix

- Some translations had the literal `%` instead of the word, which made the system think it was expecting another parameter in there. This isn't a problem when the unescaped % is after all the replaced values, but if it's in the middle, the `String.localizedStringWithFormat` will think we need to place a value in there, although there's no format specified for the value, causing a crash

## Approach

- Escape the `%` by adding a second `%%` in there
