### PR TITLE
Skip unplayable items on autoplay

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -304,9 +304,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
         let playerItem = self.playerItem,
         chapter.duration > 0
       else {
-        DispatchQueue.main.async {
-          self.currentItem = nil
-          self.isFetchingRemoteURL = nil
+        DispatchQueue.main.async { [weak self] in
+          self?.playbackQueued = nil
+          self?.isFetchingRemoteURL = nil
           NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["loaded": false])
         }
         return
@@ -837,10 +837,9 @@ extension PlayerManager {
 
     guard
       let currentItem = self.currentItem,
-      let nextBook = self.playbackService.getPlayableItem(
-        after: currentItem.relativePath,
-        parentFolder: currentItem.parentFolder,
-        autoplayed: autoPlayed,
+      let nextBook = getNextPlayableBook(
+        after: currentItem,
+        autoPlayed: autoPlayed,
         restartFinished: restartFinished
       )
     else { return }
@@ -853,6 +852,34 @@ extension PlayerManager {
     }
 
     load(nextBook, autoplay: shouldAutoplay)
+  }
+
+  /// Check `UTType` of the book before returning it
+  /// Note: if the type does not conform to `.audiovisualContent` it will skip the item
+  func getNextPlayableBook(
+    after item: PlayableItem,
+    autoPlayed: Bool,
+    restartFinished: Bool
+  ) -> PlayableItem? {
+    guard
+      let nextBook = self.playbackService.getPlayableItem(
+        after: item.relativePath,
+        parentFolder: item.parentFolder,
+        autoplayed: autoPlayed,
+        restartFinished: restartFinished
+      ),
+      let fileType = UTType(filenameExtension: nextBook.fileURL.pathExtension)
+    else { return nil }
+
+    if !fileType.isSubtype(of: .audiovisualContent) {
+      return getNextPlayableBook(
+        after: nextBook,
+        autoPlayed: autoPlayed,
+        restartFinished: restartFinished
+      )
+    }
+
+    return nextBook
   }
 
   @objc

--- a/BookPlayerTests/Mocks/PlayableItemMock.swift
+++ b/BookPlayerTests/Mocks/PlayableItemMock.swift
@@ -35,4 +35,30 @@ extension PlayableItem {
       isBoundBook: false
     )
   }
+
+  static func mockWithExtension(_ fileExtension: String) -> PlayableItem {
+    return PlayableItem(
+      title: "test-title",
+      author: "test-author",
+      chapters: [
+        PlayableChapter(
+          title: "test-chapter",
+          author: "test-author",
+          start: 0,
+          duration: 100,
+          relativePath: "test-path",
+          remoteURL: nil,
+          index: 0
+        )
+      ],
+      currentTime: 0,
+      duration: 100,
+      relativePath: "test-path.\(fileExtension)",
+      parentFolder: nil,
+      percentCompleted: 0,
+      lastPlayDate: nil,
+      isFinished: false,
+      isBoundBook: false
+    )
+  }
 }

--- a/BookPlayerTests/Services/BookSortServiceTest.swift
+++ b/BookPlayerTests/Services/BookSortServiceTest.swift
@@ -19,7 +19,7 @@ class BookSortServiceTest: XCTestCase {
     "09 Book 10.txt"
   ]
 
-    var booksByFile: [LibraryItem]?
+    var booksByFile: [BookPlayerKit.LibraryItem]?
 
     override func setUp() {
       let documentsFolder = DataManager.getDocumentsFolderURL()

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -329,14 +329,14 @@ class LibraryServiceTests: XCTestCase {
 
     XCTAssert(folder.items?.count == 2)
 
-    XCTAssert((folder.items?.allObjects as? [LibraryItem])?
+    XCTAssert((folder.items?.allObjects as? [BookPlayerKit.LibraryItem])?
       .contains(where: { $0.relativePath == folder3.relativePath}) ?? false)
 
     _ = try! self.sut.createFolder(with: "test-folder4", inside: "test-folder")
     let folder4 = self.sut.getItem(with: "test-folder/test-folder4") as! Folder
 
     XCTAssert(folder.items?.count == 3)
-    XCTAssert((folder.items?.allObjects as? [LibraryItem])?
+    XCTAssert((folder.items?.allObjects as? [BookPlayerKit.LibraryItem])?
       .contains(where: { $0.relativePath == folder4.relativePath}) ?? false)
   }
 
@@ -923,11 +923,11 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .shallow)
 
-    XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == folder)
+    XCTAssert((library.items?.allObjects as? [BookPlayerKit.LibraryItem])?.first == folder)
 
     try self.sut.delete([SimpleLibraryItem(from: folder)], mode: .shallow)
 
-    XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == book1)
+    XCTAssert((library.items?.allObjects as? [BookPlayerKit.LibraryItem])?.first == book1)
   }
 
   func testFolderShallowDeleteWithMultipleBooks() throws {
@@ -1008,7 +1008,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     try self.sut.delete([SimpleLibraryItem(from: folder2)], mode: .deep)
 
     XCTAssert(library.items?.count == 1)
-    XCTAssert((library.items?.allObjects as? [LibraryItem])?.first == book1)
+    XCTAssert((library.items?.allObjects as? [BookPlayerKit.LibraryItem])?.first == book1)
   }
 
   func testGetMaxItemsCount() throws {


### PR DESCRIPTION
## Purpose

- Autoplay can get stuck if it tries to play any non-audio file (or not supported audio files)

## Approach

- Add a `UTType` check on the next item fetched by `PlayerManager`, so if it's not a subtype of `audiovisualContent`, it should go to the next one

## Things to be aware of / Things to focus on

- This only applies to autoplay (or when skipping chapters), if the user manually opens an image, the player will show up
- I thought about doing this at the import level, but as we can import folders, it would complicate `ImportOperation` by requiring to traverse all the folder's contents, and could lead to users thinking that the import operation is faulty because it's not importing all the files
