### PR TITLE
Fix the suggested name for dropped files (iPad / Mac)

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -616,9 +616,8 @@ extension ItemListViewController: UIDropInteractionDelegate {
 
     item.itemProvider.loadObject(ofClass: ImportableItem.self) { [weak self] (object, _) in
       guard let item = object as? ImportableItem else { return }
-      if let suggestedName = providerReference.suggestedName {
-        item.suggestedName = "\(suggestedName).\(item.fileExtension)"
-      }
+      /// Set `suggesteName` from the provider
+      item.suggestedName = providerReference.suggestedName
 
       self?.viewModel.importData(from: item)
     }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -1109,7 +1109,20 @@ extension ItemListViewModel {
   }
 
   func importData(from item: ImportableItem) {
-    let filename = item.suggestedName ?? "\(Date().timeIntervalSince1970).\(item.fileExtension)"
+    let filename: String
+
+    if let suggestedName = item.suggestedName {
+      let pathExtension = (suggestedName as NSString).pathExtension
+      /// Use  `suggestedFileExtension` only if the curret name does not include an extension
+      if pathExtension.isEmpty {
+        filename = "\(suggestedName).\(item.suggestedFileExtension)"
+      } else {
+        filename = suggestedName
+      }
+    } else {
+      /// Fallback if the provider didn't have a suggested name
+      filename = "\(Date().timeIntervalSince1970).\(item.suggestedFileExtension)"
+    }
 
     let destinationURL = DataManager.getDocumentsFolderURL()
       .appendingPathComponent(filename)

--- a/BookPlayer/Library/ItemList Screen/Models/ImportableItem.swift
+++ b/BookPlayer/Library/ItemList Screen/Models/ImportableItem.swift
@@ -16,7 +16,7 @@ final public class ImportableItem: NSObject, NSItemProviderReading {
   let typeIdentifier: String
   var suggestedName: String?
 
-  var fileExtension: String {
+  var suggestedFileExtension: String {
     switch self.typeIdentifier {
     case "public.audio":
       return "mp3"


### PR DESCRIPTION
## Bugfix

When dropping .m4b files, the identifier returned is `public.audio` which is too general. In these cases the `suggestedName` from the provider already has the extension

## Approach

- Rename `fileExtension` to `suggestedFileExtension` to make it clear that it's not an exact match
- Use `suggestedFileExtension` only if the `suggestedName` of the provider does not include a file extension

## Things to be aware of / Things to focus on

- This bug only affects items that are imported via drag and drop interaction

## Screenshots

| Before  | After |
| ------------- | ------------- |
| <img width="350" alt="Screenshot 2023-09-02 at 12 25 41" src="https://github.com/TortugaPower/BookPlayer/assets/14112819/30763c9f-1183-4461-bfd3-7bdf8c9a6d02">  | <img width="559" alt="Screenshot 2023-09-02 at 12 36 26" src="https://github.com/TortugaPower/BookPlayer/assets/14112819/7b8b8fda-13d0-43a1-8c4a-a744eb592312">  |



