### PR TITLE
Add sync operations info to shareable debug information

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
 		639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
+		63B3B6902B1F625B007A367C /* StorageCloudDeletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */; };
 		63C1A8AF2B09158600C4B418 /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
 		63C1A8B02B0915EE00C4B418 /* WidgetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418445C2258AE11E0072DD13 /* WidgetUtils.swift */; };
 		63C1A8B12B09165400C4B418 /* RecentBooksWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41ADD6D92570AC6300660C64 /* RecentBooksWidgetView.swift */; };
@@ -1085,6 +1086,7 @@
 		63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackPerformanceTests.swift; sourceTree = "<group>"; };
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
 		639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPDownloadURLSession.swift; sourceTree = "<group>"; };
+		63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCloudDeletedView.swift; sourceTree = "<group>"; };
 		63F828562AED56FA00B5CE0C /* CornerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerView.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
@@ -1430,9 +1432,10 @@
 			children = (
 				4124122926D19B9100B099DB /* StorageItem.swift */,
 				4124122726D19A8600B099DB /* StorageViewModel.swift */,
-				9F2E00DD2A5C2B810001FE20 /* StorageCloudDeletedViewModel.swift */,
 				D6BA8F152A4CA94800C2BD9A /* StorageRowView.swift */,
 				D6BA8F172A4D66CD00C2BD9A /* StorageView.swift */,
+				9F2E00DD2A5C2B810001FE20 /* StorageCloudDeletedViewModel.swift */,
+				63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -3384,6 +3387,7 @@
 				41B2A5DE21CAF20E00917584 /* ThemesViewController.swift in Sources */,
 				41D20DAF25D5F5A100AAEE30 /* MappingModel_v1_to_v2.xcmappingmodel in Sources */,
 				9FF383D12A40F97000BBAC11 /* MappingModel_v8_to_v9.xcmappingmodel in Sources */,
+				63B3B6902B1F625B007A367C /* StorageCloudDeletedView.swift in Sources */,
 				9F134605293D0A410089B1DE /* ThemeViewModel.swift in Sources */,
 				41188D2A26ED4D8E0017124E /* ItemListViewModel.swift in Sources */,
 				C398559C20C492FF00BE9EC0 /* AddButton.swift in Sources */,

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -5128,7 +5128,7 @@
 			repositoryURL = "https://github.com/devicekit/DeviceKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.2.1;
+				minimumVersion = 5.1.0;
 			};
 		};
 		41F1A1F0254B09020043FCF3 /* XCRemoteSwiftPackageReference "IDZSwiftCommonCrypto" */ = {

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 		6356F9D02ACB01C700B7A027 /* PausePlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */; };
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
-		635907A02B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */; };
+		635907A02B161B14002FA524 /* DebugInformationActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */; };
 		637609192ADCD81400A01D5D /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6376091B2ADCD81400A01D5D /* AppShortcuts.strings */; };
 		637DAB0B2AEB3F6D006DC2D1 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		637DAB0D2AEBEF1B006DC2D1 /* BookPlayerWatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */; };
@@ -1058,7 +1058,7 @@
 		6356F9C92AC8A1B700B7A027 /* DatabaseInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseInitializer.swift; sourceTree = "<group>"; };
 		6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PausePlaybackIntent.swift; sourceTree = "<group>"; };
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
-		6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRepresentationActivityItemProvider.swift; sourceTree = "<group>"; };
+		6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInformationActivityItemProvider.swift; sourceTree = "<group>"; };
 		6376091A2ADCD81400A01D5D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091C2ADCD82100A01D5D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091D2ADCD82100A01D5D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
@@ -2090,7 +2090,7 @@
 				419723FF21874D5F00AB1190 /* UserActivityManager.swift */,
 				41D39D40215F177D00B65290 /* BookActivityItemProvider.swift */,
 				9FC1A29E28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift */,
-				6359079F2B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift */,
+				6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */,
 				41B30A32230232D200025D69 /* CarPlayManager.swift */,
 				4193E201243A91AE004D6A82 /* ActionParserService.swift */,
 				9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */,
