### PR TITLE
Add context to thrown errors in Player and Import

### DIFF
--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -228,7 +228,7 @@ public class ImportOperation: Operation {
 
       destinationURL.disableFileProtection()
     } catch {
-      fatalError("Fail to move file from \(currentFile) to \(destinationURL)")
+      fatalError("Fail to move file from \(currentFile) to \(destinationURL). Error: \(error.localizedDescription)")
     }
 
     self.processedFiles.append(destinationURL)

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -291,7 +291,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
         self.playbackQueued = nil
         self.isFetchingRemoteURL = nil
         self.observeStatus = false
-        self.showErrorAlert(error.localizedDescription)
+        self.showErrorAlert(title: "\("error_title".localized) Metadata", error.localizedDescription)
         return
       }
     }
@@ -742,7 +742,7 @@ extension PlayerManager {
         } else {
           playbackQueued = nil
           observeStatus = false
-          showErrorAlert(item.error?.localizedDescription)
+          showErrorAlert(title: "\("error_title".localized) AVPlayerItem", item.error?.localizedDescription)
         }
       }
       return
@@ -1006,12 +1006,12 @@ extension PlayerManager {
 }
 
 extension PlayerManager {
-  private func showErrorAlert(_ message: String?) {
+  private func showErrorAlert(title: String, _ message: String?) {
     DispatchQueue.main.async {
       AppDelegate.shared?.activeSceneDelegate?
         .startingNavigationController
         .getTopVisibleViewController()?
-        .showAlert("error_title".localized, message: message)
+        .showAlert(title, message: message)
     }
   }
 }


### PR DESCRIPTION
## Purpose

- Add context to the error title for Player-related thrown errors (shown to the user)
- Include localized description for import operation errors (crash report)