### PR TITLE
Add way to export debug information for better support

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		6356F9D02ACB01C700B7A027 /* PausePlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */; };
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
+		635907A02B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */; };
 		637609192ADCD81400A01D5D /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6376091B2ADCD81400A01D5D /* AppShortcuts.strings */; };
 		637DAB0B2AEB3F6D006DC2D1 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		637DAB0D2AEBEF1B006DC2D1 /* BookPlayerWatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */; };
@@ -1056,6 +1057,7 @@
 		6356F9C92AC8A1B700B7A027 /* DatabaseInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseInitializer.swift; sourceTree = "<group>"; };
 		6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PausePlaybackIntent.swift; sourceTree = "<group>"; };
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
+		6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRepresentationActivityItemProvider.swift; sourceTree = "<group>"; };
 		6376091A2ADCD81400A01D5D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091C2ADCD82100A01D5D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091D2ADCD82100A01D5D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
@@ -2085,6 +2087,7 @@
 				419723FF21874D5F00AB1190 /* UserActivityManager.swift */,
 				41D39D40215F177D00B65290 /* BookActivityItemProvider.swift */,
 				9FC1A29E28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift */,
+				6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */,
 				41B30A32230232D200025D69 /* CarPlayManager.swift */,
 				4193E201243A91AE004D6A82 /* ActionParserService.swift */,
 				9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */,
@@ -3389,6 +3392,7 @@
 				416AAC3323F51031005AD04F /* LocalizableButton.swift in Sources */,
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,
+				635907A02B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift in Sources */,
 				9F5FBB0A293EE0C2009F4B0E /* ItemDetailsViewModel.swift in Sources */,
 				6309F1262B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift in Sources */,
 				9FC1A29F28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift in Sources */,

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -109,7 +109,8 @@ class MainCoordinator: NSObject {
   func startSettingsCoordinator(with tabBarController: UITabBarController) {
     let settingsCoordinator = SettingsCoordinator(
       flow: .pushFlow(navigationController: AppNavigationController.instantiate(from: .Settings)),
-      libraryService: self.libraryService,
+      libraryService: self.libraryService, 
+      syncService: self.syncService,
       accountService: self.accountService
     )
     settingsCoordinator.tabBarController = tabBarController

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -48,6 +48,8 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
         self.showTipJar()
       case .credits:
         self.showCredits()
+      case .debugFiles:
+        self.shareDebugFiles()
       }
     }
 
@@ -108,7 +110,6 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
   }
 
   func showPro() {
-//    let presentingVC = flow.navigationController.getTopViewController()
     let child: Coordinator
 
     if self.accountService.getAccountId() != nil {
@@ -207,5 +208,20 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
     nav.viewControllers = [vc]
 
     flow.navigationController.present(nav, animated: true)
+  }
+
+  func shareDebugFiles() {
+    let provider = LibraryRepresentationActivityItemProvider(libraryService: libraryService)
+
+    let shareController = UIActivityViewController(activityItems: [provider], applicationActivities: nil)
+
+    if let popoverPresentationController = shareController.popoverPresentationController,
+       let view = flow.navigationController.topViewController?.view {
+      popoverPresentationController.permittedArrowDirections = []
+      popoverPresentationController.sourceView = view
+      popoverPresentationController.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+    }
+
+    flow.navigationController.present(shareController, animated: true, completion: nil)
   }
 }

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -15,20 +15,27 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
 
   let flow: BPCoordinatorPresentationFlow
   let libraryService: LibraryServiceProtocol
+  let syncService: SyncServiceProtocol
   let accountService: AccountServiceProtocol
 
   init(
     flow: BPCoordinatorPresentationFlow,
     libraryService: LibraryServiceProtocol,
+    syncService: SyncServiceProtocol,
     accountService: AccountServiceProtocol
   ) {
     self.flow = flow
     self.libraryService = libraryService
+    self.syncService = syncService
     self.accountService = accountService
   }
 
   func start() {
-    let viewModel = SettingsViewModel(accountService: accountService)
+    let viewModel = SettingsViewModel(
+      accountService: accountService,
+      libraryService: libraryService,
+      syncService: syncService
+    )
 
     viewModel.onTransition = { route in
       switch route {
@@ -48,8 +55,8 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
         self.showTipJar()
       case .credits:
         self.showCredits()
-      case .debugFiles:
-        self.shareDebugFiles()
+      case .debugFiles(let libraryRepresentation):
+        self.shareDebugFiles(libraryRepresentation: libraryRepresentation)
       }
     }
 
@@ -210,8 +217,8 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
     flow.navigationController.present(nav, animated: true)
   }
 
