### PR TITLE
Fix crash after streaming a partially corrupted file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Swiftlint
       run: swiftlint
     - name: Set Xcode version
-      run: sudo xcode-select -s "/Applications/Xcode_15.0.app/Contents/Developer"
+      run: sudo xcode-select -s "/Applications/Xcode_15.0.1.app/Contents/Developer"
     - name: Resolve dependencies
       run: xcodebuild -resolvePackageDependencies
     - name: Build and Run tests
-      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0'
+      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0.1'
 

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -214,12 +214,10 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
   override func syncList() {
     Task { @MainActor in
       do {
-        let lastPlayed: SyncableItem?
-
         if UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasScheduledLibraryContents) == true {
-          lastPlayed = try await syncService.syncListContents(at: nil)
+          try await syncService.syncListContents(at: nil)
         } else {
-          lastPlayed = try await syncService.syncLibraryContents()
+          try await syncService.syncLibraryContents()
 
           UserDefaults.standard.set(
             true,
@@ -228,9 +226,6 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
         }
 
         reloadItemsWithPadding()
-        if let lastPlayed {
-          reloadLastBook(relativePath: lastPlayed.relativePath)
-        }
       } catch BPSyncError.reloadLastBook(let relativePath) {
         reloadItemsWithPadding()
         reloadLastBook(relativePath: relativePath)

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1380,20 +1380,15 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     }
     var syncListContentsAtReceivedRelativePath: String?
     var syncListContentsAtReceivedInvocations: [String?] = []
-    var syncListContentsAtReturnValue: SyncableItem?
-    var syncListContentsAtClosure: ((String?) async throws -> SyncableItem?)?
-    func syncListContents(at relativePath: String?) async throws -> SyncableItem? {
+    var syncListContentsAtClosure: ((String?) async throws -> Void)?
+    func syncListContents(at relativePath: String?) async throws {
         if let error = syncListContentsAtThrowableError {
             throw error
         }
         syncListContentsAtCallsCount += 1
         syncListContentsAtReceivedRelativePath = relativePath
         syncListContentsAtReceivedInvocations.append(relativePath)
-        if let syncListContentsAtClosure = syncListContentsAtClosure {
-            return try await syncListContentsAtClosure(relativePath)
-        } else {
-            return syncListContentsAtReturnValue
-        }
+        try await syncListContentsAtClosure?(relativePath)
     }
     //MARK: - syncLibraryContents
 
@@ -1402,18 +1397,13 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     var syncLibraryContentsCalled: Bool {
         return syncLibraryContentsCallsCount > 0
     }
-    var syncLibraryContentsReturnValue: SyncableItem?
-    var syncLibraryContentsClosure: (() async throws -> SyncableItem?)?
-    func syncLibraryContents() async throws -> SyncableItem? {
+    var syncLibraryContentsClosure: (() async throws -> Void)?
+    func syncLibraryContents() async throws {
         if let error = syncLibraryContentsThrowableError {
             throw error
         }
         syncLibraryContentsCallsCount += 1
-        if let syncLibraryContentsClosure = syncLibraryContentsClosure {
-            return try await syncLibraryContentsClosure()
-        } else {
-            return syncLibraryContentsReturnValue
-        }
+        try await syncLibraryContentsClosure?()
     }
     //MARK: - syncBookmarksList
 


### PR DESCRIPTION
## Bugfix

- When trying to stream a book with 15kb null bytes in its header, the OS media services are crashing and being reset, and the next time the user attempts playback, it will crash due to an `AVPlayerItem` reporting the status `readyToPlay` but having attached the previous error to it

## Approach

- Rework the `observeValue` function to make it more readable with a switch statement on the item's status
- Clear out the player item when there's an error, so on the next play action, the player is reloaded
- Add new flag `canFetchRemoteURL`, to avoid a fetch loop if for some reason the error is always `NSURLErrorResourceUnavailable`

## Things to be aware of / Things to focus on

- I also reworked part of the sync service, to no longer return the last played item, as we were reloading the player without need after a sync event
