### PR TITLE
Fix media keys not working on MacOS

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -332,6 +332,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
         self.setNowPlayingArtwork(chapter: chapter)
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
+        MPNowPlayingInfoCenter.default().playbackState = .playing
 
         if let currentItem = self.currentItem {
           // if book is truly finished, start book again to avoid autoplaying next one
@@ -774,6 +775,7 @@ extension PlayerManager {
     playbackQueued = nil
     loadChapterTask?.cancel()
     nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
+    MPNowPlayingInfoCenter.default().playbackState = .paused
     setNowPlayingBookTime()
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
   }
@@ -797,6 +799,7 @@ extension PlayerManager {
     playerItem = nil
     /// Clear out flag when `playerItem` is nulled out
     hasObserverRegistered = false
+    MPNowPlayingInfoCenter.default().playbackState = .stopped
   }
 
   private func stopPlayback() {


### PR DESCRIPTION
## Bugfix

F7, F8 and F9 are note being recognized on MacOS

## Approach

- Set play/pause/stop to property `playbackState` that is specific for MacOS (see screenshot)

<img width="505" alt="Screenshot 2023-08-21 at 08 27 39" src="https://github.com/TortugaPower/BookPlayer/assets/14112819/4495abdf-e5c6-4aa1-b9ae-459f7ecc8350">