-  func shareDebugFiles() {
-    let provider = LibraryRepresentationActivityItemProvider(libraryService: libraryService)
+  func shareDebugFiles(libraryRepresentation: String) {
+    let provider = LibraryRepresentationActivityItemProvider(libraryRepresentation: libraryRepresentation)
 
     let shareController = UIActivityViewController(activityItems: [provider], applicationActivities: nil)
 

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -251,24 +251,20 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return fetchContentsAtLimitOffsetReturnValue
         }
     }
-    //MARK: - fetchRawContents
+    //MARK: - fetchIdentifiers
 
-    var fetchRawContentsAtPropertiesToFetchCallsCount = 0
-    var fetchRawContentsAtPropertiesToFetchCalled: Bool {
-        return fetchRawContentsAtPropertiesToFetchCallsCount > 0
+    var fetchIdentifiersCallsCount = 0
+    var fetchIdentifiersCalled: Bool {
+        return fetchIdentifiersCallsCount > 0
     }
-    var fetchRawContentsAtPropertiesToFetchReceivedArguments: (relativePath: String?, propertiesToFetch: [String])?
-    var fetchRawContentsAtPropertiesToFetchReceivedInvocations: [(relativePath: String?, propertiesToFetch: [String])] = []
-    var fetchRawContentsAtPropertiesToFetchReturnValue: [LibraryItem]?
-    var fetchRawContentsAtPropertiesToFetchClosure: ((String?, [String]) -> [LibraryItem]?)?
-    func fetchRawContents(at relativePath: String?, propertiesToFetch: [String]) -> [LibraryItem]? {
-        fetchRawContentsAtPropertiesToFetchCallsCount += 1
-        fetchRawContentsAtPropertiesToFetchReceivedArguments = (relativePath: relativePath, propertiesToFetch: propertiesToFetch)
-        fetchRawContentsAtPropertiesToFetchReceivedInvocations.append((relativePath: relativePath, propertiesToFetch: propertiesToFetch))
-        if let fetchRawContentsAtPropertiesToFetchClosure = fetchRawContentsAtPropertiesToFetchClosure {
-            return fetchRawContentsAtPropertiesToFetchClosure(relativePath, propertiesToFetch)
+    var fetchIdentifiersReturnValue: [String]!
+    var fetchIdentifiersClosure: (() -> [String])?
+    func fetchIdentifiers() -> [String] {
+        fetchIdentifiersCallsCount += 1
+        if let fetchIdentifiersClosure = fetchIdentifiersClosure {
+            return fetchIdentifiersClosure()
         } else {
-            return fetchRawContentsAtPropertiesToFetchReturnValue
+            return fetchIdentifiersReturnValue
         }
     }
     //MARK: - getMaxItemsCount
@@ -1478,6 +1474,26 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
             return try await syncBookmarksListRelativePathClosure(relativePath)
         } else {
             return syncBookmarksListRelativePathReturnValue
+        }
+    }
+    //MARK: - fetchSyncedIdentifiers
+
+    var fetchSyncedIdentifiersThrowableError: Error?
+    var fetchSyncedIdentifiersCallsCount = 0
+    var fetchSyncedIdentifiersCalled: Bool {
+        return fetchSyncedIdentifiersCallsCount > 0
+    }
+    var fetchSyncedIdentifiersReturnValue: [String]!
+    var fetchSyncedIdentifiersClosure: (() async throws -> [String])?
+    func fetchSyncedIdentifiers() async throws -> [String] {
+        if let error = fetchSyncedIdentifiersThrowableError {
+            throw error
+        }
+        fetchSyncedIdentifiersCallsCount += 1
+        if let fetchSyncedIdentifiersClosure = fetchSyncedIdentifiersClosure {
+            return try await fetchSyncedIdentifiersClosure()
+        } else {
+            return fetchSyncedIdentifiersReturnValue
         }
     }
     //MARK: - getRemoteFileURLs

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -251,6 +251,26 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return fetchContentsAtLimitOffsetReturnValue
         }
     }
+    //MARK: - fetchRawContents
+
+    var fetchRawContentsAtPropertiesToFetchCallsCount = 0
+    var fetchRawContentsAtPropertiesToFetchCalled: Bool {
+        return fetchRawContentsAtPropertiesToFetchCallsCount > 0
+    }
+    var fetchRawContentsAtPropertiesToFetchReceivedArguments: (relativePath: String?, propertiesToFetch: [String])?
+    var fetchRawContentsAtPropertiesToFetchReceivedInvocations: [(relativePath: String?, propertiesToFetch: [String])] = []
+    var fetchRawContentsAtPropertiesToFetchReturnValue: [LibraryItem]?
+    var fetchRawContentsAtPropertiesToFetchClosure: ((String?, [String]) -> [LibraryItem]?)?
+    func fetchRawContents(at relativePath: String?, propertiesToFetch: [String]) -> [LibraryItem]? {
+        fetchRawContentsAtPropertiesToFetchCallsCount += 1
+        fetchRawContentsAtPropertiesToFetchReceivedArguments = (relativePath: relativePath, propertiesToFetch: propertiesToFetch)
+        fetchRawContentsAtPropertiesToFetchReceivedInvocations.append((relativePath: relativePath, propertiesToFetch: propertiesToFetch))
+        if let fetchRawContentsAtPropertiesToFetchClosure = fetchRawContentsAtPropertiesToFetchClosure {
+            return fetchRawContentsAtPropertiesToFetchClosure(relativePath, propertiesToFetch)
+        } else {
+            return fetchRawContentsAtPropertiesToFetchReturnValue
+        }
+    }
     //MARK: - getMaxItemsCount
 
     var getMaxItemsCountAtCallsCount = 0