@@ -3396,7 +3396,7 @@
 				416AAC3323F51031005AD04F /* LocalizableButton.swift in Sources */,
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,
-				635907A02B161B14002FA524 /* LibraryRepresentationActivityItemProvider.swift in Sources */,
+				635907A02B161B14002FA524 /* DebugInformationActivityItemProvider.swift in Sources */,
 				9F5FBB0A293EE0C2009F4B0E /* ItemDetailsViewModel.swift in Sources */,
 				6309F1262B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift in Sources */,
 				9FC1A29F28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift in Sources */,

--- a/BookPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BookPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/devicekit/DeviceKit.git",
       "state" : {
-        "revision" : "d37e70cb2646666dcf276d7d3d4a9760a41ff8a6",
-        "version" : "4.9.0"
+        "revision" : "66837ecf1516e41fd4251bbb684dc4b1997f08ab",
+        "version" : "5.1.0"
       }
     },
     {

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -300,3 +300,4 @@ We're working hard on providing a seamless experience, if possible, please conta
 "intent_lastbook_play_title" = "Resume last played book";
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
+"storage_artwork_cache_title" = "Artwork cache size";

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -301,3 +301,4 @@ We're working hard on providing a seamless experience, if possible, please conta
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
 "storage_artwork_cache_title" = "Artwork cache size";
+"settings_share_debug_information" = "Share debug information";

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -111,7 +111,7 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
       }
     }
 
-    let vc = UIHostingController(rootView: StorageView(viewModel: viewModel))
+    let vc = UIHostingController(rootView: StorageCloudDeletedView(viewModel: viewModel))
     let nav = AppNavigationController(rootViewController: vc)
     flow.navigationController.present(nav, animated: true)
   }

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -55,8 +55,8 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
         self.showTipJar()
       case .credits:
         self.showCredits()
-      case .debugFiles(let libraryRepresentation):
-        self.shareDebugFiles(libraryRepresentation: libraryRepresentation)
+      case .shareDebugInformation(let info):
+        self.shareDebugInformation(info: info)
       }
     }
 
@@ -217,8 +217,8 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
     flow.navigationController.present(nav, animated: true)
   }
 
