### PR TITLE
[BookPlayerShareExtension] Fix app group entitlement

### DIFF
--- a/BookPlayerShareExtension/BookPlayerShareExtension.entitlements
+++ b/BookPlayerShareExtension/BookPlayerShareExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.tortugapower.audiobookplayer.files</string>
+		<string>group.$(BP_BUNDLE_IDENTIFIER).files</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Currently hard coded to tortugapower. Updated to use BP_BUNDLE_IDENTIFIER

## Bugfix

- Fix ShareExtension app group entitlement from hard coded value