--- a/BookPlayer/Services/LibraryRepresentationActivityItemProvider.swift
+++ b/BookPlayer/Services/LibraryRepresentationActivityItemProvider.swift
@@ -1,0 +1,160 @@
+//
+//  LibraryRepresentationActivityItemProvider.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 28/11/23.
+//  Copyright © 2023 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+
+final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
+  let libraryService: LibraryServiceProtocol
+
+  init(libraryService: LibraryServiceProtocol) {
+    self.libraryService = libraryService
+    super.init(placeholderItem: URL(fileURLWithPath: "placeholder.txt"))
+  }
+
+  public override func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    itemForActivityType activityType: UIActivity.ActivityType?
+  ) -> Any? {
+    let fileTitle = "library_hierarchy_tree.txt"
+    let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileTitle)
+
+    do {
+      if FileManager.default.fileExists(atPath: fileURL.path) {
+        try FileManager.default.removeItem(at: fileURL)
+      }
+
+      let libraryRepresentation = getLibraryRepresentation()
+      let contentsData = libraryRepresentation.data(using: .utf8)
+      FileManager.default.createFile(atPath: fileURL.path, contents: contentsData)
+    } catch {
+      return nil
+    }
+
+    return fileURL
+  }
+
+  /// Get a representation of the library like with the `tree` command
+  /// Note: '✓' means the backing file exists, and '𐄂' that it's missing locally
+  private func getLibraryRepresentation() -> String {
+    let contents = libraryService.fetchRawContents(
+      at: nil,
+      propertiesToFetch: [
+        #keyPath(LibraryItem.relativePath),
+        #keyPath(LibraryItem.type)
+      ]
+    ) ?? []
+
+    var libraryRepresentation = ".\n"
+    let processedFolderURL = DataManager.getProcessedFolderURL()
+
+    for (index, item) in contents.enumerated() {
+      let itemRepresentation: String
+
+      switch item.type {
+      case .book:
+        itemRepresentation = processBookRepresentation(
+          item.relativePath,
+          isLast: index == (contents.endIndex - 1),
+          processedFolderURL: processedFolderURL
+        )
+      case .folder, .bound:
+        itemRepresentation = processFolderRepresentation(
+          item.relativePath,
+          nestedLevel: 0,
+          processedFolderURL: processedFolderURL
+        )
+      }
+
+      libraryRepresentation += itemRepresentation + "\n"
+    }
+
+    return libraryRepresentation
+  }
+
+  private func processFolderRepresentation(
+    _ relativePath: String,
+    nestedLevel: Int,
+    processedFolderURL: URL
+  ) -> String {
+    let contents = libraryService.fetchRawContents(
+      at: relativePath,
+      propertiesToFetch: [
+        #keyPath(LibraryItem.relativePath),
+        #keyPath(LibraryItem.type)
+      ]
+    ) ?? []
+
+    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
+    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
+    ? "✓"
+    : "𐄂"
+
+    let baseSeparator = "|   "
+    var horizontalSeparator = String(repeating: baseSeparator, count: nestedLevel)
+    var folderRepresentation = horizontalSeparator + "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    horizontalSeparator += baseSeparator
+
+    if !contents.isEmpty {
+      folderRepresentation += "\n"
+    }
+
+    for (index, item) in contents.enumerated() {
+      let itemRepresentation: String
+      let isLast = index == (contents.endIndex - 1)
+
+      switch item.type {
+      case .book:
+        let bookRepresentation = processBookRepresentation(
+          item.relativePath,
+          isLast: isLast,
+          processedFolderURL: processedFolderURL
+        )
+
+        itemRepresentation = horizontalSeparator + bookRepresentation
+      case .folder, .bound:
+        itemRepresentation = processFolderRepresentation(
+          item.relativePath,
+          nestedLevel: nestedLevel + 1,
+          processedFolderURL: processedFolderURL
+        )
+      }
+
+      if isLast {
+        folderRepresentation += itemRepresentation
+      } else {
+        folderRepresentation += itemRepresentation + "\n"
+      }
+    }
+
+    return folderRepresentation
+  }
+
+  private func processBookRepresentation(
+    _ relativePath: String,
+    isLast: Bool,
+    processedFolderURL: URL
+  ) -> String {
+    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
+    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
+    ? "✓"
+    : "𐄂"
+
+    if isLast {
+      return "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    } else {
+      return "|-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    }
+  }
+
+  public override func activityViewControllerPlaceholderItem(
+    _ activityViewController: UIActivityViewController
+  ) -> Any {
+    return URL(fileURLWithPath: "placeholder.txt")
+  }
+}

