### PR TITLE
Fix sharing debug information from a Mac

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		6340D56E2AF13E4C003D0B09 /* RectangularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6340D56D2AF13E4C003D0B09 /* RectangularView.swift */; };
 		63432B592AC1E6F7002619D0 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63432B582AC1E6F7002619D0 /* MockNavigationController.swift */; };
 		634E67462AFC7DEF00595BAC /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
+		6354CD9C2B4902CE006D9551 /* DebugInformationActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6354CD9B2B4902CE006D9551 /* DebugInformationActivityItemSource.swift */; };
 		6356F9B52AC7CC5600B7A027 /* CancelSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9B42AC7CC5600B7A027 /* CancelSleepTimerIntent.swift */; };
 		6356F9B92AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9B82AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift */; };
 		6356F9BD2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9BC2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift */; };
@@ -352,7 +353,7 @@
 		6356F9D02ACB01C700B7A027 /* PausePlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */; };
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
-		635907A02B161B14002FA524 /* DebugInformationActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */; };
+		635907A02B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift */; };
 		637609192ADCD81400A01D5D /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6376091B2ADCD81400A01D5D /* AppShortcuts.strings */; };
 		637DAB0B2AEB3F6D006DC2D1 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		637DAB0D2AEBEF1B006DC2D1 /* BookPlayerWatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */; };
@@ -1050,6 +1051,7 @@
 		6340D56D2AF13E4C003D0B09 /* RectangularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangularView.swift; sourceTree = "<group>"; };
 		63432B582AC1E6F7002619D0 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
 		634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStartPlaybackIntent.swift; sourceTree = "<group>"; };
+		6354CD9B2B4902CE006D9551 /* DebugInformationActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInformationActivityItemSource.swift; sourceTree = "<group>"; };
 		6356F9B42AC7CC5600B7A027 /* CancelSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelSleepTimerIntent.swift; sourceTree = "<group>"; };
 		6356F9B82AC7CDDE00B7A027 /* EndChapterSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndChapterSleepTimerIntent.swift; sourceTree = "<group>"; };
 		6356F9BC2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSleepTimerIntent.swift; sourceTree = "<group>"; };
@@ -1058,7 +1060,7 @@
 		6356F9C92AC8A1B700B7A027 /* DatabaseInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseInitializer.swift; sourceTree = "<group>"; };
 		6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PausePlaybackIntent.swift; sourceTree = "<group>"; };
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
-		6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInformationActivityItemProvider.swift; sourceTree = "<group>"; };
+		6359079F2B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInformationFileActivityItemProvider.swift; sourceTree = "<group>"; };
 		6376091A2ADCD81400A01D5D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091C2ADCD82100A01D5D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091D2ADCD82100A01D5D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
@@ -2090,7 +2092,8 @@
 				419723FF21874D5F00AB1190 /* UserActivityManager.swift */,
 				41D39D40215F177D00B65290 /* BookActivityItemProvider.swift */,
 				9FC1A29E28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift */,
-				6359079F2B161B14002FA524 /* DebugInformationActivityItemProvider.swift */,
+				6359079F2B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift */,
+				6354CD9B2B4902CE006D9551 /* DebugInformationActivityItemSource.swift */,
 				41B30A32230232D200025D69 /* CarPlayManager.swift */,
 				4193E201243A91AE004D6A82 /* ActionParserService.swift */,
 				9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */,
@@ -3396,7 +3399,7 @@
 				416AAC3323F51031005AD04F /* LocalizableButton.swift in Sources */,
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,
-				635907A02B161B14002FA524 /* DebugInformationActivityItemProvider.swift in Sources */,
+				635907A02B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift in Sources */,
 				9F5FBB0A293EE0C2009F4B0E /* ItemDetailsViewModel.swift in Sources */,
 				6309F1262B0CF1C1002B86A4 /* BookPlaybackToggleIntent.swift in Sources */,
 				9FC1A29F28C0D8CC00F25906 /* BookmarksActivityItemProvider.swift in Sources */,
@@ -3407,6 +3410,7 @@
 				C3EC372E206EE0650094B4E8 /* SleepTimer.swift in Sources */,
 				4124122A26D19B9100B099DB /* StorageItem.swift in Sources */,
 				41A1B12F226FE0F900EA0400 /* Notification+BookPlayer.swift in Sources */,
