### PR TITLE
Rework downloading synced folders

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,3 +18,4 @@ disabled_rules:
   - type_body_length
   - file_length
   - orphaned_doc_comment
+  - large_tuple

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -306,11 +306,17 @@
 		631C75C72AB92BE20013E7E5 /* BPCoordinatorPresentationFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C75C62AB92BE20013E7E5 /* BPCoordinatorPresentationFlow.swift */; };
 		631C75C92AB92C540013E7E5 /* BPPushPresentationFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C75C82AB92C540013E7E5 /* BPPushPresentationFlow.swift */; };
 		631C75CC2AB92FA60013E7E5 /* BPModalPresentationFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631C75CB2AB92FA60013E7E5 /* BPModalPresentationFlow.swift */; };
+		6327E0C62ADB9913004780DC /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA429A281140021663B /* DownloadState.swift */; };
+		6327E0C72ADB9914004780DC /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA429A281140021663B /* DownloadState.swift */; };
 		63432B592AC1E6F7002619D0 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63432B582AC1E6F7002619D0 /* MockNavigationController.swift */; };
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		63833DFA2AAC139700496246 /* PlaybackPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */; };
 		6399F94D2AA03C6C00A5C8EA /* BPSKANManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */; };
+		639AC9892AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
+		639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
+		639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
+		639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
@@ -444,8 +450,6 @@
 		9FACAC6A2970F2F500D01EB7 /* SyncableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBDBC782879409600D315A2 /* SyncableItem.swift */; };
 		9FAFC9F42995BB5C00FD531E /* RemoteFileURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FAFC9F32995BB5C00FD531E /* RemoteFileURLResponse.swift */; };
 		9FAFC9F52995BB5C00FD531E /* RemoteFileURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FAFC9F32995BB5C00FD531E /* RemoteFileURLResponse.swift */; };
-		9FB20EA329A1BB750021663B /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
-		9FB20EA529A281140021663B /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA429A281140021663B /* DownloadState.swift */; };
 		9FB20EB729A423410021663B /* InterfaceUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EB629A423410021663B /* InterfaceUpdater.swift */; };
 		9FB20EB929A479FB0021663B /* BPAlertContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EB829A479FB0021663B /* BPAlertContent.swift */; };
 		9FB7C48D2835A2C1003B917E /* PlayerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB7C48C2835A2C1003B917E /* PlayerManagerTests.swift */; };
@@ -980,6 +984,7 @@
 		63833DF72AAC12AB00496246 /* Performance Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Performance Tests.xctestplan"; sourceTree = "<group>"; };
 		63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackPerformanceTests.swift; sourceTree = "<group>"; };
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
+		639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPDownloadURLSession.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
 		69343D322133844D000C425E /* VoiceOverService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverService.swift; sourceTree = "<group>"; };
@@ -1297,7 +1302,6 @@
 				C3D3852E20C1F10F00A0ACC7 /* Views */,
 				41188D2726ED4D5C0017124E /* ItemListViewController.swift */,
 				41188D2926ED4D8E0017124E /* ItemListViewModel.swift */,
-				9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */,
 			);
 			path = "ItemList Screen";
 			sourceTree = "<group>";
