### PR TITLE
Fix Recent Books Widget's spacing error and text alignment.

### DIFF
--- a/BookPlayerWidgetUI/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgetUI/RecentBooksWidgetView.swift
@@ -111,6 +111,7 @@ struct BookView: View {
           .foregroundColor(titleColor)
           .font(.caption)
           .lineLimit(2)
+          .multilineTextAlignment(.center)
           .frame(width: nil, height: 34, alignment: .leading)
       }
     }
@@ -147,6 +148,7 @@ struct RecentBooksWidgetView: View {
             HStack {
                 ForEach(items, id: \.relativePath) { item in
                     BookView(item: item, titleColor: widgetColors.primaryColor, theme: entry.theme, entry: entry)
+                    .frame(minWidth: 0, maxWidth: .infinity)
                 }
             }
             .padding([.leading, .trailing])
@@ -161,7 +163,14 @@ struct RecentBooksWidgetView: View {
 struct RecentBooksWidgetView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-          RecentBooksWidgetView(entry: LibraryEntry(date: Date(), items: [], theme: nil, timerSeconds: 300, autoplay: true))
+          RecentBooksWidgetView(
+            entry: LibraryEntry(date: Date(),
+                                items: [.previewItem(title: "a very very very long title"),
+                                        .previewItem(title: "a short title"),
+                                        .previewItem(title: "a short title")],
+                                theme: nil,
+                                timerSeconds: 300,
+                                autoplay: true))
                 .previewContext(WidgetPreviewContext(family: .systemMedium))
         }
     }

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -135,3 +135,26 @@ extension SimpleLibraryItem {
     }
   }
 }
+
+#if DEBUG
+extension SimpleLibraryItem {
+  static public func previewItem(title: String) -> Self {
+    SimpleLibraryItem(
+      title: title,
+      details: "some details",
+      speed: 1,
+      currentTime: 1,
+      duration: 1,
+      percentCompleted: 10,
+      isFinished: false,
+      relativePath: UUID().uuidString,
+      remoteURL: nil,
+      artworkURL: nil,
+      orderRank: 1,
+      parentFolder: nil,
+      originalFileName: "",
+      lastPlayDate: nil,
+      type: SimpleItemType.book)
+  }
+}
+#endif


### PR DESCRIPTION
## Bugfix

The widget distributes inequality space for book items when fewer than 4 books and 1 has a long title.
![image](https://github.com/TortugaPower/BookPlayer/assets/46838577/e09d2510-d453-410c-8249-9f542b3cc20b)

The widget should display equally like this.
![image](https://github.com/TortugaPower/BookPlayer/assets/46838577/7fe06514-9306-473f-9ef8-9fb45792c13f)

More than that, I suggest changing the title alignment to make multiline titles look more balanced.
![image](https://github.com/TortugaPower/BookPlayer/assets/46838577/744d56c3-b4a5-4e0d-8eef-e22cbaf0e1a1)