+				6354CD9C2B4902CE006D9551 /* DebugInformationActivityItemSource.swift in Sources */,
 				6356F9BD2AC7CFFB00B7A027 /* CustomSleepTimerIntent.swift in Sources */,
 				9F4691FA2800F8D600A8F0E8 /* AccountCoordinator.swift in Sources */,
 				412AB70E2701463100969618 /* LoadingViewModel.swift in Sources */,

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -218,9 +218,16 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
   }
 
   func shareDebugInformation(info: String) {
-    let provider = DebugInformationActivityItemProvider(info: info)
+    let shareController: UIActivityViewController
 
-    let shareController = UIActivityViewController(activityItems: [provider], applicationActivities: nil)
+    /// Sharing a txt file does not work well on a Mac, it's better to just share the info string
+    if ProcessInfo.processInfo.isiOSAppOnMac {
+      let source = DebugInformationActivityItemSource(info: info)
+      shareController = UIActivityViewController(activityItems: [source], applicationActivities: nil)
+    } else {
+      let provider = DebugInformationFileActivityItemProvider(info: info)
+      shareController = UIActivityViewController(activityItems: [provider], applicationActivities: nil)
+    }
 
     if let popoverPresentationController = shareController.popoverPresentationController,
        let view = flow.navigationController.topViewController?.view {

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -603,7 +603,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
 
 extension PlayerManager {
   func jumpToChapter(_ chapter: PlayableChapter) {
-    jumpTo(chapter.start + 0.5, recordBookmark: false)
+    jumpTo(chapter.start + 0.1, recordBookmark: false)
   }
 
   func initializeChapterTime(_ time: Double) {

--- a/BookPlayer/Services/DebugInformationActivityItemSource.swift
+++ b/BookPlayer/Services/DebugInformationActivityItemSource.swift
@@ -1,0 +1,47 @@
+//
+//  DebugInformationActivityItemSource.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 5/1/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import LinkPresentation
+
+/// Share the debug information as a single String
+class DebugInformationActivityItemSource: NSObject, UIActivityItemSource {
+  let title = "Debug information"
+  let info: String
+
+  init(info: String) {
+    self.info = info
+    super.init()
+  }
+
+  func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+    return info
+  }
+
+  func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    itemForActivityType activityType: UIActivity.ActivityType?
+  ) -> Any? {
+    return info
+  }
+
+  func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    subjectForActivityType activityType: UIActivity.ActivityType?
+  ) -> String {
+    return title
+  }
+
+  func activityViewControllerLinkMetadata(
+    _ activityViewController: UIActivityViewController
+  ) -> LPLinkMetadata? {
+    let metadata = LPLinkMetadata()
+    metadata.title = title
+    metadata.iconProvider = NSItemProvider(object: UIImage(systemName: "line.3.horizontal")!)
+    return metadata
+  }
+}

--- a/BookPlayer/Services/DebugInformationFileActivityItemProvider.swift
+++ b/BookPlayer/Services/DebugInformationFileActivityItemProvider.swift
@@ -1,5 +1,5 @@
 //
-//  DebugInformationActivityItemProvider.swift
+//  DebugInformationFileActivityItemProvider.swift
 //  BookPlayer
 //
 //  Created by Gianni Carlo on 28/11/23.
@@ -9,7 +9,7 @@
 import BookPlayerKit
 import Foundation
 
-final class DebugInformationActivityItemProvider: UIActivityItemProvider {
+final class DebugInformationFileActivityItemProvider: UIActivityItemProvider {
   let info: String
 
   init(info: String) {


### PR DESCRIPTION
## Bugfix

- Apple Silicon Macs running the iOS version can't share the txt file out of the app (the share sheet only shows the messages route, and tapping on any contact does not work either)

## Approach

- Add a way to export the info as a String for Macs

## Things to be aware of / Things to focus on

- It's not ideal, but it's what can be done given the constraints (not being able to use AppKit or other Mac APIs without fully embracing Catalyst)

## Screenshots

<img width="613" alt="Screenshot 2024-01-05 at 22 45 25" src="https://github.com/TortugaPower/BookPlayer/assets/14112819/5f5474cf-b0a8-49c3-a9e2-5d66e021def8">


![Simulator Screenshot - iPhone 15 - 2024-01-05 at 22 50 00](https://github.com/TortugaPower/BookPlayer/assets/14112819/9931a708-3a7f-4053-bdb8-304f44670f13)

