### PR TITLE
Add performance tests and optimize folder progress calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Resolve dependencies
       run: xcodebuild -resolvePackageDependencies
     - name: Build and Run tests
-      run: xcodebuild test -project BookPlayer.xcodeproj -scheme BookPlayer -destination 'platform=iOS Simulator,name=iPhone 13,OS=16.2'
+      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 13,OS=16.2'
 

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -972,6 +972,8 @@
 		62CADB8D2724E41800A4A98F /* Audiobook Player 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 7.xcdatamodel"; sourceTree = "<group>"; };
 		62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportableItem.swift; sourceTree = "<group>"; };
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
+		63833DF62AAC127900496246 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
+		63833DF72AAC12AB00496246 /* Performance Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Performance Tests.xctestplan"; sourceTree = "<group>"; };
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
@@ -1516,6 +1518,8 @@
 		418B6D111D2707F800F974FB /* BookPlayerTests */ = {
 			isa = PBXGroup;
 			children = (
+				63833DF62AAC127900496246 /* Unit Tests.xctestplan */,
+				63833DF72AAC12AB00496246 /* Performance Tests.xctestplan */,
 				62AAE22827492D6E001EB9FF /* Mocks */,
 				6906A551217211A300A9E0B2 /* Support */,
 				69343D34213A079B000C425E /* Services */,

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		62F2F25F25E18C7500E1D6A0 /* ImportableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */; };
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
+		63833DFA2AAC139700496246 /* PlaybackPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */; };
 		6399F94D2AA03C6C00A5C8EA /* BPSKANManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
@@ -974,6 +975,7 @@
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
 		63833DF62AAC127900496246 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
 		63833DF72AAC12AB00496246 /* Performance Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Performance Tests.xctestplan"; sourceTree = "<group>"; };
+		63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackPerformanceTests.swift; sourceTree = "<group>"; };
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
@@ -1523,6 +1525,7 @@
 				62AAE22827492D6E001EB9FF /* Mocks */,
 				6906A551217211A300A9E0B2 /* Support */,
 				69343D34213A079B000C425E /* Services */,
+				63833DF82AAC134600496246 /* PerformanceTests */,
 				4163E312214AC43000072AA2 /* ImportOperationTests.swift */,
 				41C3CF7D20AEA5E5007C3EF4 /* DataManagerTests.swift */,
 				41C2340B27324AB7006BC7B8 /* ItemListViewModelTests.swift */,