--- a/BookPlayer/Services/LibraryRepresentationActivityItemProvider.swift
+++ b/BookPlayer/Services/LibraryRepresentationActivityItemProvider.swift
@@ -10,10 +10,10 @@ import BookPlayerKit
 import Foundation
 
 final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
-  let libraryService: LibraryServiceProtocol
+  let libraryRepresentation: String
 
-  init(libraryService: LibraryServiceProtocol) {
-    self.libraryService = libraryService
+  init(libraryRepresentation: String) {
+    self.libraryRepresentation = libraryRepresentation
     super.init(placeholderItem: URL(fileURLWithPath: "placeholder.txt"))
   }
 
@@ -29,7 +29,6 @@ final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
         try FileManager.default.removeItem(at: fileURL)
       }
 
-      let libraryRepresentation = getLibraryRepresentation()
       let contentsData = libraryRepresentation.data(using: .utf8)
       FileManager.default.createFile(atPath: fileURL.path, contents: contentsData)
     } catch {
@@ -37,119 +36,6 @@ final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
     }
 
     return fileURL
-  }
-
-  /// Get a representation of the library like with the `tree` command
-  /// Note: '✓' means the backing file exists, and '𐄂' that it's missing locally
-  private func getLibraryRepresentation() -> String {
-    let contents = libraryService.fetchRawContents(
-      at: nil,
-      propertiesToFetch: [
-        #keyPath(LibraryItem.relativePath),
-        #keyPath(LibraryItem.type)
-      ]
-    ) ?? []
-
-    var libraryRepresentation = ".\n"
-    let processedFolderURL = DataManager.getProcessedFolderURL()
-
-    for (index, item) in contents.enumerated() {
-      let itemRepresentation: String
-
-      switch item.type {
-      case .book:
-        itemRepresentation = processBookRepresentation(
-          item.relativePath,
-          isLast: index == (contents.endIndex - 1),
-          processedFolderURL: processedFolderURL
-        )
-      case .folder, .bound:
-        itemRepresentation = processFolderRepresentation(
-          item.relativePath,
-          nestedLevel: 0,
-          processedFolderURL: processedFolderURL
-        )
-      }
-
-      libraryRepresentation += itemRepresentation + "\n"
-    }
-
-    return libraryRepresentation
-  }
-
-  private func processFolderRepresentation(
-    _ relativePath: String,
-    nestedLevel: Int,
-    processedFolderURL: URL
-  ) -> String {
-    let contents = libraryService.fetchRawContents(
-      at: relativePath,
-      propertiesToFetch: [
-        #keyPath(LibraryItem.relativePath),
-        #keyPath(LibraryItem.type)
-      ]
-    ) ?? []
-
-    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
-    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
-    ? "✓"
-    : "𐄂"
-
-    let baseSeparator = "|   "
-    var horizontalSeparator = String(repeating: baseSeparator, count: nestedLevel)
-    var folderRepresentation = horizontalSeparator + "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
-    horizontalSeparator += baseSeparator
-
-    if !contents.isEmpty {
-      folderRepresentation += "\n"
-    }
-
-    for (index, item) in contents.enumerated() {
-      let itemRepresentation: String
-      let isLast = index == (contents.endIndex - 1)
-
-      switch item.type {
-      case .book:
-        let bookRepresentation = processBookRepresentation(
-          item.relativePath,
-          isLast: isLast,
-          processedFolderURL: processedFolderURL
-        )
-
-        itemRepresentation = horizontalSeparator + bookRepresentation
-      case .folder, .bound:
-        itemRepresentation = processFolderRepresentation(
-          item.relativePath,
-          nestedLevel: nestedLevel + 1,
-          processedFolderURL: processedFolderURL
-        )
-      }
-
-      if isLast {
-        folderRepresentation += itemRepresentation
-      } else {
-        folderRepresentation += itemRepresentation + "\n"
-      }
-    }
-
-    return folderRepresentation
-  }
-
-  private func processBookRepresentation(
-    _ relativePath: String,
-    isLast: Bool,
-    processedFolderURL: URL
-  ) -> String {
-    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
-    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
-    ? "✓"
-    : "𐄂"
-
-    if isLast {
-      return "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
-    } else {
-      return "|-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
-    }
   }
 
   public override func activityViewControllerPlaceholderItem(

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22146" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nNa-3d-7ZC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nNa-3d-7ZC">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -475,32 +475,21 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Support" id="HHg-sB-jse">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ClD-F6-XBV" detailTextLabel="p5a-8D-TIK" rowHeight="50" style="IBUITableViewCellStyleSubtitle" id="ml3-w4-0Kh" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="MVf-CT-ocr" rowHeight="50" style="IBUITableViewCellStyleDefault" id="g64-9I-V0m" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="1353" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ml3-w4-0Kh" id="iby-ep-R6R">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="g64-9I-V0m" id="f9T-VJ-ed5">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View project on GitHub" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ClD-F6-XBV" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="9" width="176" height="20.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Tip Jar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MVf-CT-ocr" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_project_title"/>
-                                                    </userDefinedRuntimeAttributes>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open new issues for your feature requests and errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="p5a-8D-TIK" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="29.5" width="257" height="12"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                    <size key="shadowOffset" width="0.0" height="0.0"/>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_project_description"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_tip_jar_title"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>
@@ -540,21 +529,55 @@
                                             <accessibilityTraits key="traits" link="YES"/>
                                         </accessibility>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="MVf-CT-ocr" rowHeight="50" style="IBUITableViewCellStyleDefault" id="g64-9I-V0m" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="7ap-vd-Uq1" rowHeight="50" style="IBUITableViewCellStyleDefault" id="5hz-V7-avo" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="1453" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="g64-9I-V0m" id="f9T-VJ-ed5">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5hz-V7-avo" id="SBD-9V-jQS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Tip Jar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MVf-CT-ocr" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Debug Files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7ap-vd-Uq1" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_tip_jar_title"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="Debug Files"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" link="YES"/>
+                                        </accessibility>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ClD-F6-XBV" detailTextLabel="p5a-8D-TIK" rowHeight="50" style="IBUITableViewCellStyleSubtitle" id="ml3-w4-0Kh" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="1503" width="375" height="50"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ml3-w4-0Kh" id="iby-ep-R6R">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View project on GitHub" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ClD-F6-XBV" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="9" width="176" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_project_title"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open new issues for your feature requests and errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="p5a-8D-TIK" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="29.5" width="257" height="12"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <size key="shadowOffset" width="0.0" height="0.0"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_project_description"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>
@@ -568,7 +591,7 @@
                             <tableViewSection id="7d8-SQ-Lj5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="f5k-Kh-fBQ" style="IBUITableViewCellStyleDefault" id="03X-zP-RZe" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1539" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="1589" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="03X-zP-RZe" id="IIp-cC-U1k">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -50,9 +50,10 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
   let cloudDeletedIndexPath = IndexPath(row: 1, section: SettingsSection.storage.rawValue)
   let lastPlayedShortcutPath = IndexPath(row: 0, section: SettingsSection.siri.rawValue)
   let sleepTimerShortcutPath = IndexPath(row: 1, section: SettingsSection.siri.rawValue)
-  let githubLinkPath = IndexPath(row: 0, section: SettingsSection.support.rawValue)
+  let tipJarPath = IndexPath(row: 0, section: SettingsSection.support.rawValue)
   let supportEmailPath = IndexPath(row: 1, section: SettingsSection.support.rawValue)
-  let tipJarPath = IndexPath(row: 2, section: SettingsSection.support.rawValue)
+  let debugFilesPath = IndexPath(row: 2, section: SettingsSection.support.rawValue)
+  let githubLinkPath = IndexPath(row: 3, section: SettingsSection.support.rawValue)
 
   var version: String = "0.0.0"
   var build: String = "0"
@@ -239,6 +240,8 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
       self.viewModel.showTipJar()
     case self.supportEmailPath:
       self.sendSupportEmail()
+    case self.debugFilesPath:
+      self.shareDebugFiles()
     case self.githubLinkPath:
       self.showProjectOnGitHub()
     case self.lastPlayedShortcutPath:
@@ -412,6 +415,10 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
 
       self.present(alert, animated: true, completion: nil)
     }
