### PR TITLE
Enable interactive widgets (recent books, last played)

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		6340D5692AF12D48003D0B09 /* SharedWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6340D5682AF12D48003D0B09 /* SharedWidget.swift */; };
 		6340D56E2AF13E4C003D0B09 /* RectangularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6340D56D2AF13E4C003D0B09 /* RectangularView.swift */; };
 		63432B592AC1E6F7002619D0 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63432B582AC1E6F7002619D0 /* MockNavigationController.swift */; };
+		634E67462AFC7DEF00595BAC /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
 		6356F9B52AC7CC5600B7A027 /* CancelSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9B42AC7CC5600B7A027 /* CancelSleepTimerIntent.swift */; };
 		6356F9B92AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9B82AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift */; };
 		6356F9BD2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9BC2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift */; };
@@ -1039,6 +1040,7 @@
 		6340D5682AF12D48003D0B09 /* SharedWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedWidget.swift; sourceTree = "<group>"; };
 		6340D56D2AF13E4C003D0B09 /* RectangularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangularView.swift; sourceTree = "<group>"; };
 		63432B582AC1E6F7002619D0 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
+		634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStartPlaybackIntent.swift; sourceTree = "<group>"; };
 		6356F9B42AC7CC5600B7A027 /* CancelSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSleepTimerIntent.swift; sourceTree = "<group>"; };
 		6356F9B82AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndChapterSleepTimerIntent.swift; sourceTree = "<group>"; };
 		6356F9BC2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSleepTimerIntent.swift; sourceTree = "<group>"; };
@@ -2048,6 +2050,7 @@
 		63E5D6A92AECB8AB00A67B32 /* Phone */ = {
 			isa = PBXGroup;
 			children = (
+				634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */,
 				4106413E258725F1008EB8D0 /* TimeListened */,
 				637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */,
 				418445C2258AE11E0072DD13 /* WidgetUtils.swift */,
@@ -3193,6 +3196,7 @@
 				41ADD6DA2570AC6300660C64 /* RecentBooksWidgetView.swift in Sources */,
 				630826162AF6CABD002ACE0D /* SharedIconWidgetEntry.swift in Sources */,
 				9FF383D52A40F97000BBAC11 /* MappingModel_v8_to_v9.xcmappingmodel in Sources */,
+				634E67462AFC7DEF00595BAC /* BookStartPlaybackIntent.swift in Sources */,
 				630826072AF52831002ACE0D /* SharedWidget.swift in Sources */,
 				630826022AF295AE002ACE0D /* CornerView.swift in Sources */,
 			);

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -359,6 +359,10 @@
 		639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
 		639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
+		63C1A8AF2B09158600C4B418 /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
+		63C1A8B02B0915EE00C4B418 /* WidgetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418445C2258AE11E0072DD13 /* WidgetUtils.swift */; };
+		63C1A8B12B09165400C4B418 /* RecentBooksWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41ADD6D92570AC6300660C64 /* RecentBooksWidgetView.swift */; };
+		63C1A8B22B09166F00C4B418 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		63F828572AED56FA00B5CE0C /* CornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F828562AED56FA00B5CE0C /* CornerView.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
@@ -3220,6 +3224,7 @@
 				631C75CC2AB92FA60013E7E5 /* BPModalPresentationFlow.swift in Sources */,
 				9FF710AC2A212221006490E0 /* QueuedSyncTasksViewController.swift in Sources */,
 				9FEC87B227FA9F1C006C71D5 /* LoginViewModel.swift in Sources */,
+				63C1A8B22B09166F00C4B418 /* WidgetEntries.swift in Sources */,
 				9F17D5CD29159297004F4929 /* SearchListViewModel.swift in Sources */,
 				41E562C4223896B500C06BC9 /* UserDefaults+BookPlayer.swift in Sources */,
 				41AD3DA3221C7DCE00DC41E1 /* IconsViewController.swift in Sources */,
@@ -3243,6 +3248,7 @@
 				4165EE0520A743D500616EDF /* BookPlayer.xcdatamodeld in Sources */,
 				41B2A5DC21CAEE0E00917584 /* PlayerSettingsViewController.swift in Sources */,
 				9FF710B72A212A19006490E0 /* QueuedSyncTasksView.swift in Sources */,