@@ -1883,6 +1886,14 @@
 				9FD8FE4C286566FF00EB2C3D /* Sync */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		63833DF82AAC134600496246 /* PerformanceTests */ = {
+			isa = PBXGroup;
+			children = (
+				63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */,
+			);
+			path = PerformanceTests;
 			sourceTree = "<group>";
 		};
 		6906A551217211A300A9E0B2 /* Support */ = {
@@ -3215,6 +3226,7 @@
 				9FC1E4772815F97E00522FA8 /* KeychainServiceTests.swift in Sources */,
 				4137BBD0272DEBEC009ED9FE /* LoadingCoordinatorTests.swift in Sources */,
 				41A1B13E226FEF8000EA0400 /* DataTestUtils.swift in Sources */,
+				63833DFA2AAC139700496246 /* PlaybackPerformanceTests.swift in Sources */,
 				9FC1E46928150ECC00522FA8 /* NetworkClientMock.swift in Sources */,
 				9F8A9A5E27AC3F8C0093AA1C /* PlayableItemTests.swift in Sources */,
 				4163E313214AC43000072AA2 /* ImportOperationTests.swift in Sources */,

--- a/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/569EBE30-A588-4C2D-B488-0BCBB3E48052.plist
+++ b/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/569EBE30-A588-4C2D-B488-0BCBB3E48052.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>PlaybackPerformanceTests</key>
+		<dict>
+			<key>testFolderProgressUpdatePerformance()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>14410.009000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>61936.716400</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_CPU.time</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.004600</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/569EBE30-A588-4C2D-B488-0BCBB3E48052.plist
+++ b/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/569EBE30-A588-4C2D-B488-0BCBB3E48052.plist
@@ -11,21 +11,21 @@
 				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>14410.009000</real>
+					<real>7790.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.instructions_retired</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>61936.716400</real>
+					<real>28900.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
 				<key>com.apple.dt.XCTMetric_CPU.time</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.004600</real>
+					<real>0.002350</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/Info.plist
+++ b/BookPlayer.xcodeproj/xcshareddata/xcbaselines/418B6D0D1D2707F800F974FB.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>569EBE30-A588-4C2D-B488-0BCBB3E48052</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M2 Max</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>modelCode</key>
+				<string>Mac14,5</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>12</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone15,2</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayer.xcscheme
+++ b/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayer.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -54,6 +54,15 @@
             ReferencedContainer = "container:BookPlayer.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:BookPlayerTests/Unit Tests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:BookPlayerTests/Performance Tests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/BookPlayerTests/Performance Tests.xctestplan
+++ b/BookPlayerTests/Performance Tests.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "B16A6052-5C30-42F6-9BC2-DE02B53CE677",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "VoiceOverServiceTest\/testForwardText()",
+        "VoiceOverServiceTest\/testRewindText()"
+      ],
+      "target" : {
+        "containerPath" : "container:BookPlayer.xcodeproj",
+        "identifier" : "418B6D0D1D2707F800F974FB",
+        "name" : "BookPlayerTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/BookPlayerTests/Performance Tests.xctestplan
+++ b/BookPlayerTests/Performance Tests.xctestplan
@@ -9,13 +9,18 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:BookPlayer.xcodeproj",
+      "identifier" : "418B6CF71D2707F800F974FB",
+      "name" : "BookPlayer"
+    }
   },
   "testTargets" : [
     {
       "selectedTests" : [
-        "VoiceOverServiceTest\/testForwardText()",
-        "VoiceOverServiceTest\/testRewindText()"
+        "PlaybackPerformanceTests\/testExample()",
+        "PlaybackPerformanceTests\/testPerformanceExample()"
       ],
       "target" : {
         "containerPath" : "container:BookPlayer.xcodeproj",

--- a/BookPlayerTests/PerformanceTests/PlaybackPerformanceTests.swift
+++ b/BookPlayerTests/PerformanceTests/PlaybackPerformanceTests.swift
@@ -1,0 +1,39 @@
+//
+//  PlaybackPerformanceTests.swift
+//  BookPlayerTests
+//
+//  Created by Gianni Carlo on 8/9/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import XCTest
+
+final class PlaybackPerformanceTests: XCTestCase {
+
+  var sut: LibraryService!
+
+  override func setUpWithError() throws {
+    DataTestUtils.clearFolderContents(url: DataManager.getProcessedFolderURL())
+    let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: "/dev/null"))
+    self.sut = LibraryService(dataManager: dataManager)
+    _ = self.sut.getLibrary()
+  }
+
+  override func tearDownWithError() throws {
+    self.sut = nil
+  }
+
+  func testFolderProgressUpdatePerformance() throws {
+    /// Setup a test folder with 3000 ibooks inside it
+    let folder = try self.sut.createFolder(with: "test-folder", inside: nil)
+    let urls = Array(stride(from: 0, to: 3000, by: 1)).map({ URL(string: "test-book-\($0).mp3")! })
+    _ = self.sut.insertItems(from: urls, parentPath: folder.relativePath)
+
+    self.measure(metrics: [XCTCPUMetric()]) {
+      /// This is called by the `PlayerManager` when the currently playing book changes its progress percentage
+      self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+    }
+  }
+}

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1170,7 +1170,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(book.currentTime == 50)
   }
 
