### PR TITLE
Fix translations displayed in Shortcuts app for list of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
     - name: Swiftlint
       run: swiftlint
     - name: Set Xcode version
-      run: sudo xcode-select -s "/Applications/Xcode_15.0.1.app/Contents/Developer"
+      run: sudo xcode-select -s "/Applications/Xcode_15.1.app/Contents/Developer"
     - name: Resolve dependencies
       run: xcodebuild -resolvePackageDependencies
     - name: Build and Run tests
-      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0.1'
-
+      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2'

--- a/BookPlayer/AppIntents/CancelSleepTimerIntent.swift
+++ b/BookPlayer/AppIntents/CancelSleepTimerIntent.swift
@@ -11,7 +11,7 @@ import AppIntents
 
 @available(iOS 16.4, macOS 14.0, watchOS 10.0, *)
 struct CancelSleepTimerIntent: AppIntent {
-  static var title: LocalizedStringResource = .init("intent_sleeptimer_cancel", table: "Localizable.strings")
+  static var title: LocalizedStringResource = "intent_sleeptimer_cancel"
 
   func perform() async throws -> some IntentResult {
     SleepTimer.shared.setTimer(.off)

--- a/BookPlayer/AppIntents/CustomSleepTimerIntent.swift
+++ b/BookPlayer/AppIntents/CustomSleepTimerIntent.swift
@@ -11,7 +11,7 @@ import AppIntents
 
 @available(iOS 16.0, macOS 14.0, watchOS 10.0, tvOS 16.0, *)
 struct CustomSleepTimerIntent: AppIntent {
-  static var title: LocalizedStringResource = .init("intent_sleeptimer_set_duration", table: "Localizable.strings")
+  static var title: LocalizedStringResource = "intent_sleeptimer_set_duration"
 
   @Parameter(
     title: LocalizedStringResource("duration_title"),

--- a/BookPlayer/AppIntents/EndChapterSleepTimerIntent.swift
+++ b/BookPlayer/AppIntents/EndChapterSleepTimerIntent.swift
@@ -11,7 +11,7 @@ import AppIntents
 
 @available(iOS 16.4, macOS 14.0, watchOS 10.0, *)
 struct EndChapterSleepTimerIntent: AppIntent {
-  static var title: LocalizedStringResource = .init("intent_sleeptimer_eoc_title", table: "Localizable.strings")
+  static var title: LocalizedStringResource = "intent_sleeptimer_eoc_title"
 
   func perform() async throws -> some IntentResult {
     SleepTimer.shared.setTimer(.endOfChapter)

--- a/BookPlayer/AppIntents/LastBookStartPlaybackIntent.swift
+++ b/BookPlayer/AppIntents/LastBookStartPlaybackIntent.swift
@@ -12,7 +12,7 @@ import BookPlayerKit
 
 @available(iOS 16.4, macOS 14.0, watchOS 10.0, *)
 struct LastBookStartPlaybackIntent: AudioStartingIntent, ForegroundContinuableIntent {
-  static var title: LocalizedStringResource = .init("intent_lastbook_play_title", table: "Localizable.strings")
+  static var title: LocalizedStringResource = "intent_lastbook_play_title"
 
   func perform() async throws -> some IntentResult {
     let stack = try await DatabaseInitializer().loadCoreDataStack()

--- a/BookPlayer/AppIntents/PausePlaybackIntent.swift
+++ b/BookPlayer/AppIntents/PausePlaybackIntent.swift
@@ -12,7 +12,7 @@ import BookPlayerKit
 
 @available(iOS 16.4, macOS 14.0, watchOS 10.0, *)
 struct PausePlaybackIntent: AudioStartingIntent, ForegroundContinuableIntent {
-  static var title: LocalizedStringResource = .init("intent_playback_pause_title", table: "Localizable.strings")
+  static var title: LocalizedStringResource = "intent_playback_pause_title"
 
   func perform() async throws -> some IntentResult {
     let stack = try await DatabaseInitializer().loadCoreDataStack()

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -72,17 +72,7 @@ class FolderListCoordinator: ItemListCoordinator {
   }
 
   override func syncList() {
-    let userDefaultsKey = "\(Constants.UserDefaults.lastSyncTimestamp)_\(folderRelativePath)"
-    let now = Date().timeIntervalSince1970
-    let lastSync = UserDefaults.standard.double(forKey: userDefaultsKey)
-
-    /// Do not sync if one minute hasn't passed since last sync
-    guard now - lastSync > 60 else {
-      Self.logger.trace("Throttled sync operation")
-      return
-    }
-
-    UserDefaults.standard.set(now, forKey: userDefaultsKey)
+    guard syncService.canSyncListContents(at: folderRelativePath) else { return }
 
     Task { @MainActor in
       do {

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -214,17 +214,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
   }
 
   override func syncList() {
-    let userDefaultsKey = "\(Constants.UserDefaults.lastSyncTimestamp)_library"
-    let now = Date().timeIntervalSince1970
-    let lastSync = UserDefaults.standard.double(forKey: userDefaultsKey)
-
-    /// Do not sync if one minute hasn't passed since last sync
-    guard now - lastSync > 60 else {
-      Self.logger.trace("Throttled sync operation")
-      return
-    }
-
-    UserDefaults.standard.set(now, forKey: userDefaultsKey)
+    guard syncService.canSyncListContents(at: nil) else { return }
 
     /// Create new task to sync the library and the last played
     contentsFetchTask?.cancel()

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1419,6 +1419,26 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
         set(value) { underlyingDownloadProgressPublisher = value }
     }
     var underlyingDownloadProgressPublisher: PassthroughSubject<(String, String, String?, Double), Never>!
+    //MARK: - canSyncListContents
+
+    var canSyncListContentsAtCallsCount = 0
+    var canSyncListContentsAtCalled: Bool {
+        return canSyncListContentsAtCallsCount > 0
+    }
+    var canSyncListContentsAtReceivedRelativePath: String?
+    var canSyncListContentsAtReceivedInvocations: [String?] = []
+    var canSyncListContentsAtReturnValue: Bool!
+    var canSyncListContentsAtClosure: ((String?) -> Bool)?
+    func canSyncListContents(at relativePath: String?) -> Bool {
+        canSyncListContentsAtCallsCount += 1
+        canSyncListContentsAtReceivedRelativePath = relativePath
+        canSyncListContentsAtReceivedInvocations.append(relativePath)
+        if let canSyncListContentsAtClosure = canSyncListContentsAtClosure {
+            return canSyncListContentsAtClosure(relativePath)
+        } else {
+            return canSyncListContentsAtReturnValue
+        }
+    }
     //MARK: - syncListContents
 
     var syncListContentsAtThrowableError: Error?

--- a/Shared/Artwork/AVAudioAssetImageDataProvider.swift
+++ b/Shared/Artwork/AVAudioAssetImageDataProvider.swift
@@ -120,19 +120,6 @@ public struct AVAudioAssetImageDataProvider: ImageDataProvider {
         files.append(fileURL)
       }
 
-      // sort items to same order as library
-      files.sort { a, b in
-        guard let first = a.getAppOrderRank() else {
-          return false
-        }
-
-        guard let second = b.getAppOrderRank() else {
-          return true
-        }
-
-        return first < second
-      }
-
       do {
         let data = try await processNextFolderItem(from: files)
 


### PR DESCRIPTION
## Bugfix

- The app intents were not being translated inside the Shortcuts app when showing the list of available actions

## Related tasks

#1057 

## Approach

- Remove the table parameter from the title's initialization

## Things to be aware of / Things to focus on

- I'm including a change related to the previous PR, it's just grouping the conditionals under a single function

## Screenshots

![IMG_9A104298B5D5-1](https://github.com/TortugaPower/BookPlayer/assets/14112819/db1399f0-f603-4f58-8a2e-4e2c58ac0486)
![IMG_BB00940A610B-1](https://github.com/TortugaPower/BookPlayer/assets/14112819/3c91166c-00a9-4412-a3d3-6680085706fa)

