### PR TITLE
Fix random crash on playback

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -63,12 +63,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       defaults.set(true, forKey: Constants.UserDefaults.completedFirstLaunch)
     }
 
-    try? AVAudioSession.sharedInstance().setCategory(
-      AVAudioSession.Category.playback,
-      mode: .spokenAudio,
-      options: []
-    )
-
     // register to audio-interruption notifications
     NotificationCenter.default.addObserver(
       self,

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "No Title";
 "voiceover_no_author" = "No Author";
-"voiceover_book_progress" = "%@ by %@, %d percent completed, duration: %@";
+"voiceover_book_progress" = "%@ by %@, %.0f percent completed, duration: %@";
 "voiceover_no_file_title" = "No File Title";
 "voiceover_no_file_subtitle" = "No File Subtitle";
 "voiceover_no_playlist_title" = "No Folder Title";
-"voiceover_playlist_progress" = "%@, Folder, %d percent completed";
+"voiceover_playlist_progress" = "%@, Folder, %.0f percent completed";
 "voiceover_unknown_title" = "Unknown title";
 "voiceover_unknown_author" = "Unknown author";
 "voiceover_book_info" = "%@ by %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "New Book Volume";
 "bound_books_create_alert_description" = "Make sure items are in correct order. To reorder chapters later you need convert the volume back into a folder, reorder items and then re-create the volume.";
 "bound_books_create_alert_title" = "Create a volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed, duration %@";
+"voiceover_bound_books_progress" = "%@, Volume, %.0f percent Completed, duration %@";
 "voiceover_no_bound_books_title" = "No Volume Title";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Set default speed";

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -639,7 +639,13 @@ extension PlayerManager {
     self.libraryService.setLibraryLastBook(with: currentItem.relativePath)
 
     do {
-      try AVAudioSession.sharedInstance().setActive(true)
+      let audioSession = AVAudioSession.sharedInstance()
+      try audioSession.setCategory(
+        AVAudioSession.Category.playback,
+        mode: .spokenAudio,
+        options: []
+      )
+      try audioSession.setActive(true)
     } catch {
       fatalError("Failed to activate the audio session, \(error), description: \(error.localizedDescription)")
     }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -799,11 +799,13 @@ extension PlayerManager {
   func markAsCompleted(_ flag: Bool) {
     guard let currentItem = self.currentItem else { return }
 
-    self.libraryService.markAsFinished(flag: true, relativePath: currentItem.relativePath)
+    self.libraryService.markAsFinished(flag: flag, relativePath: currentItem.relativePath)
 
     if let parentFolderPath = currentItem.parentFolder {
       libraryService.recursiveFolderProgressUpdate(from: parentFolderPath)
     }
+
+    currentItem.isFinished = flag
 
     NotificationCenter.default.post(name: .bookEnd, object: nil, userInfo: nil)
   }

--- a/BookPlayer/Services/VoiceOverService.swift
+++ b/BookPlayer/Services/VoiceOverService.swift
@@ -11,20 +11,20 @@ class VoiceOverService {
         "voiceover_book_progress".localized,
         item.title,
         item.details,
-        Int(item.percentCompleted),
+        item.percentCompleted,
         item.durationFormatted
       )
     case .folder:
       return String.localizedStringWithFormat(
         "voiceover_playlist_progress".localized,
         item.title,
-        Int(item.percentCompleted)
+        item.percentCompleted
       )
     case .bound:
       return String.localizedStringWithFormat(
         "voiceover_bound_books_progress".localized,
         item.title,
-        Int(item.percentCompleted),
+        item.percentCompleted,
         item.durationFormatted
       )
     }

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "ايقاف";
 "voiceover_no_title" = "لا يوجد عنوان";
 "voiceover_no_author" = "لا يوجد كاتب";
-"voiceover_book_progress" = "%@ من %@ ، اكتمل %d في المائة ، المدة: %@";
+"voiceover_book_progress" = "%@ من %@ ، اكتمل %.0f في المائة ، المدة: %@";
 "voiceover_no_file_title" = "لا يوجد عنوان ملف";
 "voiceover_no_file_subtitle" = "لا يوجد ملف الترجمة";
 "voiceover_no_playlist_title" = "لا يوجد عنوان مجلد";
-"voiceover_playlist_progress" = "%@ ، قائمة التشغيل ، اكتمل %d بالمائة";
+"voiceover_playlist_progress" = "%@ ، قائمة التشغيل ، اكتمل %.0f بالمائة";
 "voiceover_unknown_title" = "عنوان غير معروف";
 "voiceover_unknown_author" = "كاتب غير معروف";
 "voiceover_book_info" = "%@ بواسطة %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "حجم الكتاب الجديد";
 "bound_books_create_alert_description" = "تأكد من أن العناصر في الترتيب الصحيح. لإعادة ترتيب الفصول لاحقًا ، تحتاج إلى تحويل وحدة التخزين مرة أخرى إلى مجلد ، وإعادة ترتيب العناصر ثم إعادة إنشاء المجلد.";
 "bound_books_create_alert_title" = "إنشاء وحدة تخزين";
-"voiceover_bound_books_progress" = "%@ ، وحدة التخزين ، %d مكتمل ، المدة %@";
+"voiceover_bound_books_progress" = "%@ ، وحدة التخزين ، %.0f مكتمل ، المدة %@";
 "voiceover_no_bound_books_title" = "لا يوجد عنوان وحدة التخزين";
 "default_title" = "محددة مسبقا";
 "voiceover_default_speed_title" = "ضبط السرعة الافتراضية";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pozastavit";
 "voiceover_no_title" = "Žádný název";
 "voiceover_no_author" = "Žádný autor";
-"voiceover_book_progress" = "%@ od %@, %d procent dokončeno, trvání: %@";
+"voiceover_book_progress" = "%@ od %@, %.0f procent dokončeno, trvání: %@";
 "voiceover_no_file_title" = "Žádný název souboru";
 "voiceover_no_file_subtitle" = "Žádný podtitul souboru";
 "voiceover_no_playlist_title" = "Žádný název složky";
-"voiceover_playlist_progress" = "%@, Seznam stop, %d procent Dokončeno";
+"voiceover_playlist_progress" = "%@, Seznam stop, %.0f procent Dokončeno";
 "voiceover_unknown_title" = "Neznámý název";
 "voiceover_unknown_author" = "Neznámý autor";
 "voiceover_book_info" = "%@podle%@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nový svazek knihy";
 "bound_books_create_alert_description" = "Ujistěte se, že položky jsou ve správném pořadí. Chcete-li později změnit pořadí kapitol, musíte svazek převést zpět na složku, změnit pořadí položek a poté svazek znovu vytvořit.";
 "bound_books_create_alert_title" = "Vytvořte svazek";
-"voiceover_bound_books_progress" = "%@, objem, %d procent dokončeno, trvání %@";
+"voiceover_bound_books_progress" = "%@, objem, %.0f procent dokončeno, trvání %@";
 "voiceover_no_bound_books_title" = "Bez názvu svazku";
 "default_title" = "Výchozí";
 "voiceover_default_speed_title" = "Nastavte výchozí rychlost";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Ingen titel";
 "voiceover_no_author" = "Ingen forfatter";
-"voiceover_book_progress" = "%@ af %@, %d procent fuldført, varighed: %@";
+"voiceover_book_progress" = "%@ af %@, %.0f procent fuldført, varighed: %@";
 "voiceover_no_file_title" = "Ingen filnavn";
 "voiceover_no_file_subtitle" = "Ingen undertekstfil";
 "voiceover_no_playlist_title" = "Ingen mappetitel";
-"voiceover_playlist_progress" = "%@, Playliste, %d procent fuldført";
+"voiceover_playlist_progress" = "%@, Playliste, %.0f procent fuldført";
 "voiceover_unknown_title" = "Ukendt titel";
 "voiceover_unknown_author" = "Ukendt forfatter";
 "voiceover_book_info" = "%@ af %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Ny bogbind";
 "bound_books_create_alert_description" = "Sørg for, at elementerne er i den rigtige rækkefølge. Hvis du vil ændre rækkefølgen af kapitler senere skal du konvertere bindet tilbage til en mappe, omarrangere elementer og derefter genskabe bindet.";
 "bound_books_create_alert_title" = "Opret et volumen";
-"voiceover_bound_books_progress" = "%@, Volumen, %d procent fuldført, varighed %@";
+"voiceover_bound_books_progress" = "%@, Volumen, %.0f procent fuldført, varighed %@";
 "voiceover_no_bound_books_title" = "Ingen bindtitel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Indstil standardhastighed";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Kein Titel angegeben";
 "voiceover_no_author" = "Kein Autor angegeben";
-"voiceover_book_progress" = "%@ von %@, %d%% abgeschlossen, Dauer: %@";
+"voiceover_book_progress" = "%@ von %@, %.0f%% abgeschlossen, Dauer: %@";
 "voiceover_no_file_title" = "Datei ohne Titel";
 "voiceover_no_file_subtitle" = "Datei ohne Untertitel";
 "voiceover_no_playlist_title" = "Kein Ordnertitel";
-"voiceover_playlist_progress" = "%@, Wiedergabeliste, %d%% abgeschlossen";
+"voiceover_playlist_progress" = "%@, Wiedergabeliste, %.0f%% abgeschlossen";
 "voiceover_unknown_title" = "Unbekannter Titel";
 "voiceover_unknown_author" = "Unbekannter Autor";
 "voiceover_book_info" = "%@ von %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Neuer Band";
 "bound_books_create_alert_description" = "Achte darauf, dass alle Kapitel in der richtigen Reihenfolge vorliegen. Um Kapitel neu zu sortieren, kannst du den Band wieder in einen Ordner konvertieren, dort die Kapitel neu anordnen und dann wieder einen Band erstellen.";
 "bound_books_create_alert_title" = "Band erstellen";
-"voiceover_bound_books_progress" = "%@, Band, %d Prozent gehört, Dauer %@";
+"voiceover_bound_books_progress" = "%@, Band, %.0f Prozent gehört, Dauer %@";
 "voiceover_no_bound_books_title" = "Band ohne Titel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Standardgeschwindigkeit einstellen";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "No Title";
 "voiceover_no_author" = "No Author";
-"voiceover_book_progress" = "%@ by %@, %d percent completed, duration: %@";
+"voiceover_book_progress" = "%@ by %@, %.0f percent completed, duration: %@";
 "voiceover_no_file_title" = "No File Title";
 "voiceover_no_file_subtitle" = "No File Subtitle";
 "voiceover_no_playlist_title" = "No Folder Title";
-"voiceover_playlist_progress" = "%@, Folder, %d percent completed";
+"voiceover_playlist_progress" = "%@, Folder, %.0f percent completed";
 "voiceover_unknown_title" = "Unknown title";
 "voiceover_unknown_author" = "Unknown author";
 "voiceover_book_info" = "%@ by %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "New Book Volume";
 "bound_books_create_alert_description" = "Make sure items are in correct order. To reorder chapters later you need convert the volume back into a folder, reorder items and then re-create the volume.";
 "bound_books_create_alert_title" = "Create a volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percent Completed, duration %@";
+"voiceover_bound_books_progress" = "%@, Volume, %.0f percent Completed, duration %@";
 "voiceover_no_bound_books_title" = "No Volume Title";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Set default speed";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pausar";
 "voiceover_no_title" = "Sin título";
 "voiceover_no_author" = "Sin autor";
-"voiceover_book_progress" = "%@ por %@, %d porcentaje completado, duración: %@";
+"voiceover_book_progress" = "%@ por %@, %.0f porcentaje completado, duración: %@";
 "voiceover_no_file_title" = "Sin título de archivo";
 "voiceover_no_file_subtitle" = "Sin subtítulo de archivo";
 "voiceover_no_playlist_title" = "Sin título de carpeta";
-"voiceover_playlist_progress" = "%@, Playlist %d porcentaje Completado";
+"voiceover_playlist_progress" = "%@, Playlist %.0f porcentaje Completado";
 "voiceover_unknown_title" = "Título desconocido";
 "voiceover_unknown_author" = "Autor desconocido";
 "voiceover_book_info" = "%@ por %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nuevo Volumen";
 "bound_books_create_alert_description" = "Asegúrate de que los libros estén en el orden correcto. Para reordenar los capítulos más adelante, deberás convertir el volumen nuevamente a una carpeta, reordenar los elementos y luego volver a crear el volumen.";
 "bound_books_create_alert_title" = "Crear un volumen";
-"voiceover_bound_books_progress" = "%@, volumen, %d porcentaje completado, duración %@";
+"voiceover_bound_books_progress" = "%@, volumen, %.0f porcentaje completado, duración %@";
 "voiceover_no_bound_books_title" = "Sin título";
 "default_title" = "Predeterminado";
 "voiceover_default_speed_title" = "Establecer velocidad predeterminada";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Keskeytä";
 "voiceover_no_title" = "Ei otsikkoa";
 "voiceover_no_author" = "Ei kirjailijaa";
-"voiceover_book_progress" = "%@ kirjoittaja %@ , %d prosenttia valmis, kesto: %@";
+"voiceover_book_progress" = "%@ kirjoittaja %@ , %.0f prosenttia valmis, kesto: %@";
 "voiceover_no_file_title" = "Ei tiedoston otsikkoa";
 "voiceover_no_file_subtitle" = "Ei tiedoston alaotsikkoa";
 "voiceover_no_playlist_title" = "Ei kansion otsikkoa";
-"voiceover_playlist_progress" = "%@ , soittolista, %d prosenttia valmis";
+"voiceover_playlist_progress" = "%@ , soittolista, %.0f prosenttia valmis";
 "voiceover_unknown_title" = "Tuntematon nimike";
 "voiceover_unknown_author" = "Tuntematon kirjailija";
 "voiceover_book_info" = "%@ kirjoittaja %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Uusi kirja";
 "bound_books_create_alert_description" = "Varmista, että kohteet ovat oikeassa järjestyksessä. Jos haluat uudelleenjärjestää kappaleet myöhemmin, sinun on muutettava kirja takaisin kansioksi, uudelleenjärjestettävä kohteet ja luotava kirja uudelleen.";
 "bound_books_create_alert_title" = "Luo kirja";
-"voiceover_bound_books_progress" = "%@, määrä, %d prosenttia valmis, kesto %@";
+"voiceover_bound_books_progress" = "%@, määrä, %.0f prosenttia valmis, kesto %@";
 "voiceover_no_bound_books_title" = "Ei kirjan otsikkoa";
 "default_title" = "Oletus";
 "voiceover_default_speed_title" = "Aseta oletusnopeus";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Sans titre";
 "voiceover_no_author" = "Aucun auteur";
-"voiceover_book_progress" = "%@ af %@, %d procent fuldført, varighed: %@";
+"voiceover_book_progress" = "%@ af %@, %.0f procent fuldført, varighed: %@";
 "voiceover_no_file_title" = "Fichier sans titre";
 "voiceover_no_file_subtitle" = "Fichier sans sous-titre";
 "voiceover_no_playlist_title" = "Aucun titre de dossier";
-"voiceover_playlist_progress" = "%@, Liste de lecture, %d pour cent terminé";
+"voiceover_playlist_progress" = "%@, Liste de lecture, %.0f pour cent terminé";
 "voiceover_unknown_title" = "Titre inconnu";
 "voiceover_unknown_author" = "Auteur inconnu";
 "voiceover_book_info" = "%@ par %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nouveau volume de livre";
 "bound_books_create_alert_description" = "Assurez-vous que les éléments sont dans le bon ordre. Pour réorganiser les chapitres ultérieurement, vous devez reconvertir le volume en dossier, réorganiser les éléments, puis recréer le volume.";
 "bound_books_create_alert_title" = "Créer un volume";
-"voiceover_bound_books_progress" = "%@, Volumen, %d procent fuldført, varighed %@";
+"voiceover_bound_books_progress" = "%@, Volumen, %.0f procent fuldført, varighed %@";
 "voiceover_no_bound_books_title" = "Pas de titre de volume";
 "default_title" = "Défaut";
 "voiceover_default_speed_title" = "Définir la vitesse par défaut";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Szünet";
 "voiceover_no_title" = "Nincs cím";
 "voiceover_no_author" = "Nincs szerző";
-"voiceover_book_progress" = "%@ – %@, %d százalék kész, időtartam: %@";
+"voiceover_book_progress" = "%@ – %@, %.0f százalék kész, időtartam: %@";
 "voiceover_no_file_title" = "A fájlnak nincs címe";
 "voiceover_no_file_subtitle" = "A fájlnak nincsen felirata";
 "voiceover_no_playlist_title" = "Nincs mappa címe";
-"voiceover_playlist_progress" = "%@, lejátszólista, %d%% meghallgatva";
+"voiceover_playlist_progress" = "%@, lejátszólista, %.0f%% meghallgatva";
 "voiceover_unknown_title" = "Ismeretlen cím";
 "voiceover_unknown_author" = "Ismeretlen szerző";
 "voiceover_book_info" = "%@ - %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Új könyvkötet";
 "bound_books_create_alert_description" = "Győződjön meg arról, hogy az elemek megfelelő sorrendben vannak. A fejezetek későbbi átrendezéséhez vissza kell alakítania a kötetet mappává, át kell rendeznie az elemeket, majd újra létre kell hoznia a kötetet.";
 "bound_books_create_alert_title" = "Kötet létrehozása";
-"voiceover_bound_books_progress" = "%@, kötet, %d százalék kész, időtartam %@";
+"voiceover_bound_books_progress" = "%@, kötet, %.0f százalék kész, időtartam %@";
 "voiceover_no_bound_books_title" = "Nincs kötet címke";
 "default_title" = "Alapértelmezett";
 "voiceover_default_speed_title" = "Állítsa be az alapértelmezett sebességet";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pausa";
 "voiceover_no_title" = "Nessun titolo";
 "voiceover_no_author" = "Nessun autore";
-"voiceover_book_progress" = "%@ di %@ , %d percento completato, durata: %@";
+"voiceover_book_progress" = "%@ di %@ , %.0f percento completato, durata: %@";
 "voiceover_no_file_title" = "Nessun titolo del file";
 "voiceover_no_file_subtitle" = "Nessun sottotitolo del file";
 "voiceover_no_playlist_title" = "Nessun titolo della cartella";
-"voiceover_playlist_progress" = "%@, Cartella, %d%% completato";
+"voiceover_playlist_progress" = "%@, Cartella, %.0f%% completato";
 "voiceover_unknown_title" = "Titolo sconosciuto";
 "voiceover_unknown_author" = "Autore sconosciuto";
 "voiceover_book_info" = "%@ di %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nuovo volume del libro";
 "bound_books_create_alert_description" = "Assicurati che gli articoli siano nell'ordine corretto. Per riordinare i capitoli in un secondo momento è necessario riconvertire il volume in una cartella, riordinare gli elementi e quindi ricreare il volume.";
 "bound_books_create_alert_title" = "Crea un volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d percento completato, durata %@";
+"voiceover_bound_books_progress" = "%@, Volume, %.0f percento completato, durata %@";
 "voiceover_no_bound_books_title" = "Nessun titolo del volume";
 "default_title" = "Default";
 "voiceover_default_speed_title" = "Imposta la velocità predefinita";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pause";
 "voiceover_no_title" = "Uten tittel";
 "voiceover_no_author" = "Ingen forfatter";
-"voiceover_book_progress" = "%@ av %@, %d prosent fullført, varighet: %@";
+"voiceover_book_progress" = "%@ av %@, %.0f prosent fullført, varighet: %@";
 "voiceover_no_file_title" = "Ingen filtittel";
 "voiceover_no_file_subtitle" = "Ingen filundertittel";
 "voiceover_no_playlist_title" = "Ingen mappetittel";
-"voiceover_playlist_progress" = "%@, mappe, %d prosent fullført";
+"voiceover_playlist_progress" = "%@, mappe, %.0f prosent fullført";
 "voiceover_unknown_title" = "Ukjent tittel";
 "voiceover_unknown_author" = "Ukjent forfatter";
 "voiceover_book_info" = "%@ av %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nytt volum";
 "bound_books_create_alert_description" = "Kontroller at elementene er i riktig rekkefølge. For å omorganisere kapitler senere må du konvertere volumet tilbake til en mappe, omorganisere elementer og deretter opprette volumet på nytt.";
 "bound_books_create_alert_title" = "Opprette et volum";
-"voiceover_bound_books_progress" = "%@ , Volum, %d prosent fullført, varighet %@";
+"voiceover_bound_books_progress" = "%@ , Volum, %.0f prosent fullført, varighet %@";
 "voiceover_no_bound_books_title" = "Ingen volumtittel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Angi standardhastighet";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pauze";
 "voiceover_no_title" = "Geen titel";
 "voiceover_no_author" = "Geen auteur";
-"voiceover_book_progress" = "%@ door %@ , %d procent voltooid, duur: %@";
+"voiceover_book_progress" = "%@ door %@ , %.0f procent voltooid, duur: %@";
 "voiceover_no_file_title" = "Geen bestandstitel";
 "voiceover_no_file_subtitle" = "Geen ondertitel bestand";
 "voiceover_no_playlist_title" = "Geen maptitel";
-"voiceover_playlist_progress" = "%@ , Afspeellijst, %d procent voltooid";
+"voiceover_playlist_progress" = "%@ , Afspeellijst, %.0f procent voltooid";
 "voiceover_unknown_title" = "Onbekende titel";
 "voiceover_unknown_author" = "Onbekende auteur";
 "voiceover_book_info" = "%@ door %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nieuw boekvolume";
 "bound_books_create_alert_description" = "Zorg ervoor dat de artikelen in de juiste volgorde staan. Om hoofdstukken later opnieuw te ordenen, moet u het volume weer in een map omzetten, items opnieuw ordenen en vervolgens het volume opnieuw maken.";
 "bound_books_create_alert_title" = "Een volume maken";
-"voiceover_bound_books_progress" = "%@, volume, %d procent voltooid, duur %@";
+"voiceover_bound_books_progress" = "%@, volume, %.0f procent voltooid, duur %@";
 "voiceover_no_bound_books_title" = "Geen volumetitel";
 "default_title" = "Standaard";
 "voiceover_default_speed_title" = "Standaardsnelheid instellen";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pauza";
 "voiceover_no_title" = "Brak tytułu";
 "voiceover_no_author" = "Brak autora";
-"voiceover_book_progress" = "%@ do %@, ukończono %d procent, czas trwania: %@";
+"voiceover_book_progress" = "%@ do %@, ukończono %.0f procent, czas trwania: %@";
 "voiceover_no_file_title" = "Brak tytułu pliku";
 "voiceover_no_file_subtitle" = "Brak tytułu pliku";
 "voiceover_no_playlist_title" = "Brak tytułu folderu";
-"voiceover_playlist_progress" = "%@, Playlista, ukończono %d procent";
+"voiceover_playlist_progress" = "%@, Playlista, ukończono %.0f procent";
 "voiceover_unknown_title" = "Nieznany tytuł";
 "voiceover_unknown_author" = "Nieznany autor";
 "voiceover_book_info" = "%@ - %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nowy Wolumin Książki";
 "bound_books_create_alert_description" = "Upewnij się, że elementy są we właściwej kolejności. Aby później zmienić kolejność rozdziałów, należy przekonwertować wolumin z powrotem na folder, zmienić kolejność elementów, a następnie ponownie utworzyć wolumin.";
 "bound_books_create_alert_title" = "Utwórz wolumin";
-"voiceover_bound_books_progress" = "%@, Wolumin, %d procent Ukończono, czas trwania %@";
+"voiceover_bound_books_progress" = "%@, Wolumin, %.0f procent Ukończono, czas trwania %@";
 "voiceover_no_bound_books_title" = "Brak Nazwy Woluminu";
 "default_title" = "Domyślna";
 "voiceover_default_speed_title" = "Ustaw domyślną prędkość";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pausa";
 "voiceover_no_title" = "Sem Título";
 "voiceover_no_author" = "Autor desconhecido";
-"voiceover_book_progress" = "%@ por %@, %d por cento concluído, duração: %@";
+"voiceover_book_progress" = "%@ por %@, %.0f por cento concluído, duração: %@";
 "voiceover_no_file_title" = "Arquivo Sem Título";
 "voiceover_no_file_subtitle" = "Sem legenda no Arquivo";
 "voiceover_no_playlist_title" = "Sem título de pasta";
-"voiceover_playlist_progress" = "%@, Playlist, %d por cento concluída";
+"voiceover_playlist_progress" = "%@, Playlist, %.0f por cento concluída";
 "voiceover_unknown_title" = "Título desconhecido";
 "voiceover_unknown_author" = "Autor desconhecido";
 "voiceover_book_info" = "%@ de %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Novo Volume do Livro";
 "bound_books_create_alert_description" = "Certifique-se de que os itens estão na ordem correta. Para reordenar capítulos mais tarde, você precisa converter o volume de volta em uma pasta, reordenar itens e, em seguida, recriar novamente o volume.";
 "bound_books_create_alert_title" = "Criar um volume";
-"voiceover_bound_books_progress" = "%@, Volume, %d por cento Concluído, duração %@";
+"voiceover_bound_books_progress" = "%@, Volume, %.0f por cento Concluído, duração %@";
 "voiceover_no_bound_books_title" = "Sem título de Volume";
 "default_title" = "Padrão";
 "voiceover_default_speed_title" = "Definir velocidade padrão";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pauză";
 "voiceover_no_title" = "Fără titlu";
 "voiceover_no_author" = "Fără autor";
-"voiceover_book_progress" = "%@ de %@ , %d procente finalizate, durata: %@";
+"voiceover_book_progress" = "%@ de %@ , %.0f procente finalizate, durata: %@";
 "voiceover_no_file_title" = "Fără titlu de fișier";
 "voiceover_no_file_subtitle" = "Fără fișier de subtitrare";
 "voiceover_no_playlist_title" = "Fără titlu de folder";
-"voiceover_playlist_progress" = "%@, Listă de redare, %d procent finalizat";
+"voiceover_playlist_progress" = "%@, Listă de redare, %.0f procent finalizat";
 "voiceover_unknown_title" = "Titlu necunoscut";
 "voiceover_unknown_author" = "Autor necunoscut";
 "voiceover_book_info" = "%@ cate %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Volum nou de carte";
 "bound_books_create_alert_description" = "Asigurați-vă că articolele sunt în ordinea corectă. Pentru a reordona capitolele mai târziu, trebuie să convertiți volumul înapoi într-un folder, să reordonați articolele și apoi să recreați volumul.";
 "bound_books_create_alert_title" = "Creați un volum";
-"voiceover_bound_books_progress" = "%@, Volum, %d la sută Finalizat, durata %@";
+"voiceover_bound_books_progress" = "%@, Volum, %.0f la sută Finalizat, durata %@";
 "voiceover_no_bound_books_title" = "Fără titlu de volum";
 "default_title" = "Mod implicit";
 "voiceover_default_speed_title" = "Setați viteza implicită";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Пауза";
 "voiceover_no_title" = "Без названия";
 "voiceover_no_author" = "Неизвестный автор";
-"voiceover_book_progress" = "%@ к %@, %d процентов выполнения, продолжительность: %@";
+"voiceover_book_progress" = "%@ к %@, %.0f процентов выполнения, продолжительность: %@";
 "voiceover_no_file_title" = "Нет названия файла";
 "voiceover_no_file_subtitle" = "Подзаголовок файла отсутствует";
 "voiceover_no_playlist_title" = "Нет названия папки";
-"voiceover_playlist_progress" = "Плейлист %@ завершен на %d%%";
+"voiceover_playlist_progress" = "Плейлист %@ завершен на %.0f%%";
 "voiceover_unknown_title" = "Без названия";
 "voiceover_unknown_author" = "Неизвестный автор";
 "voiceover_book_info" = "%@, %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Новая книга";
 "bound_books_create_alert_description" = "Убедитесь, что файлы расположены в правильном порядке. Чтобы позже изменить порядок глав, нужно преобразовать книгу обратно в папку, изменить порядок файлов, а затем снова создать книгу.";
 "bound_books_create_alert_title" = "Создать книгу";
-"voiceover_bound_books_progress" = "%@, Объем, %d процентов Выполнено, продолжительность %@";
+"voiceover_bound_books_progress" = "%@, Объем, %.0f процентов Выполнено, продолжительность %@";
 "voiceover_no_bound_books_title" = "Отсутствует название книги";
 "default_title" = "Дефолт";
 "voiceover_default_speed_title" = "Установить скорость по умолчанию";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -7,13 +7,13 @@
 "settings_smartrewind_description" = "Po prerušení počúvania na 10 minút dôjde k pretočeniu späť o 30 sekúnd.";
 "settings_boostvolume_title" = "Zvýšenie hlasitosti";
 "settings_boostvolume_description" = "Zdvojnásobí hlasitosť prehrávania.\nPoužívajte opatrne a chráňte si svoj sluch.";
-"settings_globalspeed_title" = "Globálne ovládanie rýchlosti prehrávania";
+"settings_globalspeed_title" = "Globálne ovládanie rýchlosti";
 "settings_globalspeed_description" = "Nastaví rýchlosť prehrávania pre všetky audioknihy.";
 "settings_autolock_title" = "Zakázať automatické uzamknutie";
 "settings_autolock_description" = "Zabráni uzamknutiu zariadenia pri zobrazení Prehrávača.";
 "settings_siri_lastplayed_title" = "Naposledy prehrávaná audiokniha";
 "settings_siri_lastplayed_description" = "Pre pokračovanie počúvania poslednej audioknihy použite Siri.";
-"settings_skip_title" = "INTERVALY PRETÁČANIA";
+"settings_skip_title" = "INTERVALY PRESKOČENIA";
 "settings_skip_rewind_title" = "Dozadu";
 "settings_skip_forward_title" = "Dopredu";
 "settings_skip_description" = "Úprava časového intervalu preskočenia pri použití tlačidiel v Prehrávači alebo Ovládacom centre.";
@@ -47,8 +47,8 @@
 "move_library_button" = "Presunúť do Knižnice";
 "options_button" = "Možnosti";
 "select_playlist_title" = "Vyberte položku Priečinok";
-"title_button" = "Názvu";
-"sort_filename_button" = "Pôvodného názvu súboru";
+"title_button" = "názvu";
+"sort_filename_button" = "pôvodného názvu súboru";
 "sort_title" = "Zoradiť položky podľa";
 "cancel_button" = "Zrušiť";
 "seconds_title" = "sek.";
@@ -159,7 +159,7 @@
 "voiceover_miniplayer_hint" = "Miniprehrávač. Ťuknite pre zobrazenie Prehrávača";
 "voiceover_chapter_time_title" = "Dĺžka aktuálnej kapitoly: %@";
 "voiceover_dismiss_player_title" = "Zavrieť prehrávač";
-"sort_most_recent_button" = "Najnovšie";
+"sort_most_recent_button" = "najnovších";
 "sort_reversed_button" = "Opačné poradie";
 "voiceover_continue_playback_title" = "Pokračovať v prehrávaní";
 "coredata_error_diskfull_description" = "Knižnicu sa nepodarilo načítať. V zariadení nie je dostatok miesta na disku.";
@@ -228,9 +228,9 @@
 "cancel_download_title" = "Zrušiť sťahovanie";
 "remove_downloaded_file_title" = "Odstrániť zo zariadenia";
 "download_from_url_title" = "Stiahnuť z adresy URL";
-"done_title" = "hotový";
-"select_title" = "Vyberte";
-"sort_button_title" = "Triediť";
+"done_title" = "Hotovo";
+"select_title" = "Výber";
+"sort_button_title" = "Zoradiť podľa";
 "search_title" = "Vyhľadávanie";
 "books_title" = "knihy";
 "folders_title" = "Priečinky";
@@ -283,6 +283,6 @@
 Majte na pamäti, že úlohy nahrávania môžu chvíľu trvať a priebeh sa bude pravidelne zobrazovať na predchádzajúcej obrazovke.
 
 Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné, kontaktujte nás na adrese support@bookplayer.app so snímkou obrazovky tejto obrazovky. Vďaka!";
-"sort_by_size_title" = "Veľkosť";
+"sort_by_size_title" = "veľkosti";
 "settings_storage_sync_deleted_description" = "Súbory boli odstránené (operácie synchronizácie)";
 "storage_sync_deleted_recover_description" = "Miestne knihy a priečinky môžete importovať späť, ak boli odstránené operáciou synchronizácie. Tým sa všetky presunú späť do priečinka dokumentov, čím sa spustí proces importu. Ak ide o priečinky, môže to znamenať, že originály sú stále v knižnici a bude potrebné vykonať určité premenovanie, ospravedlňujeme sa za túto nepríjemnosť";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Pozastaviť";
 "voiceover_no_title" = "Žiadny názov";
 "voiceover_no_author" = "Žiadny autor";
-"voiceover_book_progress" = "%@ podľa %@, %d percent dokončených, trvanie: %@";
+"voiceover_book_progress" = "%@ podľa %@, %.0f percent dokončených, trvanie: %@";
 "voiceover_no_file_title" = "Žiadny názov súboru";
 "voiceover_no_file_subtitle" = "Žiadny podtitul súboru";
 "voiceover_no_playlist_title" = "Žiadny názov priečinka";
-"voiceover_playlist_progress" = "%@, Priečinok, %d percent dokončených";
+"voiceover_playlist_progress" = "%@, Priečinok, %.0f percent dokončených";
 "voiceover_unknown_title" = "Neznámy názov";
 "voiceover_unknown_author" = "Neznámy autor";
 "voiceover_book_info" = "%@ z %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Nový zväzok knihy";
 "bound_books_create_alert_description" = "Skontrolujte, či sú položky v správnom poradí. Ak chcete neskôr zmeniť poradie kapitol, musíte zväzok previesť späť na priečinok, zmeniť poradie položiek a potom zväzok znovu vytvoriť.";
 "bound_books_create_alert_title" = "Vytváranie zväzku";
-"voiceover_bound_books_progress" = "%@, Zväzok, %d percent dokončených, trvanie %@";
+"voiceover_bound_books_progress" = "%@, Zväzok, %.0f percent dokončených, trvanie %@";
 "voiceover_no_bound_books_title" = "Žiadny názov zväzku";
 "default_title" = "Predvolené";
 "voiceover_default_speed_title" = "Nastavte predvolenú rýchlosť";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Paus";
 "voiceover_no_title" = "Titel saknas";
 "voiceover_no_author" = "Författare saknas";
-"voiceover_book_progress" = "%@ av %@, %d procent läst, varaktighet: %@";
+"voiceover_book_progress" = "%@ av %@, %.0f procent läst, varaktighet: %@";
 "voiceover_no_file_title" = "Filtitel saknas";
 "voiceover_no_file_subtitle" = "Undertext för fil saknas";
 "voiceover_no_playlist_title" = "Ingen mapptitel";
-"voiceover_playlist_progress" = "%@, Spellista %d procent läst";
+"voiceover_playlist_progress" = "%@, Spellista %.0f procent läst";
 "voiceover_unknown_title" = "Okänd titel";
 "voiceover_unknown_author" = "Okänd författare";
 "voiceover_book_info" = "%@ av %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Ny boksamling";
 "bound_books_create_alert_description" = "Se till att delarna är i rätt ordning. För att ändra kapitelordning senare måste du konvertera samlingen tillbaka till en mapp, ändra ordning på delarna och sedan återskapa samlingen.";
 "bound_books_create_alert_title" = "Skapa en boksamling";
-"voiceover_bound_books_progress" = "%@, boksamling, %d procent läst, varaktighet %@";
+"voiceover_bound_books_progress" = "%@, boksamling, %.0f procent läst, varaktighet %@";
 "voiceover_no_bound_books_title" = "Ingen volymtitel";
 "default_title" = "Standard";
 "voiceover_default_speed_title" = "Ställ in standardhastighet";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Duraklat";
 "voiceover_no_title" = "Başlık Yok";
 "voiceover_no_author" = "Yazar Yok";
-"voiceover_book_progress" = "%@ tarafından %@, yüzde %d tamamlandı, süre: %@";
+"voiceover_book_progress" = "%@ tarafından %@, yüzde %.0f tamamlandı, süre: %@";
 "voiceover_no_file_title" = "Dosya Başlığı Yok";
 "voiceover_no_file_subtitle" = "Dosya Altyazısı Yok";
 "voiceover_no_playlist_title" = "Klasör Başlığı Yok";
-"voiceover_playlist_progress" = "%@, Oynatma Listesi, yüzde %d tamamlandı";
+"voiceover_playlist_progress" = "%@, Oynatma Listesi, yüzde %.0f tamamlandı";
 "voiceover_unknown_title" = "Bilinmeyen başlık";
 "voiceover_unknown_author" = "Bilinmeyen yazar";
 "voiceover_book_info" = "%@ ( Yazar: %@ )";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Yeni Kitap Hacmi";
 "bound_books_create_alert_description" = "Öğelerin doğru sırada olduğundan emin olun. Bölümleri daha sonra yeniden sıralamak için birimi tekrar bir klasöre dönüştürmeniz, öğeleri yeniden sıralamanız ve ardından birimi yeniden oluşturmanız gerekir.";
 "bound_books_create_alert_title" = "Birim oluştur";
-"voiceover_bound_books_progress" = "%@, Cilt, %d yüzde Tamamlandı, süre %@";
+"voiceover_bound_books_progress" = "%@, Cilt, %.0f yüzde Tamamlandı, süre %@";
 "voiceover_no_bound_books_title" = "Cilt Başlığı Yok";
 "default_title" = "Varsayılan";
 "voiceover_default_speed_title" = "Varsayılan hızı ayarla";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "Пауза";
 "voiceover_no_title" = "Без назви";
 "voiceover_no_author" = "Немає автора";
-"voiceover_book_progress" = "%@ від %@ , виконано %d відсотків, тривалість: %@";
+"voiceover_book_progress" = "%@ від %@ , виконано %.0f відсотків, тривалість: %@";
 "voiceover_no_file_title" = "Немає імені файлу";
 "voiceover_no_file_subtitle" = "Відсутній підзаголовок файлу";
 "voiceover_no_playlist_title" = "Назва теки відсутня";
-"voiceover_playlist_progress" = "%@, тека, відтворена на %d%%";
+"voiceover_playlist_progress" = "%@, тека, відтворена на %.0f%%";
 "voiceover_unknown_title" = "Невідома назва";
 "voiceover_unknown_author" = "Невідомий автор";
 "voiceover_book_info" = "%@ з %@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "Новий том книги";
 "bound_books_create_alert_description" = "Переконайтеся, що елементи розташовані в правильному порядку. Щоб змінити порядок розділів, вам потрібно перетворити том назад у теку та переставити елементи, а потім знову створити том.";
 "bound_books_create_alert_title" = "Створіть том";
-"voiceover_bound_books_progress" = "%@, обсяг, %d відсоток завершено, тривалість %@";
+"voiceover_bound_books_progress" = "%@, обсяг, %.0f відсоток завершено, тривалість %@";
 "voiceover_no_bound_books_title" = "Том без заголовка";
 "default_title" = "За замовчуванням";
 "voiceover_default_speed_title" = "Встановити швидкість за замовчуванням";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -126,11 +126,11 @@
 "pause_title" = "暂停";
 "voiceover_no_title" = "未知标题";
 "voiceover_no_author" = "未知作者";
-"voiceover_book_progress" = "%@之%@ %d已完成，持续时间： %@";
+"voiceover_book_progress" = "%@之%@ %.0f已完成，持续时间： %@";
 "voiceover_no_file_title" = "没有文件标题";
 "voiceover_no_file_subtitle" = "没有文件副标题";
 "voiceover_no_playlist_title" = "没有文件夹标题";
-"voiceover_playlist_progress" = "%@播放列表%d已完成";
+"voiceover_playlist_progress" = "%@播放列表%.0f已完成";
 "voiceover_unknown_title" = "未知标题";
 "voiceover_unknown_author" = "未知作者";
 "voiceover_book_info" = "%@之%@";
@@ -195,7 +195,7 @@
 "bound_books_new_title_placeholder" = "新的书卷";
 "bound_books_create_alert_description" = "确保有声书文件的顺序正确。如果以后要重新安排章节的顺序，你需要把书卷转换回文件夹，重新安排文件顺序，然后重新创建书卷。";
 "bound_books_create_alert_title" = "创建一个卷";
-"voiceover_bound_books_progress" = "%@, 体积, %d%% 已完成, 持续时间 %@";
+"voiceover_bound_books_progress" = "%@, 体积, %.0f%% 已完成, 持续时间 %@";
 "voiceover_no_bound_books_title" = "没有书卷名";
 "default_title" = "默认";
 "voiceover_default_speed_title" = "设置默认速度";

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -94,11 +94,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
     self.currentTime = currentTime
     self.duration = duration
     self.durationFormatted = TimeParser.formatTotalDuration(duration)
-    if percentCompleted.isNaN || percentCompleted.isInfinite {
-      self.percentCompleted = 0
-    } else {
-      self.percentCompleted = percentCompleted
-    }
+    self.percentCompleted = percentCompleted
     self.isFinished = isFinished
     self.relativePath = relativePath
     self.remoteURL = remoteURL
@@ -119,11 +115,7 @@ extension SimpleLibraryItem {
     self.currentTime = item.currentTime
     self.duration = item.duration
     self.durationFormatted = TimeParser.formatTotalDuration(item.duration)
-    if item.percentCompleted.isNaN || item.percentCompleted.isInfinite {
-      self.percentCompleted = 0
-    } else {
-      self.percentCompleted = item.percentCompleted
-    }
+    self.percentCompleted = item.percentCompleted
     self.isFinished = item.isFinished
     self.relativePath = item.relativePath
     self.remoteURL = item.remoteURL

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -291,6 +291,9 @@ public final class LibraryService: LibraryServiceProtocol {
       /// Patch for optional CoreData properties until we migrate to Realm
       if dictionary["details"] == nil {
         self?.rebuildFolderDetails(relativePath)
+      } else if type == .folder &&
+                  (percentCompleted.isNaN || percentCompleted.isInfinite) {
+        self?.rebuildFolderDetails(relativePath)
       }
 
       return SimpleLibraryItem(


### PR DESCRIPTION
## Bugfix

- For some users, playback caused the app to crash after a few seconds, this is related to changes to the VoiceOver service, which tries to read the percent completed of the item to set the spoken label

## Approach

- Remove Int conversion, and update all translations to take the Float argument
- Update Slovak translation with latest values
- Fix 'Mark as complete' from the player view not working properly

## Things to be aware of / Things to focus on

- There's currently a live beta with these changes. If anyone is experiencing problems with playback, just ask to join until we release v5.0.7