-  func testUpdatePlaybackTime() throws {
+  func testUpdateFolderProgress() throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,
       title: "test-book1",
@@ -1229,6 +1229,12 @@ class ModifyLibraryTests: LibraryServiceTests {
 
     self.sut.markAsFinished(flag: false, relativePath: book2.relativePath)
     book2.percentCompleted = .nan
+    self.sut.dataManager.saveContext()
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(folder.percentCompleted == 0)
+
+    book2.percentCompleted = .infinity
     self.sut.dataManager.saveContext()
     self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
 

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1170,6 +1170,71 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(book.currentTime == 50)
   }
 
+  func testUpdatePlaybackTime() throws {
+    let book = StubFactory.book(
+      dataManager: self.sut.dataManager,
+      title: "test-book1",
+      duration: 100
+    )
+    let book2 = StubFactory.book(
+      dataManager: self.sut.dataManager,
+      title: "test-book2",
+      duration: 100
+    )
+    let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
+    try self.sut.moveItems(
+      [book.relativePath, book2.relativePath],
+      inside: folder.relativePath
+    )
+
+    let now = Date()
+    self.sut.updatePlaybackTime(
+      relativePath: book.relativePath,
+      time: 50,
+      date: now,
+      scheduleSave: false
+    )
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(book.percentCompleted == 50)
+    XCTAssert(folder.percentCompleted == 25)
+
+    self.sut.updatePlaybackTime(
+      relativePath: book2.relativePath,
+      time: 50,
+      date: now,
+      scheduleSave: false
+    )
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(book2.percentCompleted == 50)
+    XCTAssert(folder.percentCompleted == 50)
+
+    self.sut.markAsFinished(flag: true, relativePath: book2.relativePath)
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(folder.percentCompleted == 75)
+
+    self.sut.markAsFinished(flag: true, relativePath: book.relativePath)
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(folder.percentCompleted == 100)
+
+    self.sut.markAsFinished(flag: false, relativePath: book.relativePath)
+    book.percentCompleted = .nan
+    self.sut.dataManager.saveContext()
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(folder.percentCompleted == 50)
+
+    self.sut.markAsFinished(flag: false, relativePath: book2.relativePath)
+    book2.percentCompleted = .nan
+    self.sut.dataManager.saveContext()
+    self.sut.recursiveFolderProgressUpdate(from: folder.relativePath)
+
+    XCTAssert(folder.percentCompleted == 0)
+  }
+
   func testGetItemSpeed() throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1170,6 +1170,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(book.currentTime == 50)
   }
 