-  func shareDebugFiles(libraryRepresentation: String) {
-    let provider = LibraryRepresentationActivityItemProvider(libraryRepresentation: libraryRepresentation)
+  func shareDebugInformation(info: String) {
+    let provider = DebugInformationActivityItemProvider(info: info)
 
     let shareController = UIActivityViewController(activityItems: [provider], applicationActivities: nil)
 

--- a/BookPlayer/Services/DebugInformationActivityItemProvider.swift
+++ b/BookPlayer/Services/DebugInformationActivityItemProvider.swift
@@ -1,5 +1,5 @@
 //
-//  LibraryRepresentationActivityItemProvider.swift
+//  DebugInformationActivityItemProvider.swift
 //  BookPlayer
 //
 //  Created by Gianni Carlo on 28/11/23.
@@ -9,11 +9,11 @@
 import BookPlayerKit
 import Foundation
 
-final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
-  let libraryRepresentation: String
+final class DebugInformationActivityItemProvider: UIActivityItemProvider {
+  let info: String
 
-  init(libraryRepresentation: String) {
-    self.libraryRepresentation = libraryRepresentation
+  init(info: String) {
+    self.info = info
     super.init(placeholderItem: URL(fileURLWithPath: "placeholder.txt"))
   }
 
@@ -21,7 +21,7 @@ final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
     _ activityViewController: UIActivityViewController,
     itemForActivityType activityType: UIActivity.ActivityType?
   ) -> Any? {
-    let fileTitle = "library_hierarchy_tree.txt"
+    let fileTitle = "bookplayer_debug_information.txt"
     let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileTitle)
 
     do {
@@ -29,7 +29,7 @@ final class LibraryRepresentationActivityItemProvider: UIActivityItemProvider {
         try FileManager.default.removeItem(at: fileURL)
       }
 
-      let contentsData = libraryRepresentation.data(using: .utf8)
+      let contentsData = info.data(using: .utf8)
       FileManager.default.createFile(atPath: fileURL.path, contents: contentsData)
     } catch {
       return nil

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -324,7 +324,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Last played book" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Hf-KW-kuZ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Last played book" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Hf-KW-kuZ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -341,11 +341,11 @@
                                         <rect key="frame" x="0.0" y="957.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eGV-vo-55W" id="fIX-20-CXK">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sleep Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BsZ-qn-RYs" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Sleep Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BsZ-qn-RYs" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="0.0" width="340.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -368,13 +368,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ssf-Q5-vn2">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ssf-Q5-vn2">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="9Gr-mL-Nfy"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Include book files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rRx-5f-ZeW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Include book files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rRx-5f-ZeW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -408,13 +408,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fvX-JA-Us2">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fvX-JA-Us2">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="vCo-kk-ggY"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable crash reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="BI5-jj-QYz" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Disable crash reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="BI5-jj-QYz" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -443,13 +443,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SyN-Fu-K5b">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SyN-Fu-K5b">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="7V8-9T-0Tl"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable SKAN attribution" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="DOq-C5-tRv" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Disable SKAN attribution" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="DOq-C5-tRv" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -482,8 +482,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Tip Jar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MVf-CT-ocr" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Tip Jar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MVf-CT-ocr" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -505,8 +505,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Send us an email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nCM-M8-bSw" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="9" width="129" height="20.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Send us an email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nCM-M8-bSw" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="9" width="129" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -515,8 +515,8 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_email_title"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="support@bookplayer.app" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6ow-P5-iYK">
-                                                    <rect key="frame" x="16" y="29.5" width="121" height="12"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="support@bookplayer.app" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6ow-P5-iYK">
+                                                    <rect key="frame" x="8" y="29.5" width="121" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <nil key="textColor"/>
@@ -536,14 +536,14 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Debug Files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7ap-vd-Uq1" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Share debug information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7ap-vd-Uq1" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                     <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="Debug Files"/>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_share_debug_information"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                             </subviews>
@@ -559,8 +559,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View project on GitHub" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ClD-F6-XBV" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="9" width="176" height="20.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="View project on GitHub" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ClD-F6-XBV" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="9" width="176" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -569,8 +569,8 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_support_project_title"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open new issues for your feature requests and errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="p5a-8D-TIK" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="29.5" width="257" height="12"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Open new issues for your feature requests and errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="p5a-8D-TIK" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="29.5" width="257" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <nil key="textColor"/>
@@ -594,11 +594,11 @@
                                         <rect key="frame" x="0.0" y="1589" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="03X-zP-RZe" id="IIp-cC-U1k">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Credits and Licenses" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="f5k-Kh-fBQ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Credits and Licenses" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="f5k-Kh-fBQ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="0.0" width="340.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -264,7 +264,7 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
     case self.supportEmailPath:
       self.sendSupportEmail()
     case self.debugFilesPath:
-      self.shareDebugFiles()
+      self.shareDebugInformation()
     case self.githubLinkPath:
       self.showProjectOnGitHub()
     case self.lastPlayedShortcutPath:
@@ -440,8 +440,8 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
     }
   }
 
-  func shareDebugFiles() {
-    viewModel.shareDebugFiles()
+  func shareDebugInformation() {
+    viewModel.shareDebugInformation()
   }
 
   func showProjectOnGitHub() {

--- a/BookPlayer/Settings/Storage/StorageCloudDeletedView.swift
+++ b/BookPlayer/Settings/Storage/StorageCloudDeletedView.swift
@@ -1,15 +1,15 @@
 //
-//  StorageView.swift
+//  StorageCloudDeletedView.swift
 //  BookPlayer
 //
-//  Created by Dmitrij Hojkolov on 29.06.2023.
+//  Created by Gianni Carlo on 5/12/23.
 //  Copyright © 2023 Tortuga Power. All rights reserved.
 //
 
 import SwiftUI
 import BookPlayerKit
 
-struct StorageView<Model: StorageViewModelProtocol>: View {
+struct StorageCloudDeletedView<Model: StorageCloudDeletedViewModelProtocol>: View {
 
   @StateObject var themeViewModel = ThemeViewModel()
   @ObservedObject var viewModel: Model
@@ -31,23 +31,7 @@ struct StorageView<Model: StorageViewModelProtocol>: View {
 
             Spacer()
 
-            Text(viewModel.getTotalFoldersSize())
-              .foregroundColor(themeViewModel.secondaryColor)
-          }
-          .padding(.horizontal, 16)
-          .padding(.top, 4)
-          .accessibilityElement(children: .combine)
-
-          Divider()
-            .background(themeViewModel.separatorColor)
-
-          HStack(alignment: .center) {
-            Text("storage_artwork_cache_title".localized)
-              .foregroundColor(themeViewModel.primaryColor)
-
-            Spacer()
-
-            Text(viewModel.getArtworkFolderSize())
+            Text(viewModel.getFolderSize())
               .foregroundColor(themeViewModel.secondaryColor)
           }
           .padding(.horizontal, 16)
@@ -158,8 +142,8 @@ struct StorageView<Model: StorageViewModelProtocol>: View {
   }
 }
 
-struct StorageView_Previews: PreviewProvider {
-  class MockStorageViewModel: StorageViewModelProtocol, ObservableObject {
+struct StorageCloudDeletedView_Previews: PreviewProvider {
+  class MockStorageViewModel: StorageCloudDeletedViewModelProtocol, ObservableObject {
     var folderURL: URL { URL(string: "file://")! }
     var navigationTitle: String = "Files"
     var publishedFiles: [StorageItem] = []
@@ -171,11 +155,10 @@ struct StorageView_Previews: PreviewProvider {
     var alert: Alert { Alert(title: Text("")) }
     let fixButtonTitle = "Fix all"
 
-    func getTotalFoldersSize() -> String { return "0 Kb" }
-    func getArtworkFolderSize() -> String { return "0 Kb" }
+    func getFolderSize() -> String { return "0 Kb" }
     func dismiss() {}
   }
   static var previews: some View {
-    StorageView(viewModel: MockStorageViewModel())
+    StorageCloudDeletedView(viewModel: MockStorageViewModel())
   }
 }

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "لا يوجد كتاب آخر تم تشغيله";
 "intent_playback_pause_title" = "إيقاف التشغيل مؤقتًا";
 "storage_artwork_cache_title" = "حجم ذاكرة التخزين المؤقت للعمل الفني";
+"settings_share_debug_information" = "مشاركة معلومات التصحيح";

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "استئناف آخر كتاب تم تشغيله";
 "intent_lastbook_empty_error" = "لا يوجد كتاب آخر تم تشغيله";
 "intent_playback_pause_title" = "إيقاف التشغيل مؤقتًا";
+"storage_artwork_cache_title" = "حجم ذاكرة التخزين المؤقت للعمل الفني";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Obnovit naposledy přehrávanou knihu";
 "intent_lastbook_empty_error" = "Neexistuje žádná naposledy hraná kniha";
 "intent_playback_pause_title" = "Pozastavit přehrávání";
+"storage_artwork_cache_title" = "Velikost mezipaměti uměleckých děl";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Neexistuje žádná naposledy hraná kniha";
 "intent_playback_pause_title" = "Pozastavit přehrávání";
 "storage_artwork_cache_title" = "Velikost mezipaměti uměleckých děl";
+"settings_share_debug_information" = "Sdílejte informace o ladění";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Der er ingen sidst spillet bog";
 "intent_playback_pause_title" = "Sæt afspilning på pause";
 "storage_artwork_cache_title" = "Artwork cache størrelse";
+"settings_share_debug_information" = "Del fejlretningsoplysninger";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Genoptag sidste spillede bog";
 "intent_lastbook_empty_error" = "Der er ingen sidst spillet bog";
 "intent_playback_pause_title" = "Sæt afspilning på pause";
+"storage_artwork_cache_title" = "Artwork cache størrelse";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Setzen Sie das zuletzt gespielte Buch fort";
 "intent_lastbook_empty_error" = "Es gibt kein zuletzt gespieltes Buch";
 "intent_playback_pause_title" = "Wiedergabe anhalten";
+"storage_artwork_cache_title" = "Größe des Grafik-Cache";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Es gibt kein zuletzt gespieltes Buch";
 "intent_playback_pause_title" = "Wiedergabe anhalten";
 "storage_artwork_cache_title" = "Größe des Grafik-Cache";
+"settings_share_debug_information" = "Teilen Sie Debug-Informationen";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -300,3 +300,4 @@ We're working hard on providing a seamless experience, if possible, please conta
 "intent_lastbook_play_title" = "Resume last played book";
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
+"storage_artwork_cache_title" = "Artwork cache size";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -301,3 +301,4 @@ We're working hard on providing a seamless experience, if possible, please conta
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
 "storage_artwork_cache_title" = "Artwork cache size";
+"settings_share_debug_information" = "Share debug information";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "No hay ningún último libro reproducido";
 "intent_playback_pause_title" = "Pausar la reproducción";
 "storage_artwork_cache_title" = "Tamaño de caché de ilustraciones";
+"settings_share_debug_information" = "Compartir información de depuración";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Reanudar el último libro reproducido";
 "intent_lastbook_empty_error" = "No hay ningún último libro reproducido";
 "intent_playback_pause_title" = "Pausar la reproducción";
+"storage_artwork_cache_title" = "Tamaño de caché de ilustraciones";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Jatka viimeksi toistettua kirjaa";
 "intent_lastbook_empty_error" = "Ei ole viimeksi pelattua kirjaa";
 "intent_playback_pause_title" = "Keskeytä toisto";
+"storage_artwork_cache_title" = "Taideteoksen välimuistin koko";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Ei ole viimeksi pelattua kirjaa";
 "intent_playback_pause_title" = "Keskeytä toisto";
 "storage_artwork_cache_title" = "Taideteoksen välimuistin koko";
+"settings_share_debug_information" = "Jaa virheenkorjaustiedot";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Il n'y a pas de dernier livre joué";
 "intent_playback_pause_title" = "Suspendre la lecture";
 "storage_artwork_cache_title" = "Taille du cache des illustrations";
+"settings_share_debug_information" = "Partager les informations de débogage";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Reprendre le dernier livre lu";
 "intent_lastbook_empty_error" = "Il n'y a pas de dernier livre joué";
 "intent_playback_pause_title" = "Suspendre la lecture";
+"storage_artwork_cache_title" = "Taille du cache des illustrations";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Nincs utoljára játszott könyv";
 "intent_playback_pause_title" = "Lejátszás szüneteltetése";
 "storage_artwork_cache_title" = "Az alkotás gyorsítótár mérete";
+"settings_share_debug_information" = "Ossza meg a hibakeresési információkat";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Utoljára lejátszott könyv folytatása";
 "intent_lastbook_empty_error" = "Nincs utoljára játszott könyv";
 "intent_playback_pause_title" = "Lejátszás szüneteltetése";
+"storage_artwork_cache_title" = "Az alkotás gyorsítótár mérete";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Non c'è l'ultimo libro giocato";
 "intent_playback_pause_title" = "Mettere in pausa la riproduzione";
 "storage_artwork_cache_title" = "Dimensioni della cache della grafica";
+"settings_share_debug_information" = "Condividi le informazioni di debug";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Riprendi l'ultimo libro riprodotto";
 "intent_lastbook_empty_error" = "Non c'è l'ultimo libro giocato";
 "intent_playback_pause_title" = "Mettere in pausa la riproduzione";
+"storage_artwork_cache_title" = "Dimensioni della cache della grafica";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -300,3 +300,4 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "intent_lastbook_play_title" = "Fortsett sist spilte bok";
 "intent_lastbook_empty_error" = "Det er ingen sist spilte bok";
 "intent_playback_pause_title" = "Sett avspilling på pause";
+"storage_artwork_cache_title" = "Artwork cache-størrelse";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -301,3 +301,4 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "intent_lastbook_empty_error" = "Det er ingen sist spilte bok";
 "intent_playback_pause_title" = "Sett avspilling på pause";
 "storage_artwork_cache_title" = "Artwork cache-størrelse";
+"settings_share_debug_information" = "Del feilsøkingsinformasjon";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Er is geen laatst gespeeld boek";
 "intent_playback_pause_title" = "Pauzeer het afspelen";
 "storage_artwork_cache_title" = "Grootte van de artworkcache";
+"settings_share_debug_information" = "Deel foutopsporingsinformatie";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Hervat het laatst gespeelde boek";
 "intent_lastbook_empty_error" = "Er is geen laatst gespeeld boek";
 "intent_playback_pause_title" = "Pauzeer het afspelen";
+"storage_artwork_cache_title" = "Grootte van de artworkcache";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Wznów ostatnio odtwarzaną książkę";
 "intent_lastbook_empty_error" = "Nie ma ostatnio odtwarzanej książki";
 "intent_playback_pause_title" = "Wstrzymaj odtwarzanie";
+"storage_artwork_cache_title" = "Rozmiar pamięci podręcznej grafiki";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Nie ma ostatnio odtwarzanej książki";
 "intent_playback_pause_title" = "Wstrzymaj odtwarzanie";
 "storage_artwork_cache_title" = "Rozmiar pamięci podręcznej grafiki";
+"settings_share_debug_information" = "Udostępnij informacje debugowania";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Retomar o último livro jogado";
 "intent_lastbook_empty_error" = "Não há último livro jogado";
 "intent_playback_pause_title" = "Pausar a reprodução";
+"storage_artwork_cache_title" = "Tamanho do cache de arte";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Não há último livro jogado";
 "intent_playback_pause_title" = "Pausar a reprodução";
 "storage_artwork_cache_title" = "Tamanho do cache de arte";
+"settings_share_debug_information" = "Compartilhe informações de depuração";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Resume last played book";
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
+"storage_artwork_cache_title" = "Tamanho do cache de arte";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "There's no last played book";
 "intent_playback_pause_title" = "Pause playback";
 "storage_artwork_cache_title" = "Tamanho do cache de arte";
+"settings_share_debug_information" = "Compartilhe informações de depuração";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Reluați ultima carte jucată";
 "intent_lastbook_empty_error" = "Nu există ultima carte jucată";
 "intent_playback_pause_title" = "Întrerupeți redarea";
+"storage_artwork_cache_title" = "Dimensiunea memoriei cache a lucrărilor de artă";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Nu există ultima carte jucată";
 "intent_playback_pause_title" = "Întrerupeți redarea";
 "storage_artwork_cache_title" = "Dimensiunea memoriei cache a lucrărilor de artă";
+"settings_share_debug_information" = "Partajați informațiile de depanare";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Возобновить последнюю воспроизведенную книгу";
 "intent_lastbook_empty_error" = "Нет последней прослушанной книги";
 "intent_playback_pause_title" = "Пауза воспроизведения";
+"storage_artwork_cache_title" = "Размер кэша иллюстраций";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Нет последней прослушанной книги";
 "intent_playback_pause_title" = "Пауза воспроизведения";
 "storage_artwork_cache_title" = "Размер кэша иллюстраций";
+"settings_share_debug_information" = "Делитесь отладочной информацией";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -300,3 +300,4 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "intent_lastbook_play_title" = "Obnovenie poslednej prehrávanej knihy";
 "intent_lastbook_empty_error" = "Žiadna naposledy prehrávaná kniha";
 "intent_playback_pause_title" = "Pozastavenie prehrávanie";
+"storage_artwork_cache_title" = "Veľkosť vyrovnávacej pamäte umeleckých diel";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -301,3 +301,4 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "intent_lastbook_empty_error" = "Žiadna naposledy prehrávaná kniha";
 "intent_playback_pause_title" = "Pozastavenie prehrávanie";
 "storage_artwork_cache_title" = "Veľkosť vyrovnávacej pamäte umeleckých diel";
+"settings_share_debug_information" = "Zdieľajte informácie o ladení";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -300,5 +300,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "intent_lastbook_play_title" = "Obnovenie poslednej prehrávanej knihy";
 "intent_lastbook_empty_error" = "Žiadna naposledy prehrávaná kniha";
 "intent_playback_pause_title" = "Pozastavenie prehrávanie";
-"storage_artwork_cache_title" = "Veľkosť vyrovnávacej pamäte umeleckých diel";
-"settings_share_debug_information" = "Zdieľajte informácie o ladení";
+"storage_artwork_cache_title" = "Veľkosť vyrovnávacej pamäte obalov kníh";
+"settings_share_debug_information" = "Zdieľať informácie o ladení";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Återuppta senast spelade bok";
 "intent_lastbook_empty_error" = "Det finns ingen senast spelad bok";
 "intent_playback_pause_title" = "Pausa uppspelningen";
+"storage_artwork_cache_title" = "Artwork cachestorlek";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Det finns ingen senast spelad bok";
 "intent_playback_pause_title" = "Pausa uppspelningen";
 "storage_artwork_cache_title" = "Artwork cachestorlek";
+"settings_share_debug_information" = "Dela felsökningsinformation";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Son çalınan kitap yok";
 "intent_playback_pause_title" = "Oynatmayı duraklat";
 "storage_artwork_cache_title" = "Resim önbellek boyutu";
+"settings_share_debug_information" = "Hata ayıklama bilgilerini paylaşın";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Son oynatılan kitabı devam ettir";
 "intent_lastbook_empty_error" = "Son çalınan kitap yok";
 "intent_playback_pause_title" = "Oynatmayı duraklat";
+"storage_artwork_cache_title" = "Resim önbellek boyutu";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "Відновити останню відтворену книгу";
 "intent_lastbook_empty_error" = "Немає останньої програної книги";
 "intent_playback_pause_title" = "Призупинити відтворення";
+"storage_artwork_cache_title" = "Розмір кеша ілюстрації";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "Немає останньої програної книги";
 "intent_playback_pause_title" = "Призупинити відтворення";
 "storage_artwork_cache_title" = "Розмір кеша ілюстрації";
+"settings_share_debug_information" = "Поділіться інформацією про налагодження";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -301,3 +301,4 @@
 "intent_lastbook_empty_error" = "没有最后玩过的书";
 "intent_playback_pause_title" = "暂停播放";
 "storage_artwork_cache_title" = "艺术品缓存大小";
+"settings_share_debug_information" = "共享调试信息";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -300,3 +300,4 @@
 "intent_lastbook_play_title" = "继续上次播放的书";
 "intent_lastbook_empty_error" = "没有最后玩过的书";
 "intent_playback_pause_title" = "暂停播放";
+"storage_artwork_cache_title" = "艺术品缓存大小";

--- a/Shared/Artwork/ArtworkService.swift
+++ b/Shared/Artwork/ArtworkService.swift
@@ -11,14 +11,17 @@ import Kingfisher
 import UIKit
 
 public class ArtworkService {
-  static public var cache: ImageCache {
+  static public var cache: ImageCache = {
     let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)!
 
     let cache = try! ImageCache(name: "BookPlayer", cacheDirectoryURL: url)
     cache.diskStorage.config.expiration = .never
-
     return cache
-  }
+  }()
+
+  static public var cacheDirectoryURL: URL = {
+    return cache.diskStorage.directoryURL
+  }()
 
   static private var manager: KingfisherManager {
     return KingfisherManager(downloader: .default, cache: ArtworkService.cache)


### PR DESCRIPTION
## Purpose

- Append current sync operations info and profile email for the debug information file that can be generated and exported
- Include artwork cache key in storage management
- Update DeviceKit

## Things to be aware of / Things to focus on

- There may be a third part to this, where we store any errors of the sync operations on the client side and append that to the debug file