### PR TITLE
Fix updating the last played book info

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -74,8 +74,12 @@ class FolderListCoordinator: ItemListCoordinator {
 
   override func syncList() {
     Task { @MainActor in
-      _ = try await syncService.syncListContents(at: folderRelativePath)
-      reloadItemsWithPadding()
+      do {
+        _ = try await syncService.syncListContents(at: folderRelativePath)
+        reloadItemsWithPadding()
+      } catch {
+        Self.logger.trace("Sync contents error: \(error.localizedDescription)")
+      }
     }
   }
 }

--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -18,7 +18,7 @@ enum ItemListActionRoutes {
   case reloadItems(_ pageSizePadding: Int)
 }
 
-class ItemListCoordinator: Coordinator, AlertPresenter {
+class ItemListCoordinator: Coordinator, AlertPresenter, BPLogger {
   public var onAction: BPTransition<ItemListActionRoutes>?
   let playerManager: PlayerManagerProtocol
   let libraryService: LibraryServiceProtocol

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -10,7 +10,7 @@ import BookPlayerKit
 import Combine
 import UIKit
 
-class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegate, BPLogger {
+class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegate {
   weak var tabBarController: UITabBarController?
   let importManager: ImportManager
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -234,7 +234,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
         reloadLastBook(relativePath: relativePath)
       } catch BPSyncError.differentLastBook(let relativePath) {
         reloadItemsWithPadding()
-        refreshLastBook(relativePath: relativePath)
+        setSyncedLastPlayedItem(relativePath: relativePath)
       } catch {
         Self.logger.trace("Sync contents error: \(error.localizedDescription)")
       }
@@ -252,7 +252,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
     )
   }
 
-  func refreshLastBook(relativePath: String) {
+  func setSyncedLastPlayedItem(relativePath: String) {
     /// Only continue overriding local book if it's not currently playing
     guard playerManager.isPlaying == false else { return }
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -10,7 +10,7 @@ import BookPlayerKit
 import Combine
 import UIKit
 
-class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegate {
+class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegate, BPLogger {
   weak var tabBarController: UITabBarController?
   let importManager: ImportManager
 
@@ -211,77 +211,57 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
 
   override func syncList() {
     Task { @MainActor in
-      let lastPlayed: SyncableItem?
+      do {
+        let lastPlayed: SyncableItem?
 
-      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasScheduledLibraryContents) == true {
-        lastPlayed = try await syncService.syncListContents(at: nil)
-      } else {
-        lastPlayed = try await syncService.syncLibraryContents()
+        if UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasScheduledLibraryContents) == true {
+          lastPlayed = try await syncService.syncListContents(at: nil)
+        } else {
+          lastPlayed = try await syncService.syncLibraryContents()
 
-        UserDefaults.standard.set(
-          true,
-          forKey: Constants.UserDefaults.hasScheduledLibraryContents
-        )
-      }
+          UserDefaults.standard.set(
+            true,
+            forKey: Constants.UserDefaults.hasScheduledLibraryContents
+          )
+        }
 
-      reloadItemsWithPadding()
-      if let lastPlayed {
-        handleSyncedLastPlayed(item: lastPlayed)
-      }
-    }
-  }
-
-  func handleSyncedLastPlayed(item: SyncableItem) {
-    guard
-      let localLastItem = libraryService.getLibraryLastItem(),
-      let lastPlayDateTimestamp = item.lastPlayDateTimestamp
-    else {
-      setSyncedLastPlayedItem(relativePath: item.relativePath)
-      return
-    }
-
-    /// Check to update current time or not
-    if item.relativePath == localLastItem.relativePath {
-      /// Add a padding of 1 min to local time
-      if item.currentTime > (localLastItem.currentTime + 60) {
-        /// Continue playback after time sync
-        let wasPlaying = playerManager.isPlaying
-        playerManager.stop()
-        libraryService.updatePlaybackTime(
-          relativePath: item.relativePath,
-          time: item.currentTime,
-          date: Date(timeIntervalSince1970: lastPlayDateTimestamp),
-          scheduleSave: false
-        )
-        AppDelegate.shared?.loadPlayer(
-          item.relativePath,
-          autoplay: wasPlaying,
-          showPlayer: nil,
-          alertPresenter: self
-        )
-      }
-    } else {
-      /// Only continue overriding local book if it's not currently playing
-      guard playerManager.isPlaying == false else { return }
-
-      if let lastPlayDateTimestamp = item.lastPlayDateTimestamp,
-         let localLastPlayDateTimestamp = localLastItem.lastPlayDate?.timeIntervalSince1970,
-         lastPlayDateTimestamp > localLastPlayDateTimestamp {
-        setSyncedLastPlayedItem(relativePath: item.relativePath)
+        reloadItemsWithPadding()
+        if let lastPlayed {
+          reloadLastBook(relativePath: lastPlayed.relativePath)
+        }
+      } catch BPSyncError.reloadLastBook(let relativePath) {
+        reloadItemsWithPadding()
+        reloadLastBook(relativePath: relativePath)
+      } catch BPSyncError.differentLastBook(let relativePath) {
+        reloadItemsWithPadding()
+        refreshLastBook(relativePath: relativePath)
+      } catch {
+        Self.logger.trace("Sync contents error: \(error.localizedDescription)")
       }
     }
   }
 
-  func setSyncedLastPlayedItem(relativePath: String?) {
+  func reloadLastBook(relativePath: String) {
+    let wasPlaying = playerManager.isPlaying
+    playerManager.stop()
+    AppDelegate.shared?.loadPlayer(
+      relativePath,
+      autoplay: wasPlaying,
+      showPlayer: nil,
+      alertPresenter: self
+    )
+  }
+
+  func refreshLastBook(relativePath: String) {
+    /// Only continue overriding local book if it's not currently playing
+    guard playerManager.isPlaying == false else { return }
+
     libraryService.setLibraryLastBook(with: relativePath)
-
-    if let relativePath {
-      AppDelegate.shared?.loadPlayer(
-        relativePath,
-        autoplay: false,
-        showPlayer: nil,
-        alertPresenter: self
-      )
-    }
+    AppDelegate.shared?.loadPlayer(
+      relativePath,
+      autoplay: false,
+      showPlayer: nil,
+      alertPresenter: self
+    )
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -468,15 +468,19 @@ extension LibraryService {
   }
 
   public func setLibraryLastBook(with relativePath: String?) {
-    let library = self.getLibraryReference()
+    setLibraryLastBook(with: relativePath, context: dataManager.getContext())
+  }
+
+  func setLibraryLastBook(with relativePath: String?, context: NSManagedObjectContext) {
+    let library = getLibraryReference(context: context)
 
     if let relativePath = relativePath {
-      library.lastPlayedItem = getItemReference(with: relativePath)
+      library.lastPlayedItem = getItemReference(with: relativePath, context: context)
     } else {
       library.lastPlayedItem = nil
     }
 
-    self.dataManager.saveContext()
+    dataManager.saveSyncContext(context)
   }
 
   @discardableResult

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -137,7 +137,6 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
     /// Do not sync if one minute hasn't passed since last sync
     guard now - lastSync > 60 else {
-      Self.logger.trace("Throttled sync operation")
       throw BookPlayerError.networkError("Throttled sync operation")
     }
 


### PR DESCRIPTION
## Bugfix

The last played item is not getting updated correctly

## Related tasks

#1009

## Approach

- Move logic that decides when to update the `currentTime` from `LibraryListCoordinator` to `SyncService`
  - Throw errors when the app needs to handle reloading the book for different scenarios
- Remove `updateLastPlayedInfo` in favor of new `updateInfo` for single items


## Things to be aware of / Things to focus on

- There are still edge cases, where the fetch request won't execute if the last request was made less than a minute ago