+				63C1A8B02B0915EE00C4B418 /* WidgetUtils.swift in Sources */,
 				41B2A5ED21CCC6D100917584 /* AppNavigationController.swift in Sources */,
 				9F22DE40288D8BC800056FCD /* BaseLabel.swift in Sources */,
 				41B2AC8E1D43CCE8005382A9 /* ChaptersViewController.swift in Sources */,
@@ -3328,10 +3334,12 @@
 				415B274421FAE47200F9D9B7 /* LoadingView.swift in Sources */,
 				41E79BED26C61D2B00EA9FFF /* PlayPauseIconView.swift in Sources */,
 				9F4691F52800F84800A8F0E8 /* AccountViewController.swift in Sources */,
+				63C1A8AF2B09158600C4B418 /* BookStartPlaybackIntent.swift in Sources */,
 				9FEC87B027FA9F0F006C71D5 /* LoginViewController.swift in Sources */,
 				9F00A5FA294F8BFE005EA316 /* ClearableTextField.swift in Sources */,
 				9F5FBB08293EDCD8009F4B0E /* ItemDetailsViewController.swift in Sources */,
 				9F2681B628898A7300359BD3 /* LoginDisclaimerView.swift in Sources */,
+				63C1A8B12B09165400C4B418 /* RecentBooksWidgetView.swift in Sources */,
 				9FD8D95829DC53750074C2D8 /* CoreServices.swift in Sources */,
 				9F4691F22800D58A00A8F0E8 /* CompleteAccountCoordinator.swift in Sources */,
 				9F00A5F6294F793F005EA316 /* ItemDetailsView.swift in Sources */,

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -326,6 +326,8 @@
 		630826122AF6CA45002ACE0D /* SharedIconWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308260F2AF6C9B0002ACE0D /* SharedIconWidget.swift */; };
 		630826152AF6CABC002ACE0D /* SharedIconWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630826132AF6CA81002ACE0D /* SharedIconWidgetEntry.swift */; };
 		630826162AF6CABD002ACE0D /* SharedIconWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630826132AF6CA81002ACE0D /* SharedIconWidgetEntry.swift */; };
+		6309F1262B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309F1252B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift */; };
+		6309F1272B0CF658002B86A4 /* BookPlaybackToggleIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309F1252B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift */; };
 		630F115E2AE7EEBA000A997A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 419B375B23B8D6DB00128A8F /* Localizable.strings */; };
 		630F115F2AE7EECA000A997A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4140EA34227288EF0009F794 /* Assets.xcassets */; };
 		631B360C2ABE8ACC001F4C1C /* BPModalOnlyPresentationFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631B360B2ABE8ACC001F4C1C /* BPModalOnlyPresentationFlow.swift */; };
@@ -1034,6 +1036,7 @@
 		6308260C2AF6C312002ACE0D /* WidgetReloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetReloadService.swift; sourceTree = "<group>"; };
 		6308260F2AF6C9B0002ACE0D /* SharedIconWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedIconWidget.swift; sourceTree = "<group>"; };
 		630826132AF6CA81002ACE0D /* SharedIconWidgetEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedIconWidgetEntry.swift; sourceTree = "<group>"; };
+		6309F1252B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookPlaybackToggleIntent.swift; sourceTree = "<group>"; };
 		631B360B2ABE8ACC001F4C1C /* BPModalOnlyPresentationFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPModalOnlyPresentationFlow.swift; sourceTree = "<group>"; };
 		631C75C62AB92BE20013E7E5 /* BPCoordinatorPresentationFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPCoordinatorPresentationFlow.swift; sourceTree = "<group>"; };
 		631C75C82AB92C540013E7E5 /* BPPushPresentationFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPPushPresentationFlow.swift; sourceTree = "<group>"; };
@@ -2055,6 +2058,7 @@
 			isa = PBXGroup;
 			children = (
 				634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */,
+				6309F1252B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift */,
 				4106413E258725F1008EB8D0 /* TimeListened */,
 				637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */,
 				418445C2258AE11E0072DD13 /* WidgetUtils.swift */,
