### PR TITLE
Fix crash when percentCompleted is NaN or infinite

### DIFF
--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -94,7 +94,11 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
     self.currentTime = currentTime
     self.duration = duration
     self.durationFormatted = TimeParser.formatTotalDuration(duration)
-    self.percentCompleted = percentCompleted
+    if percentCompleted.isNaN || percentCompleted.isInfinite {
+      self.percentCompleted = 0
+    } else {
+      self.percentCompleted = percentCompleted
+    }
     self.isFinished = isFinished
     self.relativePath = relativePath
     self.remoteURL = remoteURL
@@ -115,7 +119,11 @@ extension SimpleLibraryItem {
     self.currentTime = item.currentTime
     self.duration = item.duration
     self.durationFormatted = TimeParser.formatTotalDuration(item.duration)
-    self.percentCompleted = item.percentCompleted
+    if item.percentCompleted.isNaN || item.percentCompleted.isInfinite {
+      self.percentCompleted = 0
+    } else {
+      self.percentCompleted = item.percentCompleted
+    }
     self.isFinished = item.isFinished
     self.relativePath = item.relativePath
     self.remoteURL = item.remoteURL


### PR DESCRIPTION
## Bugfix

- Including the percent completed for VoiceOver was making it fail when the percent was not defined (which looks to be a product of a bad migration, as it should default to 0 to any new item or empty folder)

## Related tasks

#971 

## Approach

- On initialization of `SimpleLibraryItem`, add a check for the `percentCompleted` property and assign `0` if it's nil or infinite