+  }
+
+  func shareDebugFiles() {
+    viewModel.shareDebugFiles()
   }
 
   func showProjectOnGitHub() {

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -389,7 +389,11 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
 
       mail.mailComposeDelegate = self
       mail.setToRecipients([self.supportEmail])
-      mail.setSubject("I need help with BookPlayer \(self.version)-\(self.build)")
+      /// Note: c for cloud enabled
+      let subject: String = viewModel.hasMadeDonation()
+      ? "I need help with BookPlayer \(self.version)-\(self.build)c"
+      : "I need help with BookPlayer \(self.version)-\(self.build)"
+      mail.setSubject(subject)
       mail.setMessageBody("<p>Hello BookPlayer Crew,<br>I have an issue concerning BookPlayer \(self.appVersion) on my \(device) running \(self.systemVersion)</p><p>When I try to…</p>", isHTML: true)
 
       self.present(mail, animated: true)

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -74,9 +74,10 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
 
     setUpTheming()
 
-    self.bindObservers()
+    bindObservers()
+    bindDataItems()
 
-    self.setupSwitchValues()
+    setupSwitchValues()
 
     guard
       let version = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String,
@@ -183,6 +184,28 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
 
   @objc func skanPreferenceDidChange() {
     viewModel.toggleSKANPreference(skanSwitch.isOn)
+  }
+
+  func bindDataItems() {
+    self.viewModel.observeEvents()
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] event in
+        switch event {
+        case .showLoader(let flag):
+          self?.showLoader(flag)
+        case .showAlert(let content):
+          self?.showAlert(content)
+        }
+      }
+      .store(in: &disposeBag)
+  }
+
+  func showLoader(_ flag: Bool) {
+    if flag {
+      LoadingUtils.loadAndBlock(in: self)
+    } else {
+      LoadingUtils.stopLoading(in: self)
+    }
   }
 
   override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -21,6 +21,7 @@ class SettingsViewModel: ViewModelProtocol {
     case deletedFilesManagement
     case tipJar
     case credits
+    case debugFiles
   }
   weak var coordinator: SettingsCoordinator!
   let accountService: AccountServiceProtocol