@@ -3189,6 +3193,7 @@
 				630826052AF522FF002ACE0D /* RectangularView.swift in Sources */,
 				41D20DB425D5F5A100AAEE30 /* MappingModel_v1_to_v2.xcmappingmodel in Sources */,
 				410641282579AA2F008EB8D0 /* TimeListenedWidgetView.swift in Sources */,
+				6309F1272B0CF658002B86A4 /* BookPlaybackToggleIntent.swift in Sources */,
 				630826032AF5225F002ACE0D /* CircularView.swift in Sources */,
 				630826042AF522EA002ACE0D /* SharedWidgetEntry.swift in Sources */,
 				41064152258726D2008EB8D0 /* TimeListenedMediumView.swift in Sources */,
@@ -3385,6 +3390,7 @@
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,
 				9F5FBB0A293EE0C2009F4B0E /* ItemDetailsViewModel.swift in Sources */,
+				6309F1262B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift in Sources */,
 				9FC1A29F28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift in Sources */,
 				D6BA8F182A4D66CD00C2BD9A /* StorageView.swift in Sources */,
 				9F64C6212793C31600B2493C /* PlayerControlsCoordinator.swift in Sources */,

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -48,8 +48,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       return lastSceneToResignActive
     }
   }
-  /// Reference for observer
+  /// Reference for observers
   private var crashReportsAccessObserver: NSKeyValueObservation?
+  private var sharedWidgetActionURLObserver: NSKeyValueObservation?
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     Self.shared = self
@@ -69,6 +70,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.setupRevenueCat()
     // Setup Sentry
     self.setupSentry()
+    // Setup observer for interactive widgets
+    self.setupSharedWidgetActionObserver()
 
     return true
   }
@@ -378,6 +381,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     handleSentryPreference(
       isDisabled: userDefaults.bool(forKey: Constants.UserDefaults.crashReportsDisabled)
     )