@@ -1306,7 +1310,6 @@
 			isa = PBXGroup;
 			children = (
 				62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */,
-				9FB20EA429A281140021663B /* DownloadState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1803,6 +1806,7 @@
 		62793619272CD9800097837D /* Lightweight-Models */ = {
 			isa = PBXGroup;
 			children = (
+				9FB20EA429A281140021663B /* DownloadState.swift */,
 				41188D3026ED715D0017124E /* SimpleLibraryItem.swift */,
 				9FFCC08E289418CA00F4952E /* SimpleChapter.swift */,
 				41546FF226F559CE00825180 /* SimpleItemType.swift */,
@@ -2171,9 +2175,11 @@
 		9FC1E4572814E09700522FA8 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */,
 				9F07B79629B7706B005A939D /* BPTaskUploadDelegate.swift */,
 				9FC1E4492814C4DE00522FA8 /* NetworkClient.swift */,
 				6357F1182A8BA084007947FC /* BPURLSession.swift */,
+				639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */,
 				9FC1E45B2814E6A500522FA8 /* NetworkProvider.swift */,
 				9FC1E4582814E0B000522FA8 /* NetworkUtils.swift */,
 			);
@@ -2939,6 +2945,7 @@
 				9F7B64782803B0B000895ECC /* AccountService.swift in Sources */,
 				4140EA78227289BC0009F794 /* PlaybackRecord+CoreDataClass.swift in Sources */,
 				4140EA79227289BF0009F794 /* PlaybackRecord+CoreDataProperties.swift in Sources */,
+				639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */,
 				9F07B72629B512F1005A939D /* LibraryItemSyncJob.swift in Sources */,
 				41A90C4927564DAA00C30394 /* BookPlayerError.swift in Sources */,
 				41C23402272E1960006BC7B8 /* SimpleTheme.swift in Sources */,
@@ -2986,6 +2993,7 @@
 				4124AB1825DFE07E0007C839 /* DataMigrationManager.swift in Sources */,
 				41C3394A25E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */,
 				9F56C84E287B734C00EA9751 /* BPLogger.swift in Sources */,
+				6327E0C72ADB9914004780DC /* DownloadState.swift in Sources */,
 				9FF710C12A215B90006490E0 /* QueuedJobInfo.swift in Sources */,
 				418CABB525EF28FC00D8C878 /* MappingModel_v3_to_v4.xcmappingmodel in Sources */,
 				9F9F3B71280E4E4B004359DA /* SyncService.swift in Sources */,
@@ -2993,6 +3001,7 @@
 				9F7B64722803216100895ECC /* Account+CoreDataProperties.swift in Sources */,
 				9F7B64752803217400895ECC /* Account+CoreDataClass.swift in Sources */,
 				9FBF33ED29F6293C00501639 /* SimpleBookmark.swift in Sources */,
+				639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */,
 				4140EA75227289B20009F794 /* Theme+CoreDataProperties.swift in Sources */,
 				9FBDBC812879C6C900D315A2 /* UploadItemResponse.swift in Sources */,
 				41A90C4627563F5A00C30394 /* ItemType.swift in Sources */,
@@ -3162,7 +3171,6 @@
 				C3FE94792080086800BCEA37 /* BookCellView.swift in Sources */,
 				9F5F13682978D9E100F061A0 /* ProfileSyncTasksStatusView.swift in Sources */,
 				41AD3DA7221C850F00DC41E1 /* IconCellView.swift in Sources */,
-				9FB20EA529A281140021663B /* DownloadState.swift in Sources */,
 				9FF710B92A213084006490E0 /* QueuedSyncTaskRowView.swift in Sources */,
 				9FAB93742A53117C005B92B2 /* CompleteAccountView.swift in Sources */,
 				4158388326EBD76A00F4A12B /* LibraryListCoordinator.swift in Sources */,
@@ -3179,7 +3187,6 @@
 				9FE86B8E2A544CB200B5450E /* Binding+BookPlayer.swift in Sources */,
 				41A1B12E226FC7E500EA0400 /* ImportOperation.swift in Sources */,
 				5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
-				9FB20EA329A1BB750021663B /* BPTaskDownloadDelegate.swift in Sources */,
 				9F5F13462977A06300F061A0 /* ProfileCardView.swift in Sources */,
 				410D0FED1EDCF4B000A52EB9 /* SettingsViewController.swift in Sources */,
 				9F2DA27F27F0C68D00C8EF2B /* CarPlaySceneDelegate.swift in Sources */,
@@ -3256,12 +3263,14 @@
 				4138CE1626E584B60014F11E /* BookmarkType.swift in Sources */,
 				412AB7092701421600969618 /* ManualOrderMigrationUtils.swift in Sources */,
 				9F1345B82938DF360089B1DE /* UIFont+BookPlayer.swift in Sources */,
+				639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */,
 				9FFCC08F289418CA00F4952E /* SimpleChapter.swift in Sources */,
 				416AAC3423F515AF005AD04F /* String+BookPlayer.swift in Sources */,
 				9FBDBC792879409600D315A2 /* SyncableItem.swift in Sources */,
 				62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */,
 				9F2DC9E52A014BB5006CDF1F /* PricingModel.swift in Sources */,
 				41A1B126226F88C500EA0400 /* LibraryItem+CoreDataProperties.swift in Sources */,
+				6327E0C62ADB9913004780DC /* DownloadState.swift in Sources */,
 				62CADBAB2725C23A00A4A98F /* ArtworkService.swift in Sources */,
 				9F7B64772803B0B000895ECC /* AccountService.swift in Sources */,
 				41A1B128226F88C500EA0400 /* Library+CoreDataProperties.swift in Sources */,
@@ -3321,6 +3330,7 @@
 				9F9F3B70280E4E4B004359DA /* SyncService.swift in Sources */,
 				41A1B104226E9DBA00EA0400 /* UIColor+BookPlayer.swift in Sources */,
 				9F7B64712803216100895ECC /* Account+CoreDataProperties.swift in Sources */,
+				639AC9892AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */,
 				9F7B64742803217400895ECC /* Account+CoreDataClass.swift in Sources */,
 				9FBDBC802879C6C900D315A2 /* UploadItemResponse.swift in Sources */,
 				41A1B11D226F88C500EA0400 /* Theme+CoreDataClass.swift in Sources */,

--- a/BookPlayerTests/Mocks/NetworkClientMock.swift
+++ b/BookPlayerTests/Mocks/NetworkClientMock.swift
@@ -56,11 +56,9 @@ class NetworkClientMock: NetworkClientProtocol {
     return (Data(), URLResponse())
   }
 
-  func download(
-    url: URL,
-    taskDescription: String?,
-    delegate: URLSessionTaskDelegate
-  ) -> URLSessionDownloadTask {
+  func download(url: URL, delegate: BPTaskDownloadDelegate) {}
+
+  func download(url: URL, taskDescription: String?, session: URLSession) async -> URLSessionTask {
     return URLSession.shared.downloadTask(with: URLRequest(url: URL(string: "https://google.com")!))
   }
 }

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -89,6 +89,21 @@ public class DataManager {
     return absoluteUrl.contains(processedFolderUrl)
   }
 
+  /// Create the parent folder (and intermediates) for a file URL if necessary
+  public class func createContainingFolderIfNeeded(for url: URL) throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+
+    let containingFolder = url.deletingLastPathComponent()
+
+    guard 
+      processedFolder != containingFolder,
+      !FileManager.default.fileExists(atPath: containingFolder.path)
+    else { return }
+
+    try FileManager.default.createDirectory(at: containingFolder, withIntermediateDirectories: true)
+  }
+
+  /// Create the folder on disk if needed for the passed URL
   public class func createBackingFolderIfNeeded(_ url: URL) throws {
     if !FileManager.default.fileExists(atPath: url.path) {
       try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -89,6 +89,12 @@ public class DataManager {
     return absoluteUrl.contains(processedFolderUrl)
   }
 
+  public class func createBackingFolderIfNeeded(_ url: URL) throws {
+    if !FileManager.default.fileExists(atPath: url.path) {
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+  }
+
   public func getContext() -> NSManagedObjectContext {
     return self.coreDataStack.managedContext
   }

--- a/Shared/CoreData/Lightweight-Models/DownloadState.swift
+++ b/Shared/CoreData/Lightweight-Models/DownloadState.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum DownloadState: Hashable {
+public enum DownloadState: Hashable {
   /// The asset is not downloaded.
   case notDownloaded
   /// The asset has a download in progress.
@@ -16,7 +16,7 @@ enum DownloadState: Hashable {
   /// The asset is downloaded and saved on disk.
   case downloaded
 
-  func hash(into hasher: inout Hasher) {
+  public func hash(into hasher: inout Hasher) {
     // Custom implementation of hashable protocol to ignore the
     // associated values when computing a hash value
     switch self {
@@ -29,7 +29,7 @@ enum DownloadState: Hashable {
     }
   }
 
-  static func == (lhs: DownloadState, rhs: DownloadState) -> Bool {
+  public static func == (lhs: DownloadState, rhs: DownloadState) -> Bool {
     // Custom implementation of Equatable protocol to ignore the
     // associated values when comparing values
     switch (lhs, rhs) {

--- a/Shared/Network/BPDownloadURLSession.swift
+++ b/Shared/Network/BPDownloadURLSession.swift
@@ -1,0 +1,39 @@
+//
+//  BPDownloadURLSession.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 13/10/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+/// URL session meant for download tasks
+public class BPDownloadURLSession {
+  public let backgroundSession: URLSession
+
+  /// Initializer
+  /// - Parameters:
+  ///   - downloadProgressUpdated: Callback triggered when there's an update on the download progress
+  ///   - didFinishDownloadingTask: Callback triggered when the download task is finished
+  public init(
+    downloadProgressUpdated: @escaping ((URLSessionDownloadTask, Double) -> Void),
+    didFinishDownloadingTask: @escaping ((URLSessionDownloadTask, URL) -> Void)
+  ) {
+    let bundleIdentifier: String = Bundle.main.configurationValue(for: .bundleIdentifier)
+
+    let delegate = BPTaskDownloadDelegate()
+    
+    delegate.downloadProgressUpdated = downloadProgressUpdated
+    delegate.didFinishDownloadingTask = didFinishDownloadingTask
+
+    self.backgroundSession = URLSession(
+      configuration: URLSessionConfiguration.background(
+        withIdentifier: "\(bundleIdentifier).background.download"
+      ),
+      delegate: delegate,
+      delegateQueue: OperationQueue()
+    )
+  }
+}

--- a/Shared/Network/BPTaskDownloadDelegate.swift
+++ b/Shared/Network/BPTaskDownloadDelegate.swift
@@ -8,25 +8,30 @@
 
 import Foundation
 
-class BPTaskDownloadDelegate: NSObject, URLSessionDownloadDelegate {
+public class BPTaskDownloadDelegate: NSObject, URLSessionDownloadDelegate {
   /// Callback triggered when the download task is finished
-  var didFinishDownloadingTask: ((URLSessionDownloadTask, URL) -> Void)?
+  public var didFinishDownloadingTask: ((URLSessionDownloadTask, URL) -> Void)?
   /// Callback triggered when the download task fails
   /// - Note: the Error parameter represents client side errors
-  var didFinishTaskWithError: ((URLSessionTask, Error?) -> Void)?
+  public var didFinishTaskWithError: ((URLSessionTask, Error?) -> Void)?
   /// Callback triggered when there's an update on the download progress
-  var downloadProgressUpdated: ((URLSessionDownloadTask, Double) -> Void)?
-
-  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+  public var downloadProgressUpdated: ((URLSessionDownloadTask, Double) -> Void)?
+  /// Delegate callback when download finishes
+  public func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didFinishDownloadingTo location: URL
+  ) {
     didFinishDownloadingTask?(downloadTask, location)
   }
 
   /// Note: this gets called even if there's no error
-  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+  public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     didFinishTaskWithError?(task, error)
   }
 
-  func urlSession(
+  /// Delegate callback when there's a progress update for the ongoing download
+  public func urlSession(
     _ session: URLSession,
     downloadTask: URLSessionDownloadTask,
     didWriteData bytesWritten: Int64,

--- a/Shared/Network/BPURLSession.swift
+++ b/Shared/Network/BPURLSession.swift
@@ -9,6 +9,7 @@
 import Combine
 import Foundation
 
+/// URL session meant for upload tasks
 class BPURLSession {
   static let shared = BPURLSession()
 

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Tortuga Power. All rights reserved.
 //
 
+import AVFoundation
 import CoreData
 import Foundation
 import Combine
@@ -31,6 +32,8 @@ public protocol LibrarySyncProtocol {
   func setLibraryLastBook(with relativePath: String?) async
   /// Returns boolean determining if the item exists for the relativePath
   func itemExists(for relativePath: String) async -> Bool
+  /// Load encoded chapters from file into DB
+  func loadChaptersIfNeeded(relativePath: String)
 
   /// Fetch all items and folders inside a given folder (Used for newly imported folders)
   func getAllNestedItems(inside relativePath: String) -> [SyncableItem]?
@@ -331,5 +334,11 @@ extension LibraryService: LibrarySyncProtocol {
     if !FileManager.default.fileExists(atPath: url.path) {
       try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     }
+  }
+
+  public func loadChaptersIfNeeded(relativePath: String) {
+    let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(relativePath)
+
+    loadChaptersIfNeeded(relativePath: relativePath, asset: AVAsset(url: fileURL))
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1194,6 +1194,12 @@ extension LibraryService {
 
   /// Internal function to calculate the entire folder's progress
   func calculateFolderProgress(at relativePath: String) -> (Double, Int) {
+    let totalCount = getMaxItemsCount(at: relativePath)
+
+    guard totalCount > 0 else {
+      return (0, 0)
+    }
+
     let countExpression = NSExpressionDescription()
     countExpression.expression = NSExpression(forFunction: "count:", arguments: [
       NSExpression(forKeyPath: #keyPath(LibraryItem.relativePath))
@@ -1232,7 +1238,6 @@ extension LibraryService {
       fetchedSum = 0
     }
 
-    let totalCount = getMaxItemsCount(at: relativePath)
     let totalProgress = fetchedSum + Double((totalCount - fetchedCount) * 100)
 
     return (totalProgress / Double(totalCount), totalCount)
@@ -1448,7 +1453,10 @@ extension LibraryService {
 
     item.currentTime = time
     item.lastPlayDate = date
-    let percentCompleted = round((item.currentTime / item.duration) * 100)
+    let progress = round((item.currentTime / item.duration) * 100)
+    let percentCompleted = (progress.isNaN || progress.isInfinite)
+    ? 0
+    : progress
     item.percentCompleted = percentCompleted
 
     if let parentFolderPath = item.folder?.relativePath {

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -562,8 +562,12 @@ extension LibraryService {
     let destinationUrl: URL
 
     if let parentPath {
-      destinationUrl = processedFolderURL
+      let parentURL = processedFolderURL
         .appendingPathComponent(parentPath)
+
+      try DataManager.createBackingFolderIfNeeded(parentURL)
+
+      destinationUrl = parentURL
         .appendingPathComponent(sourceUrl.lastPathComponent)
     } else {
       destinationUrl = processedFolderURL

--- a/Shared/Services/Sync/Model/RemoteFileURLResponse.swift
+++ b/Shared/Services/Sync/Model/RemoteFileURLResponse.swift
@@ -11,9 +11,10 @@ import Foundation
 public struct RemoteFileURL: Decodable {
   public let url: URL
   public let relativePath: String
+  public let type: SimpleItemType
 
   enum CodingKeys: CodingKey {
-    case url, relativePath
+    case url, relativePath, type
   }
 }
 

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -26,6 +26,10 @@ public protocol SyncServiceProtocol {
   var isActive: Bool { get set }
   /// Count of the currently queued sync jobs
   var queuedJobsCount: Int { get }
+  /// Completion publisher for ongoing-download tasks
+  var downloadCompletedPublisher: PassthroughSubject<(String, String, String?), Never> { get }
+  /// Progress publisher for ongoing-download tasks
+  var downloadProgressPublisher: PassthroughSubject<(String, String, String?, Double), Never> { get }
 
   /// Fetch the contents at the relativePath and override local contents with the remote repsonse
   func syncListContents(at relativePath: String?) async throws -> SyncableItem?
@@ -41,11 +45,7 @@ public protocol SyncServiceProtocol {
     type: SimpleItemType
   ) async throws -> [RemoteFileURL]
 
-  func downloadRemoteFiles(
-    for relativePath: String,
-    type: SimpleItemType,
-    delegate: URLSessionTaskDelegate
-  ) async throws -> [URLSessionDownloadTask]
+  func downloadRemoteFiles(for item: SimpleLibraryItem) async throws
 
   func scheduleUpload(items: [SimpleLibraryItem])
 
@@ -69,6 +69,11 @@ public protocol SyncServiceProtocol {
   func getAllQueuedJobs() -> [QueuedJobInfo]
   /// Cancel all scheduled jobs
   func cancelAllJobs()
+
+  /// Cancel ongoing downloads for an item
+  func cancelDownload(of item: SimpleLibraryItem) throws
+
+  func getDownloadState(for item: SimpleLibraryItem) -> DownloadState
 }
 
 public final class SyncService: SyncServiceProtocol, BPLogger {
@@ -78,6 +83,31 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   public var isActive: Bool
 
   public var queuedJobsCount: Int { jobManager.queuedJobsCount }
+
+  /// Dictionary holding the initiating item relative path as key and the download tasks as value
+  private lazy var downloadTasksDictionary = [String: [URLSessionTask]]()
+  /// Reference to the initiating item path for the download tasks (relevant for bound books)
+  private lazy var ongoingTasksParentReference = [String: String]()
+  /// Reference to the parent folder of the initiating item to pass on observer
+  private lazy var initiatingFolderReference = [String: String]()
+  /// Completion publisher for ongoing-download tasks
+  public var downloadCompletedPublisher = PassthroughSubject<(String, String, String?), Never>()
+  /// Progress publisher for ongoing-download tasks
+  public var downloadProgressPublisher = PassthroughSubject<(String, String, String?, Double), Never>()
+  /// Background URL session to handle downloading synced items
+  private lazy var downloadURLSession: BPDownloadURLSession = {
+    BPDownloadURLSession { task, progress in
+      self.handleDownloadProgressUpdated(
+        task: task,
+        individualProgress: progress
+      )
+    } didFinishDownloadingTask: { task, location in
+      self.handleFinishedDownload(
+        task: task,
+        location: location
+      )
+    }
+  }()
 
   private let provider: NetworkProvider<LibraryAPI>
 
@@ -292,12 +322,8 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     return response.content
   }
 
-  public func downloadRemoteFiles(
-    for relativePath: String,
-    type: SimpleItemType,
-    delegate: URLSessionTaskDelegate
-  ) async throws -> [URLSessionDownloadTask] {
-    let remoteURLs = try await getRemoteFileURLs(of: relativePath, type: type)
+  public func downloadRemoteFiles(for item: SimpleLibraryItem) async throws {
+    let remoteURLs = try await getRemoteFileURLs(of: item.relativePath, type: item.type)
 
     let folderURLs = remoteURLs.filter({ $0.type != .book })
 
@@ -313,19 +339,26 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
     let bookURLs = remoteURLs.filter({ $0.type == .book })
 
-    var tasks = [URLSessionDownloadTask]()
+    var tasks = [URLSessionTask]()
 
     for remoteURL in bookURLs {
-      let task = self.provider.client.download(
+      let task = await provider.client.download(
         url: remoteURL.url,
         taskDescription: remoteURL.relativePath,
-        delegate: delegate
+        session: downloadURLSession.backgroundSession
       )
 
       tasks.append(task)
     }
 
-    return tasks
+    downloadTasksDictionary[item.relativePath] = tasks
+    ongoingTasksParentReference = tasks.reduce(
+      into: ongoingTasksParentReference, {
+        $0[$1.taskDescription!] = item.relativePath
+      }
+    )
+    ongoingTasksParentReference.keys
+      .forEach({ initiatingFolderReference[$0] = item.parentFolder })
   }
 
   public func scheduleUploadArtwork(relativePath: String) {
@@ -451,5 +484,143 @@ extension SyncService {
     guard isActive else { return }
 
     jobManager.scheduleRenameFolderJob(with: relativePath, name: name)
+  }
+}
+
+extension SyncService {
+  private func handleFinishedDownload(task: URLSessionTask, location: URL) {
+    guard let relativePath = task.taskDescription else { return }
+
+    do {
+      let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(relativePath)
+
+      /// If there's already something there, replace with new finished download
+      if FileManager.default.fileExists(atPath: fileURL.path) {
+        try FileManager.default.removeItem(at: fileURL)
+      }
+      try DataManager.createContainingFolderIfNeeded(for: fileURL)
+      try FileManager.default.moveItem(at: location, to: fileURL)
+
+      DispatchQueue.main.async {
+        self.libraryService.loadChaptersIfNeeded(relativePath: relativePath)
+      }
+    } catch {
+      Self.logger.trace("Error moving downloaded file to the destination: \(error.localizedDescription)")
+    }
+
+    guard let startingItemPath = ongoingTasksParentReference[relativePath] else {
+      initiatingFolderReference[relativePath] = nil
+      return
+    }
+
+    let parentFolderPath = initiatingFolderReference[relativePath]
+
+    /// cleanup individual reference
+    if downloadTasksDictionary[startingItemPath]?
+      .filter({ $0 != task })
+      .allSatisfy({ $0.state == .completed }) == true {
+      downloadTasksDictionary[startingItemPath] = nil
+    }
+    ongoingTasksParentReference[relativePath] = nil
+    initiatingFolderReference[relativePath] = nil
+
+    DispatchQueue.main.async {
+      self.downloadCompletedPublisher.send((relativePath, startingItemPath, parentFolderPath))
+    }
+  }
+
+  public func cancelDownload(of item: SimpleLibraryItem) throws {
+    guard let tasks = downloadTasksDictionary[item.relativePath] else { return }
+
+    var hasCompletedTasks = false
+
+    for task in tasks {
+      guard task.state != .completed else {
+        hasCompletedTasks = true
+        continue
+      }
+
+      if let relativePath = task.taskDescription {
+        ongoingTasksParentReference[relativePath] = nil
+        initiatingFolderReference[relativePath] = nil
+      }
+
+      task.cancel()
+    }
+
+    /// Clean up bound downloads if at least one was finished
+    if item.type == .bound,
+       hasCompletedTasks {
+      let fileURL = item.fileURL
+      try FileManager.default.removeItem(at: fileURL)
+      try FileManager.default.createDirectory(
+        at: fileURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+    }
+
+    downloadTasksDictionary[item.relativePath] = nil
+  }
+
+  /// Handler called when the download has finished for a task
+  func handleDownloadProgressUpdated(task: URLSessionTask, individualProgress: Double) {
+    guard
+      let relativePath = task.taskDescription,
+      let initiatingItemRelativePath = ongoingTasksParentReference[relativePath]
+    else { return }
+
+    let progress: Double
+    /// For individual items, the `fractionCompleted` of the current task can be 0
+    let calculatedProgress = calculateDownloadProgress(with: initiatingItemRelativePath)
+    if calculatedProgress != 0 && calculatedProgress.isFinite {
+      progress = calculatedProgress
+    } else {
+      progress = individualProgress
+    }
+
+    let parentFolderPath = initiatingFolderReference[relativePath]
+    downloadProgressPublisher.send(
+      (relativePath, initiatingItemRelativePath, parentFolderPath, progress)
+    )
+  }
+
+  /// Calculate the overall download progress for an item (useful for bound books)
+  func calculateDownloadProgress(with relativePath: String) -> Double {
+    guard let tasks = downloadTasksDictionary[relativePath] else { return 1.0 }
+
+    let completedTasksCount = tasks.filter({ $0.state == .completed }).count
+    let runningTasksProgress = tasks.filter({ $0.state == .running })
+      .reduce(0.0, { $0 + $1.progress.fractionCompleted })
+
+    return (runningTasksProgress + Double(completedTasksCount)) / Double(tasks.count)
+  }
+
+  /// Get download state of an item
+  public func getDownloadState(for item: SimpleLibraryItem) -> DownloadState {
+    /// Only process if subscription is active
+    guard isActive else { return .downloaded }
+
+    if downloadTasksDictionary[item.relativePath]?.isEmpty == false {
+      return .downloading(progress: calculateDownloadProgress(with: item.relativePath))
+    }
+
+    let fileURL = item.fileURL
+
+    if (item.type == .bound || item.type == .folder),
+       let enumerator = FileManager.default.enumerator(
+        at: fileURL,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+       ),
+       enumerator.nextObject() == nil {
+      return .notDownloaded
+    }
+
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+      return .downloaded
+    }
+
+    return .notDownloaded
   }
 }


### PR DESCRIPTION
## Bugfix

- Removing and redownloading the folders from the device is prone to error

## Approach

- Recreate folders on disk after the user uses the option to 'Remove from device'
- Rework the background session for downloading synced items to just be one on the SyncService
- Move logic to keep track of downloading progress for sync items from the ItemListViewModel to the SyncService, as when dismissing a folder list, the reference to those tasks would be lost, and recreating the references from tasks on the background session is too much unnecessary work
- Expose publishers from the SyncService, to each ItemListViewModel can subscribe to the progress and completion events, and filter out based on the nested level of the screen
