### PR TITLE
Add original filename to item details

### DIFF
--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -168,9 +168,7 @@ extension ItemListCoordinator {
       vc.dismiss(animated: true)
     }
 
-    if UIAccessibility.isVoiceOverRunning {
-      vc.navigationItem.largeTitleDisplayMode = .never
-    }
+    vc.navigationItem.largeTitleDisplayMode = .never
     let nav = AppNavigationController.instantiate(from: .Main)
     nav.viewControllers = [vc]
 

--- a/BookPlayer/Library/ItemDetails Screen/ItemDetailsFormViewModel.swift
+++ b/BookPlayer/Library/ItemDetails Screen/ItemDetailsFormViewModel.swift
@@ -12,6 +12,8 @@ import Foundation
 import UIKit
 
 class ItemDetailsFormViewModel: ObservableObject {
+  /// File name
+  @Published var originalFileName: String
   /// Title of the item
   @Published var title: String
   /// Author of the item (only applies for books)
@@ -35,6 +37,7 @@ class ItemDetailsFormViewModel: ObservableObject {
     self.titlePlaceholder = item.title
     self.author = item.details
     self.authorPlaceholder = item.details
+    self.originalFileName = item.originalFileName
     self.showAuthor = item.type == .book
     self.originalImageDataProvider = ArtworkService.getArtworkProvider(for: item.relativePath)
     let cachedImageURL = ArtworkService.getCachedImageURL(for: item.relativePath)

--- a/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
+++ b/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
@@ -62,6 +62,14 @@ struct ItemDetailsForm: View {
           ]
         )
       }
+
+      Section {
+        EmptyView()
+      } footer: {
+        Text(viewModel.originalFileName)
+          .font(Font(Fonts.body))
+          .foregroundColor(themeViewModel.secondaryColor)
+      }
     }
     .onChange(of: viewModel.selectedImage, perform: { _ in
       viewModel.artworkIsUpdated = true
@@ -96,7 +104,7 @@ struct ItemDetailsForm_Previews: PreviewProvider {
           artworkURL: nil,
           orderRank: 0,
           parentFolder: nil,
-          originalFileName: "",
+          originalFileName: "this is a test filename.mp3",
           lastPlayDate: nil,
           type: .book
         )


### PR DESCRIPTION
## Purpose

Add the filename used for the item in the details screen

## Approach

- Update `ItemDetailsFormViewModel` with the new field
- Add an empty section in `ItemDetailsForm` to set the original filename

## Screenshots

![Simulator Screenshot - iPhone 15 - 2023-10-10 at 08 15 21](https://github.com/TortugaPower/BookPlayer/assets/14112819/3013cfbe-e91b-4338-8b02-dd7d1156bfba)

