### PR TITLE
Add support for loading chapter artwork for volumes

### DIFF
--- a/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
+++ b/BookPlayer/Player/Player Screen/Views/ArtworkControl.swift
@@ -161,11 +161,18 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
 
   public func setupInfo(
     with title: String,
-    author: String,
-    relativePath: String
+    author: String
   ) {
     self.titleLabel.text = title
     self.authorLabel.text = author
+    self.artworkOverlay.isAccessibilityElement = true
+    self.artworkOverlay.accessibilityLabel = VoiceOverService.playerMetaText(
+      title: title,
+      author: author
+    )
+  }
+
+  public func setupArtworkImage(relativePath: String) {
     self.artworkImage.kf.setImage(
       with: ArtworkService.getArtworkProvider(for: relativePath),
       options: [.targetCache(ArtworkService.cache)],
@@ -179,11 +186,6 @@ class ArtworkControl: UIView, UIGestureRecognizerDelegate {
           self.artworkImage.isHidden = true
         }
       }
-    )
-    self.artworkOverlay.isAccessibilityElement = true
-    self.artworkOverlay.accessibilityLabel = VoiceOverService.playerMetaText(
-      title: title,
-      author: author
     )
   }
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -329,31 +329,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
         self.setNowPlayingBookTitle(chapter: chapter)
         self.setNowPlayingBookTime()
-
-        var pathForArtwork = chapter.relativePath
-
-        if !ArtworkService.isCached(relativePath: chapter.relativePath),
-           let currentItem {
-          pathForArtwork = currentItem.relativePath
-        }
-
-        ArtworkService.retrieveImageFromCache(for: pathForArtwork) { result in
-          let image: UIImage
-
-          switch result {
-          case .success(let value):
-            image = value.image
-          case .failure:
-            image = ArtworkService.generateDefaultArtwork(from: ThemeManager.shared.currentTheme.linkColor)!
-          }
-
-          self.nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size,
-                                                                               requestHandler: { (_) -> UIImage in
-            image
-          })
-
-          MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
-        }
+        self.setNowPlayingArtwork(chapter: chapter)
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
 
@@ -368,6 +344,36 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
         NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["loaded": true])
       }
+    }
+  }
+
+  func setNowPlayingArtwork(chapter: PlayableChapter) {
+    var pathForArtwork = chapter.relativePath
+
+    if !ArtworkService.isCached(relativePath: chapter.relativePath),
+       let currentItem = currentItem {
+      pathForArtwork = currentItem.relativePath
+    }
+
+    ArtworkService.retrieveImageFromCache(for: pathForArtwork) { [weak self] result in
+      guard let self else { return }
+
+      let image: UIImage
+
+      switch result {
+      case .success(let value):
+        image = value.image
+      case .failure:
+        image = ArtworkService.generateDefaultArtwork(from: ThemeManager.shared.currentTheme.linkColor)!
+      }
+
+      self.nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
+        boundsSize: image.size,
+        requestHandler: { (_) -> UIImage in
+          image
+        })
+
+      MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
     }
   }
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -330,7 +330,14 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
         self.setNowPlayingBookTitle(chapter: chapter)
         self.setNowPlayingBookTime()
 
-        ArtworkService.retrieveImageFromCache(for: chapter.relativePath) { result in
+        var pathForArtwork = chapter.relativePath
+
+        if !ArtworkService.isCached(relativePath: chapter.relativePath),
+           let currentItem {
+          pathForArtwork = currentItem.relativePath
+        }
+
+        ArtworkService.retrieveImageFromCache(for: pathForArtwork) { result in
           let image: UIImage
 
           switch result {


### PR DESCRIPTION
## Purpose

- Individual files from a Volume may have embedded chapter artwork, the goal is to prefer these artworks vs the main item artwork whenever they're present

## Approach

- Add chapter observer on the Player screen, to reload the displayed artwork
- Add check on the `PlayerManager` when a chapter is loaded, so the proper artwork is loaded in the control center

## Things to be aware of / Things to focus on

- m4b files (or even single mp3 files) that have chapter markers and individual artwork embedded in those markers are not yet supported. We'd have to check the embedded metadata in `AVAudioAssetImageDataProvider`