@@ -104,5 +105,9 @@ class SettingsViewModel: ViewModelProtocol {
 
   func showCredits() {
     onTransition?(.credits)
+  }
+
+  func showDebugFiles() {
+    onTransition?(.debugFiles)
   }
 }

--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -107,7 +107,7 @@ class SettingsViewModel: ViewModelProtocol {
     onTransition?(.credits)
   }
 
-  func showDebugFiles() {
+  func shareDebugFiles() {
     onTransition?(.debugFiles)
   }
 }

--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -21,19 +21,34 @@ class SettingsViewModel: ViewModelProtocol {
     case deletedFilesManagement
     case tipJar
     case credits
-    case debugFiles
+    case debugFiles(libraryRepresentation: String)
   }
+
+  enum Events {
+    case showLoader(flag: Bool)
+    case showAlert(content: BPAlertContent)
+  }
+
   weak var coordinator: SettingsCoordinator!
   let accountService: AccountServiceProtocol
+  let libraryService: LibraryServiceProtocol
+  let syncService: SyncServiceProtocol
 
   var onTransition: BPTransition<Routes>?
 
   @Published var account: Account?
 
   private var disposeBag = Set<AnyCancellable>()
+  var eventsPublisher = InterfaceUpdater<SettingsViewModel.Events>()
 
-  init(accountService: AccountServiceProtocol) {
+  init(
+    accountService: AccountServiceProtocol,
+    libraryService: LibraryServiceProtocol,
+    syncService: SyncServiceProtocol
+  ) {
     self.accountService = accountService
+    self.libraryService = libraryService
+    self.syncService = syncService
     self.reloadAccount()
     self.bindObservers()
   }
@@ -44,6 +59,14 @@ class SettingsViewModel: ViewModelProtocol {
         self?.reloadAccount()
       })
       .store(in: &disposeBag)