+  // swiftlint:disable:next function_body_length
   func testUpdateFolderProgress() throws {
     let book = StubFactory.book(
       dataManager: self.sut.dataManager,

--- a/BookPlayerTests/Unit Tests.xctestplan
+++ b/BookPlayerTests/Unit Tests.xctestplan
@@ -32,6 +32,9 @@
   "testTargets" : [
     {
       "parallelizable" : true,
+      "skippedTests" : [
+        "PlaybackPerformanceTests"
+      ],
       "target" : {
         "containerPath" : "container:BookPlayer.xcodeproj",
         "identifier" : "418B6D0D1D2707F800F974FB",

--- a/BookPlayerTests/Unit Tests.xctestplan
+++ b/BookPlayerTests/Unit Tests.xctestplan
@@ -1,0 +1,43 @@
+{
+  "configurations" : [
+    {
+      "id" : "CB210662-C4F6-4F8C-8B04-93C66DF8C8C4",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:BookPlayer.xcodeproj",
+          "identifier" : "418B6CF71D2707F800F974FB",
+          "name" : "BookPlayer"
+        },
+        {
+          "containerPath" : "container:BookPlayer.xcodeproj",
+          "identifier" : "41A1B0D1226E9BC400EA0400",
+          "name" : "BookPlayerKit"
+        }
+      ]
+    },
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:BookPlayer.xcodeproj",
+      "identifier" : "418B6CF71D2707F800F974FB",
+      "name" : "BookPlayer"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BookPlayer.xcodeproj",
+        "identifier" : "418B6D0D1D2707F800F974FB",
+        "name" : "BookPlayerTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1211,9 +1211,14 @@ extension LibraryService {
     guard
       let results = try? self.dataManager.getContext().fetch(fetchRequest).first as? [String: Any],
       let fetchedCount = results["totalCount"] as? Int,
-      let fetchedSum = results["totalSum"] as? Double
+      var fetchedSum = results["totalSum"] as? Double
     else {
       return (0, 0)
+    }
+
+    /// Catch edge case and default to 0
+    if fetchedSum == .infinity {
+      fetchedSum = 0
     }
 
     let totalCount = getMaxItemsCount(at: relativePath)

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1183,33 +1183,43 @@ extension LibraryService {
 
   /// Internal function to calculate the entire folder's progress
   func calculateFolderProgress(at relativePath: String) -> (Double, Int) {
-    let progressExpression = NSExpressionDescription()
-    progressExpression.expression = NSExpression(
-      forConditional: NSPredicate(format: "%K == 1", #keyPath(LibraryItem.isFinished)),
-      trueExpression: NSExpression(forConstantValue: 100.0),
-      falseExpression: NSExpression(forKeyPath: #keyPath(LibraryItem.percentCompleted))
-    )
-    progressExpression.name = "parsedPercentCompleted"
-    progressExpression.expressionResultType = NSAttributeType.doubleAttributeType
+    let countExpression = NSExpressionDescription()
+    countExpression.expression = NSExpression(forFunction: "count:", arguments: [
+      NSExpression(forKeyPath: #keyPath(LibraryItem.relativePath))
+    ])
+    countExpression.name = "totalCount"
+    /// Largest 16-bit integer 65535
+    countExpression.expressionResultType = .integer16AttributeType
+
+    let sumExpression = NSExpressionDescription()
+    sumExpression.expression = NSExpression(forFunction: "sum:", arguments: [
+      NSExpression(forKeyPath: #keyPath(LibraryItem.percentCompleted))
+    ])
+    sumExpression.name = "totalSum"
+    sumExpression.expressionResultType = .doubleAttributeType
 
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-    fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.folder.relativePath), relativePath)
-    fetchRequest.propertiesToFetch = [progressExpression]
+    fetchRequest.predicate = NSPredicate(
+      format: "%K == %@ && %K != 1",
+      #keyPath(LibraryItem.folder.relativePath),
+      relativePath,
+      #keyPath(LibraryItem.isFinished)
+    )
+    fetchRequest.propertiesToFetch = [sumExpression, countExpression]
     fetchRequest.resultType = .dictionaryResultType
 
     guard
-      let results = try? self.dataManager.getContext().fetch(fetchRequest) as? [[String: Double]],
-      !results.isEmpty
+      let results = try? self.dataManager.getContext().fetch(fetchRequest).first as? [String: Any],
+      let fetchedCount = results["totalCount"] as? Int,
+      let fetchedSum = results["totalSum"] as? Double
     else {
       return (0, 0)
     }
 
-    let count = results.count
-    let totalProgress = results.reduce(into: Double(0)) { partialResult, dict in
-      partialResult += dict.values.first ?? 0
-    }
+    let totalCount = getMaxItemsCount(at: relativePath)
+    let totalProgress = fetchedSum + Double((totalCount - fetchedCount) * 100)
 
-    return (totalProgress / Double(count), count)
+    return (totalProgress / Double(totalCount), totalCount)
   }
 
   public func rebuildFolderDetails(_ relativePath: String) {


### PR DESCRIPTION
## Purpose

Recalculating the parent folder progress could be impacting battery life, specially on cases where one folder contains thousands of short files (and with increased playback speed it also makes the percentage need to be updated with more frequency)

## Related tasks

#1000 
#843 

## Approach

- Add performance tests for `calculateFolderProgress` and record baseline performance for CPU
- Rework `calculateFolderProgress` to fetch the sum of all unfinished books in the folder and the count of how many unfinished items were there. With the max items count of the folder, add the missing 100% progress of the finished items to get the accurate total progress
- Add unit tests to make sure .nan and .infinity are considered

## Things to be aware of / Things to focus on

The performance improvements are of around 50% across the three CPU metrics (when simulating a folder with 3000 books), but I'm not sure how much of that % translates to battery health

<img width="350" alt="Screenshot 2023-09-11 at 07 47 01" src="https://github.com/TortugaPower/BookPlayer/assets/14112819/b262e732-65a0-4a0b-b0aa-e29062f2f290">
