### PR TITLE
Fix local playback overriding progress while fetching remote progress

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -72,6 +72,18 @@ class FolderListCoordinator: ItemListCoordinator {
   }
 
   override func syncList() {
+    let userDefaultsKey = "\(Constants.UserDefaults.lastSyncTimestamp)_\(folderRelativePath)"
+    let now = Date().timeIntervalSince1970
+    let lastSync = UserDefaults.standard.double(forKey: userDefaultsKey)
+
+    /// Do not sync if one minute hasn't passed since last sync
+    guard now - lastSync > 60 else {
+      Self.logger.trace("Throttled sync operation")
+      return
+    }
+
+    UserDefaults.standard.set(now, forKey: userDefaultsKey)
+
     Task { @MainActor in
       do {
         _ = try await syncService.syncListContents(at: folderRelativePath)

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -89,6 +89,7 @@ class MainCoordinator: NSObject {
       playbackService: self.playbackService,
       syncService: syncService
     )
+    playerManager.syncProgressDelegate = libraryCoordinator
     self.libraryCoordinator = libraryCoordinator
     libraryCoordinator.tabBarController = tabBarController
     libraryCoordinator.start()

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1085,6 +1085,7 @@ class PlayerManagerProtocolMock: PlayerManagerProtocol {
         set(value) { underlyingIsPlaying = value }
     }
     var underlyingIsPlaying: Bool!
+    var syncProgressDelegate: PlaybackSyncProgressDelegate?
     //MARK: - load
 
     var loadAutoplayCallsCount = 0

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -8,7 +8,6 @@
 
 import Combine
 import Foundation
-import RevenueCat
 
 /// Sync errors that must be handled (not shown as alerts)
 public enum BPSyncError: Error {
@@ -163,20 +162,6 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasQueuedJobs) == false else {
       throw BookPlayerError.runtimeError("Can't fetch items while there are sync operations in progress")
     }
-
-    let userDefaultsKey = "\(Constants.UserDefaults.lastSyncTimestamp)_\(relativePath ?? "library")"
-    let now = Date().timeIntervalSince1970
-    let lastSync = UserDefaults.standard.double(forKey: userDefaultsKey)
-
-    /// Do not sync if one minute hasn't passed since last sync
-    guard now - lastSync > 60 else {
-      throw BookPlayerError.networkError("Throttled sync operation")
-    }
-
-    UserDefaults.standard.set(
-      Date().timeIntervalSince1970,
-      forKey: userDefaultsKey
-    )
 
     Self.logger.trace("Fetching list of contents")
 


### PR DESCRIPTION
## Bugfix

- When opening the app, if you start playback before the sync network call is finished, the app will ignore the fetched progress (as the local timestamp for playback is more recent)

## Approach

- Add new delegate for `PlayerManager`, and rework the play event, to await on this new delegate if it needs to finish an operation before resuming playback
- Make the `LibraryListCoordinator` the delegate for the player, so it keeps track of the current sync operation, and can await for the task to finish
- Extract from the sync service the 1-min cooldown check, and put that at the coordinator level so we avoid overriding the fetch task at the coordinator level