+  }
+
+  func observeEvents() -> AnyPublisher<SettingsViewModel.Events, Never> {
+    eventsPublisher.eraseToAnyPublisher()
+  }
+
+  private func sendEvent(_ event: SettingsViewModel.Events) {
+    eventsPublisher.send(event)
   }
 
   func reloadAccount() {
@@ -108,6 +131,91 @@ class SettingsViewModel: ViewModelProtocol {
   }
 
   func shareDebugFiles() {
-    onTransition?(.debugFiles)
+    sendEvent(.showLoader(flag: true))
+
+    Task { @MainActor in
+      do {
+        var remoteIdentifiers: [String]?
+
+        if syncService.isActive {
+          remoteIdentifiers = try await syncService.fetchSyncedIdentifiers()
+        }
+
+        let localidentifiers = libraryService.fetchIdentifiers()
+
+        let libraryRepresentation = getLibraryRepresentation(
+          localidentifiers: localidentifiers,
+          remoteIdentifiers: remoteIdentifiers
+        )
+
+        sendEvent(.showLoader(flag: false))
+        onTransition?(.debugFiles(libraryRepresentation: libraryRepresentation))
+      } catch {
+        sendEvent(.showLoader(flag: false))
+        sendEvent(.showAlert(
+          content: BPAlertContent.errorAlert(message: error.localizedDescription)
+        ))
+      }
+    }
+  }
+
+  /// Get a representation of the library like with the `tree` command
+  /// Note:  For the first status, '✓' means the backing file exists, and '𐄂' that it's missing locally,
+  /// and for the second status, ☐ means the file is not uploaded yet, and ☑ that it's already synced
+  func getLibraryRepresentation(
+    localidentifiers: [String],
+    remoteIdentifiers: [String]?
+  ) -> String {
+    let identifiers = libraryService.fetchIdentifiers()
+
+    var libraryRepresentation = ".\n"
+    let processedFolderURL = DataManager.getProcessedFolderURL()
+
+    let baseSeparator = "|   "
+    var nestedLevel = 0
+
+    for (index, identifier) in identifiers.enumerated() {
+      let fileURL = processedFolderURL.appendingPathComponent(identifier)
+      let fileExistsRepresentation = getFileExistsRepresentation(
+        identifier: identifier,
+        fileURL: fileURL,
+        remoteIdentifiers: remoteIdentifiers
+      )
+      let isLast = index == (identifiers.endIndex - 1)
+      let newNestedLevel = identifier.components(separatedBy: "/").count - 1
+      var horizontalSeparator = String(repeating: baseSeparator, count: newNestedLevel)
+
+      if nestedLevel != newNestedLevel || isLast || fileURL.isDirectoryFolder {
+        horizontalSeparator += horizontalSeparator + "`-- "
+      } else {
+        horizontalSeparator += horizontalSeparator +  "|-- "
+      }
+
+      libraryRepresentation += "\(horizontalSeparator)\(fileExistsRepresentation) \(fileURL.lastPathComponent)\n"
+
+      nestedLevel = newNestedLevel
+    }
+
+    return libraryRepresentation
+  }
+
+  func getFileExistsRepresentation(
+    identifier: String,
+    fileURL: URL,
+    remoteIdentifiers: [String]?
+  ) -> String {
+    let localRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
+    ? "[✓]"
+    : "[𐄂]"
+
+    guard let remoteIdentifiers else {
+      return localRepresentation
+    }
+
+    if remoteIdentifiers.contains(identifier) {
+      return localRepresentation + "[☑]"
+    } else {
+      return localRepresentation + "[☐]"
+    }
   }
 }

--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -143,10 +143,18 @@ class SettingsViewModel: ViewModelProtocol {
 
         let localidentifiers = libraryService.fetchIdentifiers()
 
-        let libraryRepresentation = getLibraryRepresentation(
+        var libraryRepresentation = getLibraryRepresentation(
           localidentifiers: localidentifiers,
           remoteIdentifiers: remoteIdentifiers
         )
+
+        if let remoteIdentifiers,
+           let remoteOnlyInfo = getRemoteOnlyInformation(
+            localidentifiers: localidentifiers,
+            remoteIdentifiers: remoteIdentifiers
+           ) {
+          libraryRepresentation += remoteOnlyInfo
+        }
 
         sendEvent(.showLoader(flag: false))
         onTransition?(.debugFiles(libraryRepresentation: libraryRepresentation))
@@ -168,7 +176,7 @@ class SettingsViewModel: ViewModelProtocol {
   ) -> String {
     let identifiers = libraryService.fetchIdentifiers()
 
-    var libraryRepresentation = ".\n"
+    var libraryRepresentation = "Library\n.\n"
     let processedFolderURL = DataManager.getProcessedFolderURL()
 
     let baseSeparator = "|   "
@@ -217,5 +225,26 @@ class SettingsViewModel: ViewModelProtocol {
     } else {
       return localRepresentation + "[☐]"
     }
+  }
+
+  func getRemoteOnlyInformation(
+    localidentifiers: [String],
+    remoteIdentifiers: [String]
+  ) -> String? {
+    var remoteOnlyIdentifiers = Array(Set(remoteIdentifiers).subtracting(Set(localidentifiers)))
+
+    guard !remoteOnlyIdentifiers.isEmpty else {
+      return nil
+    }
+
+    remoteOnlyIdentifiers.sort(by: { $0.localizedStandardCompare($1) == ComparisonResult.orderedAscending })
+
+    var remoteInfo = "\n\nRemote only items:\n"
+
+    for remoteOnlyIdentifier in remoteOnlyIdentifiers {
+      remoteInfo += "\(remoteOnlyIdentifier)\n"
+    }
+
+    return remoteInfo
   }
 }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -130,6 +130,10 @@ public protocol LibraryServiceProtocol {
   func addNote(_ note: String, bookmark: SimpleBookmark)
   /// Delete a bookmark
   func deleteBookmark(_ bookmark: SimpleBookmark)
+
+  /// Get a representation of the library like with the `tree` command
+  /// Note: '✓' means the backing file exists, and '𐄂' that it's missing locally
+  func getLibraryRepresentation() -> String
 }
 
 // swiftlint:disable force_cast
@@ -1079,7 +1083,11 @@ extension LibraryService {
     }
 
     try? removeFolderIfNeeded(destinationURL, context: context)
-    try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: false, attributes: nil)
+    try FileManager.default.createDirectory(
+      at: destinationURL,
+      withIntermediateDirectories: true,
+      attributes: nil
+    )
   }
 
   func createFolderOnDisk(title: String, inside relativePath: String?) throws {
@@ -1819,3 +1827,117 @@ extension LibraryService {
   }
 }
 // swiftlint:enable force_cast
