### PR TITLE
Fix multiple reported issues

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -181,7 +181,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ relativePath: String,
     autoplay: Bool,
     showPlayer: (() -> Void)?,
-    alertPresenter: AlertPresenter
+    alertPresenter: AlertPresenter,
+    recordAsLastBook: Bool = true
   ) {
     Task { @MainActor in
       let fileURL = DataManager.getProcessedFolderURL().appendingPathComponent(relativePath)
@@ -224,6 +225,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       guard let item = item else { return }
 
       playerManager?.load(item, autoplay: autoplay)
+
+      if recordAsLastBook {
+        await libraryService?.setLibraryLastBook(with: item.relativePath)
+      }
 
       showPlayer?()
     }

--- a/BookPlayer/Base.lproj/Main.storyboard
+++ b/BookPlayer/Base.lproj/Main.storyboard
@@ -223,7 +223,7 @@
                                 <constraints>
                                     <constraint firstItem="GAA-F6-6lf" firstAttribute="leading" secondItem="oVP-SJ-Vkq" secondAttribute="leading" constant="12" id="G7I-0H-RUz"/>
                                     <constraint firstItem="GAA-F6-6lf" firstAttribute="top" secondItem="q8y-d7-HKX" secondAttribute="bottom" constant="16" id="Kdg-10-Xf3"/>
-                                    <constraint firstItem="q8y-d7-HKX" firstAttribute="centerY" secondItem="ine-tP-Is6" secondAttribute="centerY" constant="-50" id="LV4-lL-Boh"/>
+                                    <constraint firstItem="q8y-d7-HKX" firstAttribute="centerY" secondItem="ine-tP-Is6" secondAttribute="centerY" constant="-80" id="LV4-lL-Boh"/>
                                     <constraint firstAttribute="trailing" secondItem="GAA-F6-6lf" secondAttribute="trailing" constant="16" id="Tqt-AP-cw8"/>
                                     <constraint firstItem="ine-tP-Is6" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="GAA-F6-6lf" secondAttribute="bottom" id="Yl9-3o-iAe"/>
                                     <constraint firstItem="q8y-d7-HKX" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ine-tP-Is6" secondAttribute="top" id="jfg-AW-LQJ"/>

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -167,7 +167,8 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
           self?.showPlayer()
         }
       },
-      alertPresenter: self
+      alertPresenter: self,
+      recordAsLastBook: false
     )
   }
 

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -407,7 +407,6 @@ extension ItemListViewController: UITableViewDataSource {
     return self.viewModel.items.count
   }
 
-  // swiftlint:disable:next function_body_length
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard indexPath.sectionValue != .add,
           let cell = tableView.dequeueReusableCell(withIdentifier: "BookCellView", for: indexPath) as? BookCellView else {
@@ -452,20 +451,7 @@ extension ItemListViewController: UITableViewDataSource {
           remoteURL: item.remoteURL
         ),
         placeholder: defaultArtwork,
-        options: [.targetCache(ArtworkService.cache)]) { [weak self] result in
-          /// Cache default artwork if the provider errors out with .missingImage to avoid multiple
-          /// retries on files we know don't have an artwork for
-          guard
-            case .failure(let error) = result,
-            case .imageSettingError(let reason) = error,
-            case .dataProviderError(let provider, let error) = reason,
-            let providerError = error as? AVAudioAssetImageDataProvider.ProviderError,
-            providerError == .missingImage,
-            let artworkData = self?.viewModel.defaultArtwork
-          else { return }
-
-          ArtworkService.storeInCache(artworkData, for: provider.cacheKey)
-        }
+        options: [.targetCache(ArtworkService.cache)])
     }
     let label = VoiceOverService.getAccessibilityLabel(for: item)
     cell.setAccessibilityLabel(label)

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -379,7 +379,6 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
             let time = (currentItem.currentTime + 1) >= currentItem.duration ? 0 : currentItem.currentTime
             self.initializeChapterTime(time)
           }
-          self.libraryService.setLibraryLastBook(with: currentItem.relativePath)
         }
 
         NotificationCenter.default.post(name: .bookReady, object: nil, userInfo: ["loaded": true])
@@ -463,7 +462,12 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
   // MARK: - Player states
 
   var isPlaying: Bool {
-    return self.audioPlayer.timeControlStatus == .playing
+    let controlStatusFlag = audioPlayer.timeControlStatus != .paused
+    let playbackQueuedFlag = playbackQueued == true
+
+    return controlStatusFlag
+    || playbackQueuedFlag
+    || (isFetchingRemoteURL == true && playbackQueuedFlag)
   }
 
   /// We need an intermediate publisher for the `timeControlStatus`, as the `AVPlayer` instance can be recreated,

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -809,8 +809,10 @@ extension PlayerManager {
       self.playbackQueued = nil
     case .failed:
       if canFetchRemoteURL,
-        (item.error as? NSError)?.code == NSURLErrorResourceUnavailable,
-        let currentItem {
+         let nsError = item.error as? NSError,
+         (nsError.code == NSURLErrorResourceUnavailable
+          || nsError.code == NSURLErrorNoPermissionsToReadFile),
+         let currentItem {
         loadAndRefreshURL(item: currentItem)
         canFetchRemoteURL = false
       } else {

--- a/Shared/Artwork/AVAudioAssetImageDataProvider.swift
+++ b/Shared/Artwork/AVAudioAssetImageDataProvider.swift
@@ -10,6 +10,8 @@ import AVFoundation
 import Foundation
 import Kingfisher
 
+/// Note: This provider does not take into account items at the DB level, only at the disk level
+/// so for folders where all the items are offloaded, it won't find items to parse an artwork
 public struct AVAudioAssetImageDataProvider: ImageDataProvider {
 
   public enum ProviderError: Error {


### PR DESCRIPTION
## Bugfix

- Fix last played sync not being reloaded to the proper time on secondary device (bug introduced when setting the last played item was reworked for widgets)
- Fix refreshing the URL for streaming a book when it's expired
- Fix 'Add' button being hidden behind mini player on Mac (and some iPads) when viewing an empty folder
- Remove caching the default artwork for folders