+  }
+
+  func setupSharedWidgetActionObserver() {
+    let audioSession = AVAudioSession.sharedInstance()
+    try? audioSession.setCategory(
+      AVAudioSession.Category.playback,
+      mode: .spokenAudio,
+      options: []
+    )
+    try? audioSession.setActive(true)
+
+    let sharedDefaults = UserDefaults.sharedDefaults
+
+    if let actionURL = sharedDefaults.sharedWidgetActionURL {
+      ActionParserService.process(actionURL)
+      sharedDefaults.removeObject(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+    }
+
+    sharedWidgetActionURLObserver = sharedDefaults.observe(\.sharedWidgetActionURL) { defaults, _ in
+      guard let actionURL = defaults.sharedWidgetActionURL else { return }
+
+      ActionParserService.process(actionURL)
+      sharedDefaults.removeObject(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+    }
   }
 
   /// Setup or stop Sentry based on flag

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -384,14 +384,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
 
   func setupSharedWidgetActionObserver() {
-    let audioSession = AVAudioSession.sharedInstance()
-    try? audioSession.setCategory(
-      AVAudioSession.Category.playback,
-      mode: .spokenAudio,
-      options: []
-    )
-    try? audioSession.setActive(true)
-
     let sharedDefaults = UserDefaults.sharedDefaults
 
     if let actionURL = sharedDefaults.sharedWidgetActionURL {
@@ -400,10 +392,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     sharedWidgetActionURLObserver = sharedDefaults.observe(\.sharedWidgetActionURL) { defaults, _ in
-      guard let actionURL = defaults.sharedWidgetActionURL else { return }
+      DispatchQueue.main.async {
+        guard let actionURL = defaults.sharedWidgetActionURL else { return }
 
-      ActionParserService.process(actionURL)
-      sharedDefaults.removeObject(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+        ActionParserService.process(actionURL)
+        sharedDefaults.removeObject(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+      }
     }
   }
 

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -407,6 +407,7 @@ extension ItemListViewController: UITableViewDataSource {
     return self.viewModel.items.count
   }
 
+  // swiftlint:disable:next function_body_length
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard indexPath.sectionValue != .add,
           let cell = tableView.dequeueReusableCell(withIdentifier: "BookCellView", for: indexPath) as? BookCellView else {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -133,6 +133,14 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     SleepTimer.shared.timerEndedPublisher.sink { [weak self] state in
       self?.handleSleepTimerEndEvent(state)
     }.store(in: &disposeBag)
+
+    isPlayingPublisher().sink { [weak self] isPlayingValue in
+      UserDefaults.sharedDefaults.set(
+        isPlayingValue,
+        forKey: Constants.UserDefaults.sharedWidgetIsPlaying
+      )
+      self?.widgetReloadService.reloadWidget(.lastPlayedWidget)
+    }.store(in: &disposeBag)
   }
 
   func bindInterruptObserver() {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -281,6 +281,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
 
     self.currentItem = item
+    self.libraryService.setLibraryLastBook(with: item.relativePath)
 
     self.playableChapterSubscription?.cancel()
     self.playableChapterSubscription = item.$currentChapter.sink { [weak self] chapter in

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -134,7 +134,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       self?.handleSleepTimerEndEvent(state)
     }.store(in: &disposeBag)
 
-    isPlayingPublisher().sink { [weak self] isPlayingValue in
+    isPlayingPublisher()
+      .removeDuplicates()
+      .sink { [weak self] isPlayingValue in
       UserDefaults.sharedDefaults.set(
         isPlayingValue,
         forKey: Constants.UserDefaults.sharedWidgetIsPlaying
@@ -289,7 +291,6 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
 
     self.currentItem = item
-    self.libraryService.setLibraryLastBook(with: item.relativePath)
 
     self.playableChapterSubscription?.cancel()
     self.playableChapterSubscription = item.$currentChapter.sink { [weak self] chapter in

--- a/BookPlayer/Player/WidgetReloadService.swift
+++ b/BookPlayer/Player/WidgetReloadService.swift
@@ -13,6 +13,8 @@ import WidgetKit
 protocol WidgetReloadServiceProtocol {
   /// Reload all the registered widgets
   func reloadAllWidgets()
+  /// Reload specific widget
+  func reloadWidget(_ type: Constants.Widgets)
   /// Reload a specific widget
   /// Note: Widgets showing progress info are subject to be constantly updated, so it's better to just make one update
   func scheduleWidgetReload(of type: Constants.Widgets)
@@ -30,6 +32,14 @@ class WidgetReloadService: WidgetReloadServiceProtocol {
     })
     referenceWorkItems = [:]
     WidgetCenter.shared.reloadAllTimelines()
+  }
+
+  func reloadWidget(_ type: Constants.Widgets) {
+    let referenceWorkItem = referenceWorkItems[type]
+
+    referenceWorkItem?.cancel()
+
+    WidgetCenter.shared.reloadTimelines(ofKind: type.rawValue)
   }
 
   func scheduleWidgetReload(of type: Constants.Widgets) {

--- a/BookPlayer/Services/ActionParserService.swift
+++ b/BookPlayer/Services/ActionParserService.swift
@@ -50,6 +50,8 @@ class ActionParserService {
       self.handlePlayAction(action)
     case .pause:
       self.handlePauseAction(action)
+    case .playbackToggle:
+      self.handlePlaybackToggleAction(action)
     case .download:
       self.handleDownloadAction(action)
     case .sleep:
@@ -152,8 +154,26 @@ class ActionParserService {
     }
   }
 
+  private class func handlePlaybackToggleAction(_ action: Action) {
+    guard
+      let playerManager = AppDelegate.shared?.playerManager
+    else {
+      return
+    }
+
+    self.removeAction(action)
+    playerManager.playPause()
+  }
+
   private class func handlePauseAction(_ action: Action) {
-    AppDelegate.shared?.playerManager?.pause()
+    guard
+      let playerManager = AppDelegate.shared?.playerManager
+    else {
+      return
+    }
+
+    self.removeAction(action)
+    playerManager.pause()
   }
 
   private class func handlePlayAction(_ action: Action) {
@@ -216,6 +236,11 @@ class ActionParserService {
   private class func handleWidgetAction(_ action: Action) {
     if action.getQueryValue(for: "autoplay") != nil {
       let playAction = Action(command: .play, parameters: action.parameters)
+      self.handleAction(playAction)
+    }
+
+    if action.getQueryValue(for: "playbackToggle") != nil {
+      let playAction = Action(command: .playbackToggle, parameters: action.parameters)
       self.handleAction(playAction)
     }
 

--- a/BookPlayerWidgets/BookPlayerWidgets.swift
+++ b/BookPlayerWidgets/BookPlayerWidgets.swift
@@ -21,9 +21,7 @@ struct BookPlayerWidgetUI_Previews: PreviewProvider {
       LastPlayedWidgetView(entry: SimpleEntry(
         date: Date(),
         title: "Test Book Title",
-        relativePath: nil,
-        timerSeconds: 300,
-        autoplay: true
+        relativePath: nil
       ))
       .previewContext(WidgetPreviewContext(family: .systemSmall))
     }

--- a/BookPlayerWidgets/Phone/BookPlaybackToggleIntent.swift
+++ b/BookPlayerWidgets/Phone/BookPlaybackToggleIntent.swift
@@ -1,8 +1,8 @@
 //
-//  BookStartPlaybackIntent.swift
+//  BookPlaybackToggleIntent.swift
 //  BookPlayer
 //
-//  Created by Gianni Carlo on 7/11/23.
+//  Created by Gianni Carlo on 21/11/23.
 //  Copyright © 2023 Tortuga Power. All rights reserved.
 //
 
@@ -12,9 +12,9 @@ import BookPlayerKit
 import AVFoundation
 
 @available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
-struct BookStartPlaybackIntent: AudioPlaybackIntent {
+struct BookPlaybackToggleIntent: AudioPlaybackIntent {
 
-  static var title: LocalizedStringResource = .init("Start playback of book")
+  static var title: LocalizedStringResource = .init("Toggle playback of book")
 
   @Parameter(title: "relativePath")
   var relativePath: String?
@@ -30,8 +30,7 @@ struct BookStartPlaybackIntent: AudioPlaybackIntent {
   func perform() async throws -> some IntentResult {
     let url = WidgetUtils.getWidgetActionURL(
       with: relativePath,
-      autoplay: true,
-      timerSeconds: nil
+      playbackToggle: true
     ).absoluteString
 
     UserDefaults.sharedDefaults.set(
@@ -42,4 +41,3 @@ struct BookStartPlaybackIntent: AudioPlaybackIntent {
     return .result()
   }
 }
-

--- a/BookPlayerWidgets/Phone/BookStartPlaybackIntent.swift
+++ b/BookPlayerWidgets/Phone/BookStartPlaybackIntent.swift
@@ -1,0 +1,43 @@
+//
+//  BookStartPlaybackIntent.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 7/11/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import AppIntents
+import BookPlayerKit
+import AVFoundation
+
+@available(iOS 17.0, macOS 14.0, watchOS 10.0, *)
+struct BookStartPlaybackIntent: AudioPlaybackIntent {
+
+  static var title: LocalizedStringResource = .init("Start playback of book")
+
+  @Parameter(title: "relativePath")
+  var relativePath: String?
+
+  init() {
+    relativePath = nil
+  }
+
+  init(relativePath: String) {
+    self.relativePath = relativePath
+  }
+
+  func perform() async throws -> some IntentResult {
+    let url = WidgetUtils.getWidgetActionURL(
+      with: relativePath,
+      autoplay: true,
+      timerSeconds: nil
+    )
+
+    let sharedDefaults = UserDefaults.sharedDefaults
+    sharedDefaults.set(url, forKey: Constants.UserDefaults.sharedWidgetActionURL)
+
+    return .result()
+  }
+}
+

--- a/BookPlayerWidgets/Phone/BookStartPlaybackIntent.swift
+++ b/BookPlayerWidgets/Phone/BookStartPlaybackIntent.swift
@@ -32,7 +32,7 @@ struct BookStartPlaybackIntent: AudioPlaybackIntent {
       with: relativePath,
       autoplay: true,
       timerSeconds: nil
-    )
+    ).absoluteString
 
     let sharedDefaults = UserDefaults.sharedDefaults
     sharedDefaults.set(url, forKey: Constants.UserDefaults.sharedWidgetActionURL)

--- a/BookPlayerWidgets/Phone/LastPlayedWidgetView.swift
+++ b/BookPlayerWidgets/Phone/LastPlayedWidgetView.swift
@@ -65,7 +65,9 @@ struct LastPlayedProvider: TimelineProvider {
       throw BookPlayerError.emptyResponse
     }
 
-    let isPlaying = true
+    let isPlaying = UserDefaults.sharedDefaults.bool(
+      forKey: Constants.UserDefaults.sharedWidgetIsPlaying
+    )
 
     let theme = libraryService.getLibraryCurrentTheme() ?? SimpleTheme.getDefaultTheme()
 
@@ -109,7 +111,7 @@ struct LastPlayedWidgetView: View {
       HStack {
         if let relativePath = entry.relativePath {
           if #available(iOSApplicationExtension 17.0, iOS 17.0, *) {
-            Button(intent: BookStartPlaybackIntent(relativePath: relativePath)) {
+            Button(intent: BookPlaybackToggleIntent(relativePath: relativePath)) {
               ZStack {
                 getArtworkView(for: relativePath)
                 Circle()
@@ -199,7 +201,7 @@ struct LastPlayedWidgetView_Previews: PreviewProvider {
 }
 
 struct LastPlayedWidget: Widget {
-  let kind: String = "com.bookplayer.widget.small.lastPlayed"
+  let kind: String = Constants.Widgets.lastPlayedWidget.rawValue
 
   var body: some WidgetConfiguration {
     StaticConfiguration(

--- a/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
@@ -151,6 +151,7 @@ struct RecentBooksWidgetView: View {
               )
               .frame(minWidth: 0, maxWidth: .infinity)
             }
+            .buttonStyle(.plain)
           } else {
             BookView(
               item: item,

--- a/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
@@ -34,7 +34,6 @@ struct RecentBooksProvider: TimelineProvider {
     Task {
       do {
         let entry = try await getEntryForTimeline(
-          for: configuration,
           context: context
         )
         completion(entry)
@@ -109,7 +108,6 @@ struct BookView: View {
         .font(.caption)
         .lineLimit(2)
         .multilineTextAlignment(.center)
-      }
     }
   }
 }

--- a/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgets/Phone/RecentBooksWidgetView.swift
@@ -143,7 +143,7 @@ struct RecentBooksWidgetView: View {
       .padding([.top], 8)
       HStack {
         ForEach(items, id: \.relativePath) { item in
-          if #available(iOSApplicationExtension 17.0, *) {
+          if #available(iOSApplicationExtension 17.0, iOS 17.0, *) {
             Button(intent: BookStartPlaybackIntent(relativePath: item.relativePath)) {
               BookView(
                 item: item,

--- a/BookPlayerWidgets/Phone/WidgetEntries.swift
+++ b/BookPlayerWidgets/Phone/WidgetEntries.swift
@@ -15,38 +15,32 @@ struct SimpleEntry: TimelineEntry {
   let title: String?
   let relativePath: String?
   let theme: SimpleTheme
-  let timerSeconds: Double
-  let autoplay: Bool
+  let isPlaying: Bool
 
   init(
     date: Date,
     title: String?,
     relativePath: String?,
     theme: SimpleTheme,
-    timerSeconds: Double,
-    autoplay: Bool
+    isPlaying: Bool
   ) {
     self.date = date
     self.title = title
     self.relativePath = relativePath
     self.theme = theme
-    self.timerSeconds = timerSeconds
-    self.autoplay = autoplay
+    self.isPlaying = isPlaying
   }
 
   init(
     date: Date,
     title: String?,
-    relativePath: String?,
-    timerSeconds: Double,
-    autoplay: Bool
+    relativePath: String?
   ) {
     self.date = date
     self.title = title
     self.relativePath = relativePath
     self.theme = SimpleTheme.getDefaultTheme()
-    self.timerSeconds = timerSeconds
-    self.autoplay = autoplay
+    self.isPlaying = false
   }
 }
 

--- a/BookPlayerWidgets/Phone/WidgetEntries.swift
+++ b/BookPlayerWidgets/Phone/WidgetEntries.swift
@@ -54,34 +54,24 @@ struct LibraryEntry: TimelineEntry {
   let date: Date
   let items: [SimpleLibraryItem]
   let theme: SimpleTheme
-  let timerSeconds: Double
-  let autoplay: Bool
 
   init(
     date: Date,
     items: [SimpleLibraryItem],
-    theme: SimpleTheme,
-    timerSeconds: Double,
-    autoplay: Bool
+    theme: SimpleTheme
   ) {
     self.date = date
     self.items = items
     self.theme = theme
-    self.timerSeconds = timerSeconds
-    self.autoplay = autoplay
   }
 
   init(
     date: Date,
-    items: [SimpleLibraryItem],
-    timerSeconds: Double,
-    autoplay: Bool
+    items: [SimpleLibraryItem]
   ) {
     self.date = date
     self.items = items
     self.theme = SimpleTheme.getDefaultTheme()
-    self.timerSeconds = timerSeconds
-    self.autoplay = autoplay
   }
 }
 

--- a/BookPlayerWidgets/Phone/WidgetUtils.swift
+++ b/BookPlayerWidgets/Phone/WidgetUtils.swift
@@ -152,7 +152,22 @@ class WidgetUtils {
   }
 
   class func getWidgetActionURL(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double?) -> URL {
-    let urlString = CommandParser.createWidgetActionString(with: bookIdentifier, autoplay: autoplay, timerSeconds: timerSeconds)
+    let urlString = CommandParser.createWidgetActionString(
+      with: bookIdentifier,
+      autoplay: autoplay,
+      timerSeconds: timerSeconds
+    )
+    return URL(string: urlString)!
+  }
+
+  class func getWidgetActionURL(
+    with bookIdentifier: String?,
+    playbackToggle: Bool
+  ) -> URL {
+    let urlString = CommandParser.createWidgetActionString(
+      with: bookIdentifier,
+      playbackToggle: playbackToggle
+    )
     return URL(string: urlString)!
   }
 

--- a/BookPlayerWidgets/Phone/WidgetUtils.swift
+++ b/BookPlayerWidgets/Phone/WidgetUtils.swift
@@ -21,7 +21,7 @@ struct WidgetColors {
   let backgroundColor: Color
 }
 
-struct PlaybackRecordViewer: Hashable {
+struct PlaybackRecordViewer: Hashable, Codable {
   var time: Double
   var date: Date
 }
@@ -151,7 +151,7 @@ class WidgetUtils {
     return UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)?.string(forKey: Constants.UserDefaults.appIcon) ?? "Default"
   }
 
-  class func getWidgetActionURL(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double) -> URL {
+  class func getWidgetActionURL(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double?) -> URL {
     let urlString = CommandParser.createWidgetActionString(with: bookIdentifier, autoplay: autoplay, timerSeconds: timerSeconds)
     return URL(string: urlString)!
   }

--- a/BookPlayerWidgets/Phone/WidgetUtils.swift
+++ b/BookPlayerWidgets/Phone/WidgetUtils.swift
@@ -193,7 +193,7 @@ extension View {
 
 extension WidgetConfiguration {
   public func contentMarginsDisabledIfAvailable() -> some WidgetConfiguration {
-    if #available(iOSApplicationExtension 17.0, *) {
+    if #available(iOSApplicationExtension 17.0, iOS 15.0, *) {
       return self.contentMarginsDisabled()
     } else {
       return self

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -106,7 +106,11 @@ public class CommandParser {
     return actionString
   }
 
-  public class func createWidgetActionString(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double?) -> String {
+  public class func createWidgetActionString(
+    with bookIdentifier: String?,
+    autoplay: Bool,
+    timerSeconds: Double?
+  ) -> String {
     var actionString = "bookplayer://widget?autoplay=\(autoplay)"
 
     if let identifier = bookIdentifier {
@@ -123,11 +127,29 @@ public class CommandParser {
 
     return actionString
   }
+
+  public class func createWidgetActionString(
+    with bookIdentifier: String?,
+    playbackToggle: Bool
+  ) -> String {
+    var actionString = "bookplayer://widget?playbackToggle=\(playbackToggle)"
+
+    if let identifier = bookIdentifier {
+      actionString += "&identifier=\(identifier)"
+    }
+
+    if let encodedActionString = actionString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+      actionString = encodedActionString
+    }
+
+    return actionString
+  }
 }
 
 public enum Command: String {
   case play
   case pause
+  case playbackToggle
   case download
   case refresh
   case skipRewind

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -106,11 +106,15 @@ public class CommandParser {
     return actionString
   }
 
-  public class func createWidgetActionString(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double) -> String {
-    var actionString = "bookplayer://widget?autoplay=\(autoplay)&seconds=\(timerSeconds)"
+  public class func createWidgetActionString(with bookIdentifier: String?, autoplay: Bool, timerSeconds: Double?) -> String {
+    var actionString = "bookplayer://widget?autoplay=\(autoplay)"
 
     if let identifier = bookIdentifier {
       actionString += "&identifier=\(identifier)"
+    }
+
+    if let timerSeconds {
+      actionString += "&seconds=\(timerSeconds)"
     }
 
     if let encodedActionString = actionString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -44,6 +44,9 @@ public enum Constants {
 
     // One-time migrations
     public static let fileProtectionMigration = "userFileProtectionMigration"
+
+    /// Shared widget action URL
+    public static let sharedWidgetActionURL = "sharedWidgetActionURL"
   }
 
   public enum SmartRewind {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -47,6 +47,9 @@ public enum Constants {
 
     /// Shared widget action URL
     public static let sharedWidgetActionURL = "sharedWidgetActionURL"
+
+    /// Shared widget isPlaying state
+    public static let sharedWidgetIsPlaying = "sharedWidgetIsPlaying"
   }
 
   public enum SmartRewind {
@@ -65,5 +68,6 @@ public enum Constants {
   public enum Widgets: String {
     case sharedNowPlayingWidget = "com.bookplayer.shared.widget"
     case sharedIconWidget = "com.bookplayer.shared.icon.widget"
+    case lastPlayedWidget = "com.bookplayer.widget.small.lastPlayed"
   }
 }

--- a/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
+++ b/Shared/CoreData/Backed-Models/Book+CoreDataClass.swift
@@ -56,10 +56,11 @@ extension CodingUserInfoKey {
 }
 
 extension Book {
-  public func loadChaptersIfNeeded(from asset: AVAsset, context: NSManagedObjectContext) {
-    guard chapters?.count == 0 else { return }
+  public func loadChaptersIfNeeded(from asset: AVAsset, context: NSManagedObjectContext) -> Bool {
+    guard chapters?.count == 0 else { return false }
 
     setChapters(from: asset, context: context)
+    return true
   }
 
   public func setChapters(from asset: AVAsset, context: NSManagedObjectContext) {

--- a/Shared/Extensions/UserDefaults+BookPlayer.swift
+++ b/Shared/Extensions/UserDefaults+BookPlayer.swift
@@ -10,4 +10,8 @@ import Foundation
 
 extension UserDefaults {
   public static var sharedDefaults = UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)!
+
+  @objc public dynamic var sharedWidgetActionURL: URL? {
+    return url(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+  }
 }

--- a/Shared/Extensions/UserDefaults+BookPlayer.swift
+++ b/Shared/Extensions/UserDefaults+BookPlayer.swift
@@ -12,6 +12,10 @@ extension UserDefaults {
   public static var sharedDefaults = UserDefaults(suiteName: Constants.ApplicationGroupIdentifier)!
 
   @objc public dynamic var sharedWidgetActionURL: URL? {
-    return url(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+    guard
+      let widgetActionString = string(forKey: Constants.UserDefaults.sharedWidgetActionURL)
+    else { return nil }
+
+    return URL(string: widgetActionString)
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1061,9 +1061,11 @@ extension LibraryService {
       let book = getItem(with: relativePath, context: context) as? Book
     else { return }
 
-    book.loadChaptersIfNeeded(from: asset, context: context)
+    let hadEmptyChapters = book.loadChaptersIfNeeded(from: asset, context: context)
 
-    dataManager.saveSyncContext(context)
+    if hadEmptyChapters {
+      dataManager.saveSyncContext(context)
+    }
   }
 
   func createFolderOnDisk(title: String, inside relativePath: String?, context: NSManagedObjectContext) throws {


### PR DESCRIPTION
## Purpose

- Enable interactive widgets for recent books and last played

## Approach

- Setup new app intents for playback (and toggle playback)
- Update the recent books widget to play the selected book
- Update the last played widget to toggle playback when tapping the artwork
- Setup observers for shared user defaults, to handle showing the proper state for the widgets

## Things to be aware of / Things to focus on

- Per Apple's recommendation, I'm keeping the intents simple and with a single action, so the last played and recent books widget will no longer have the sleep timer functionality, if there are requests about this, I think it would make sense to create a separate widget to handle setting the sleep timer