+
+// MARK: - Debug functionality
+extension LibraryService {
+  public func getLibraryRepresentation() -> String {
+    let contents = fetchRawContents(
+      at: nil,
+      propertiesToFetch: [
+        #keyPath(LibraryItem.relativePath),
+        #keyPath(LibraryItem.type)
+      ]
+    ) ?? []
+
+    var libraryRepresentation = ".\n"
+    let processedFolderURL = DataManager.getProcessedFolderURL()
+
+    for (index, item) in contents.enumerated() {
+      let itemRepresentation: String
+
+      switch item.type {
+      case .book:
+        itemRepresentation = processBookRepresentation(
+          item.relativePath,
+          isLast: index == (contents.endIndex - 1),
+          processedFolderURL: processedFolderURL
+        )
+      case .folder, .bound:
+        itemRepresentation = processFolderRepresentation(
+          item.relativePath,
+          nestedLevel: 0,
+          processedFolderURL: processedFolderURL
+        )
+      }
+
+      libraryRepresentation += itemRepresentation + "\n"
+    }
+
+    return libraryRepresentation
+  }
+
+  private func processFolderRepresentation(
+    _ relativePath: String,
+    nestedLevel: Int,
+    processedFolderURL: URL
+  ) -> String {
+    let contents = fetchRawContents(
+      at: relativePath,
+      propertiesToFetch: [
+        #keyPath(LibraryItem.relativePath),
+        #keyPath(LibraryItem.type)
+      ]
+    ) ?? []
+
+    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
+    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
+    ? "✓"
+    : "𐄂"
+
+    let baseSeparator = "|   "
+    var horizontalSeparator = String(repeating: baseSeparator, count: nestedLevel)
+    var folderRepresentation = horizontalSeparator + "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    horizontalSeparator += baseSeparator
+
+    if !contents.isEmpty {
+      folderRepresentation += "\n"
+    }
+
+    for (index, item) in contents.enumerated() {
+      let itemRepresentation: String
+      let isLast = index == (contents.endIndex - 1)
+
+      switch item.type {
+      case .book:
+        let bookRepresentation = processBookRepresentation(
+          item.relativePath,
+          isLast: isLast,
+          processedFolderURL: processedFolderURL
+        )
+
+        itemRepresentation = horizontalSeparator + bookRepresentation
+      case .folder, .bound:
+        itemRepresentation = processFolderRepresentation(
+          item.relativePath,
+          nestedLevel: nestedLevel + 1,
+          processedFolderURL: processedFolderURL
+        )
+      }
+
+      if isLast {
+        folderRepresentation += itemRepresentation
+      } else {
+        folderRepresentation += itemRepresentation + "\n"
+      }
+    }
+
+    return folderRepresentation
+  }
+
+  private func processBookRepresentation(
+    _ relativePath: String,
+    isLast: Bool,
+    processedFolderURL: URL
+  ) -> String {
+    let fileURL = processedFolderURL.appendingPathComponent(relativePath)
+    let fileExistsRepresentation = FileManager.default.fileExists(atPath: fileURL.path)
+    ? "✓"
+    : "𐄂"
+
+    if isLast {
+      return "`-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    } else {
+      return "|-- \(fileURL.lastPathComponent) \(fileExistsRepresentation)"
+    }
+  }
+}

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -40,6 +40,9 @@ public protocol SyncServiceProtocol {
 
   func syncBookmarksList(relativePath: String) async throws -> [SimpleBookmark]?
 
+  /// Fetch the remote synced identifiers
+  func fetchSyncedIdentifiers() async throws -> [String]
+
   func getRemoteFileURLs(
     of relativePath: String,
     type: SimpleItemType
@@ -270,7 +273,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     return libraryService.getBookmarks(of: .user, relativePath: relativePath)
   }
 
-  func fetchSyncedIdentifiers() async throws -> [String] {
+  public func fetchSyncedIdentifiers() async throws -> [String] {
     let response: IdentifiersResponse = try await self.provider.request(.syncedIdentifiers)
 
     return response.content


### PR DESCRIPTION
## Purpose

- Expose a way to export data for easier debugging when there's an issue

## Approach

- Add new `LibraryRepresentationActivityItemProvider` to export the library hierarchy representation in a txt file

## Things to be aware of / Things to focus on

- I'll update this PR later to include sync logs on a file in a cached folder

## Screenshots

![IMG_1996](https://github.com/TortugaPower/BookPlayer/assets/14112819/0532b529-8d87-45d0-b8a2-83259e5a6eca)


