### PR TITLE
Rebrand sticky timer to auto timer

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -202,8 +202,6 @@
 "error_loading_chapters" = "Chapters couldn't be loaded from: \n%@";
 "error_empty_chapters" = "Chapters are empty, please verify the contents of the folder: %@";
 "sleeptimer_option_custom" = "Custom";
-"sleeptimer_option_sticky_on" = "Sticky ✓";
-"sleeptimer_option_sticky_off" = "Sticky";
 "sleeptimer_custom_alert_title" = "Custom sleep timer";
 "settings_progresslabels_title" = "Progress Labels";
 "settings_playerinterface_list_title" = "Opens";
@@ -305,3 +303,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "storage_artwork_cache_title" = "Artwork cache size";
 "settings_share_debug_information" = "Share debug information";
 "settings_autlock_section_title" = "Autolock";
+"settings_sleeptimer_auto_title" = "Auto Sleep Timer";
+"settings_sleeptimer_auto_description" = "Restart the last active sleep timer when playback is resumed";

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -395,23 +395,7 @@ class PlayerViewModel: ViewModelProtocol {
       )
     )
 
-    let formatter = DateComponentsFormatter()
-
-    formatter.unitsStyle = .full
-    formatter.allowedUnits = [.hour, .minute]
-
-    for interval in SleepTimer.shared.intervals {
-      guard let formattedDuration = formatter.string(from: interval) else { continue }
-
-      actions.append(
-        BPActionItem(
-          title: String.localizedStringWithFormat("sleep_interval_title".localized, formattedDuration),
-          handler: {
-            SleepTimer.shared.setTimer(.countdown(interval))
-          }
-        )
-      )
-    }
+    actions.append(contentsOf: getCountdownActions())
 
     actions.append(
       BPActionItem(
@@ -431,21 +415,7 @@ class PlayerViewModel: ViewModelProtocol {
       )
     )
 
-    let stickyAction = SleepTimer.shared.getSticky()
-    ? BPActionItem(
-      title: "sleeptimer_option_sticky_on".localized,
-      handler: {
-        SleepTimer.shared.setSticky(stickyState: false)
-      }
-    )
-    : BPActionItem(
-      title: "sleeptimer_option_sticky_off".localized,
-      handler: {
-        SleepTimer.shared.setSticky(stickyState: true)
-      }
-    )
-
-    actions.append(stickyAction)
+    actions.append(getStickyPreferenceAction())
     actions.append(BPActionItem.cancelAction)
 
     sendEvent(.sleepTimerAlert(
@@ -487,6 +457,35 @@ class PlayerViewModel: ViewModelProtocol {
     guard storedTime > 0 else { return nil }
 
     return storedTime
+  }
+
+  private func getCountdownActions() -> [BPActionItem] {
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .full
+    formatter.allowedUnits = [.hour, .minute]
+
+    return SleepTimer.shared.intervals.compactMap { interval in
+      guard let formattedDuration = formatter.string(from: interval) else { return nil }
+
+      return BPActionItem(
+        title: String.localizedStringWithFormat("sleep_interval_title".localized, formattedDuration),
+        handler: {
+          SleepTimer.shared.setTimer(.countdown(interval))
+        }
+      )
+    }
+  }
+
+  private func getStickyPreferenceAction() -> BPActionItem {
+    let isStickyPreferenceEnabled = SleepTimer.shared.isStickyPreferenceEnabled()
+    let title = isStickyPreferenceEnabled ? "sleeptimer_option_sticky_on" : "sleeptimer_option_sticky_off"
+
+    return BPActionItem(
+      title: title.localized,
+      handler: {
+        SleepTimer.shared.setStickyPreference(!isStickyPreferenceEnabled)
+      }
+    )
   }
 }
 

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -415,7 +415,6 @@ class PlayerViewModel: ViewModelProtocol {
       )
     )
 
-    actions.append(getStickyPreferenceAction())
     actions.append(BPActionItem.cancelAction)
 
     sendEvent(.sleepTimerAlert(
@@ -474,18 +473,6 @@ class PlayerViewModel: ViewModelProtocol {
         }
       )
     }
-  }
-
-  private func getStickyPreferenceAction() -> BPActionItem {
-    let isStickyPreferenceEnabled = SleepTimer.shared.isStickyPreferenceEnabled()
-    let title = isStickyPreferenceEnabled ? "sleeptimer_option_sticky_on" : "sleeptimer_option_sticky_off"
-
-    return BPActionItem(
-      title: title.localized,
-      handler: {
-        SleepTimer.shared.setStickyPreference(!isStickyPreferenceEnabled)
-      }
-    )
   }
 }
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -739,8 +739,8 @@ extension PlayerManager {
 
       handleSmartRewind(currentItem)
 
-      handleStickyTimer()
-      
+      handleAutoTimer()
+
       fadeTimer?.invalidate()
       shakeMotionService.stopMotionUpdates()
       boostVolume = UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
@@ -775,9 +775,9 @@ extension PlayerManager {
     }
   }
   
-  func handleStickyTimer() {
-    guard SleepTimer.shared.isStickyPreferenceEnabled() else { return }
-    
+  func handleAutoTimer() {
+    guard UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoTimerEnabled) else { return }
+
     SleepTimer.shared.restartTimer()
   }
 

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -776,9 +776,9 @@ extension PlayerManager {
   }
   
   func handleStickyTimer() {
-    if SleepTimer.shared.getSticky() {
-      SleepTimer.shared.restartTimer()
-    }
+    guard SleepTimer.shared.isStickyPreferenceEnabled() else { return }
+    
+    SleepTimer.shared.restartTimer()
   }
 
   func setSpeed(_ newValue: Float) {

--- a/BookPlayer/Player/SleepTimer.swift
+++ b/BookPlayer/Player/SleepTimer.swift
@@ -39,8 +39,6 @@ final class SleepTimer {
     1800.0,
     3600.0
   ]
-  
-  public var sticky = false
 
   /// Publisher when the countdown timer reaches the defined threshold
   public var countDownThresholdPublisher = PassthroughSubject<Bool, Never>()
@@ -93,24 +91,24 @@ final class SleepTimer {
 
   // MARK: Public methods
 
-  public func setSticky(stickyState: Bool) {
-      sticky = stickyState
+  public func setStickyPreference(_ flag: Bool) {
+    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.stickyTimerEnabled)
   }
   
-  public func getSticky() -> Bool {
-    return sticky
+  public func isStickyPreferenceEnabled() -> Bool {
+    return UserDefaults.standard.bool(forKey: Constants.UserDefaults.stickyTimerEnabled)
   }
   
   public func setTimer(_ newState: SleepTimerState) {
     /// Always cancel any ongoing timer
     reset()
     state = newState
-    lastActiveState = newState
 
     switch newState {
     case .off:
       donateTimerIntent(with: .cancel)
     case .countdown(let interval):
+      lastActiveState = newState
       if let option = TimeParser.getTimerOption(from: interval) {
         donateTimerIntent(with: option)
       }
@@ -120,11 +118,12 @@ final class SleepTimer {
           self?.update()
         }
     case .endOfChapter:
+      lastActiveState = newState
       donateTimerIntent(with: .endChapter)
       NotificationCenter.default.addObserver(self, selector: #selector(self.end), name: .chapterChange, object: nil)
       NotificationCenter.default.addObserver(self, selector: #selector(self.end), name: .bookEnd, object: nil)
     }
-    }
+  }
 
   public func restartTimer() {
     setTimer(lastActiveState)

--- a/BookPlayer/Player/SleepTimer.swift
+++ b/BookPlayer/Player/SleepTimer.swift
@@ -90,14 +90,6 @@ final class SleepTimer {
   }
 
   // MARK: Public methods
-
-  public func setStickyPreference(_ flag: Bool) {
-    UserDefaults.standard.set(flag, forKey: Constants.UserDefaults.stickyTimerEnabled)
-  }
-  
-  public func isStickyPreferenceEnabled() -> Bool {
-    return UserDefaults.standard.bool(forKey: Constants.UserDefaults.stickyTimerEnabled)
-  }
   
   public func setTimer(_ newState: SleepTimerState) {
     /// Always cancel any ongoing timer

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -294,7 +294,7 @@
                                 <string key="footerTitle">SKAN is Apple's privacy-first attribution solution that enables measuring how effective a campaign was without compromising the user privacy</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="z7s-7T-Ue2" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="893.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="921.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="z7s-7T-Ue2" id="585-78-tbb">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -1998,12 +1998,51 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection footerTitle="Restart the last active sleep timer when playback is resumed" id="vIz-ti-1ab">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="h7A-iW-714" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="299.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="h7A-iW-714" id="d1f-wd-r7D">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hao-jf-1z7">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="49" id="hsz-jf-rOL"/>
+                                                    </constraints>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Auto Sleep Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OdU-iJ-lVp" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="11.5" width="286" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_sleeptimer_auto_title"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="OdU-iJ-lVp" firstAttribute="leading" secondItem="d1f-wd-r7D" secondAttribute="leading" constant="16" id="6Po-Ck-T1f"/>
+                                                <constraint firstItem="OdU-iJ-lVp" firstAttribute="centerY" secondItem="d1f-wd-r7D" secondAttribute="centerY" id="BuU-Ly-hCh"/>
+                                                <constraint firstItem="Hao-jf-1z7" firstAttribute="leading" secondItem="OdU-iJ-lVp" secondAttribute="trailing" constant="8" id="Dv5-Lx-P6f"/>
+                                                <constraint firstAttribute="trailing" secondItem="Hao-jf-1z7" secondAttribute="trailing" constant="16" id="f4N-RF-KfP"/>
+                                                <constraint firstItem="Hao-jf-1z7" firstAttribute="centerY" secondItem="d1f-wd-r7D" secondAttribute="centerY" id="tZS-w5-yec"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="customLabel" destination="OdU-iJ-lVp" id="3Hv-uf-PVC"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection id="ndB-eX-83q">
                                 <string key="footerTitle">Doubles the volume.
 Use with caution and care for your hearing.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="7L4-ZR-6Y1" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="299.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="407.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7L4-ZR-6Y1" id="X9G-J4-qAq">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -2042,7 +2081,7 @@ Use with caution and care for your hearing.</string>
                             <tableViewSection footerTitle="Set speed across all books." id="lcf-oa-ncd">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="biN-UB-ceL" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="407.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="515.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="biN-UB-ceL" id="9dd-C5-rSL">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -2081,7 +2120,7 @@ Use with caution and care for your hearing.</string>
                             <tableViewSection footerTitle="Adjust what the list button in the player screen opens" id="04N-lB-8ix">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Ydn-hQ-kXZ" detailTextLabel="Jbk-jB-Hyp" imageView="wIP-hW-J0B" style="IBUITableViewCellStyleValue1" id="oMW-vV-SO2" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="499.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="607.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oMW-vV-SO2" id="8zv-VN-kiu">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
@@ -2117,7 +2156,7 @@ Use with caution and care for your hearing.</string>
                                 <string key="footerTitle">Toggle between displaying the remaining time, total duration and progress of either the chapter or the book in the player screen</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="BJG-C7-5Vg" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="619" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="727" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BJG-C7-5Vg" id="dpV-7M-H3x">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -2152,19 +2191,19 @@ Use with caution and care for your hearing.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="vru-07-FFi" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="663" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="771" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vru-07-FFi" id="V6Q-pu-WgH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jzV-Oj-QRt">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jzV-Oj-QRt">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="dX3-2o-B6Y"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use Chapter Context" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jWe-Ru-KOW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Use Chapter Context" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jWe-Ru-KOW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2196,6 +2235,7 @@ Use with caution and care for your hearing.</string>
                     </tableView>
                     <navigationItem key="navigationItem" title="Player Controls" leftItemsSupplementBackButton="YES" largeTitleDisplayMode="never" id="gST-Cn-uPB"/>
                     <connections>
+                        <outlet property="autoSleepTimerSwitch" destination="Hao-jf-1z7" id="aV4-Cs-ZbU"/>
                         <outlet property="boostVolumeSwitch" destination="REu-u1-fwP" id="ORF-rl-zos"/>
                         <outlet property="chapterTimeSwitch" destination="jzV-Oj-QRt" id="lY1-Fl-C2d"/>
                         <outlet property="forwardIntervalLabel" destination="hD8-4g-KSV" id="kFR-tA-8kv"/>

--- a/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
+++ b/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
@@ -12,6 +12,7 @@ import Themeable
 import UIKit
 
 class PlayerSettingsViewController: UITableViewController, Storyboarded {
+  @IBOutlet weak var autoSleepTimerSwitch: UISwitch!
   @IBOutlet weak var smartRewindSwitch: UISwitch!
   @IBOutlet weak var boostVolumeSwitch: UISwitch!
   @IBOutlet weak var globalSpeedSwitch: UISwitch!
@@ -26,7 +27,7 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
   private var disposeBag = Set<AnyCancellable>()
 
   enum SettingsSection: Int {
-    case intervals = 0, rewind, volume, speed, playerList, progressLabels
+    case intervals = 0, rewind, sleepTimer, volume, speed, playerList, progressLabels
   }
 
   let playerListPreferencePath = IndexPath(row: 0, section: SettingsSection.playerList.rawValue)
@@ -43,16 +44,36 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
       target: self,
       action: #selector(self.didPressClose)
     )
-    self.smartRewindSwitch.addTarget(self, action: #selector(self.rewindToggleDidChange), for: .valueChanged)
-    self.boostVolumeSwitch.addTarget(self, action: #selector(self.boostVolumeToggleDidChange), for: .valueChanged)
-    self.globalSpeedSwitch.addTarget(self, action: #selector(self.globalSpeedToggleDidChange), for: .valueChanged)
+    smartRewindSwitch.addTarget(self, action: #selector(rewindToggleDidChange), for: .valueChanged)
+    autoSleepTimerSwitch.addTarget(self, action: #selector(autoSleepTimerToggleDidChange), for: .valueChanged)
+    boostVolumeSwitch.addTarget(self, action: #selector(boostVolumeToggleDidChange), for: .valueChanged)
+    globalSpeedSwitch.addTarget(self, action: #selector(globalSpeedToggleDidChange), for: .valueChanged)
 
     // Set initial switch positions
-    self.smartRewindSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled), animated: false)
-    self.boostVolumeSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled), animated: false)
-    self.globalSpeedSwitch.setOn(UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled), animated: false)
-    self.chapterTimeSwitch.setOn(self.viewModel.prefersChapterContext, animated: false)
-    self.remainingTimeSwitch.setOn(self.viewModel.prefersRemainingTime, animated: false)
+    smartRewindSwitch.setOn(
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.smartRewindEnabled), 
+      animated: false
+    )
+    autoSleepTimerSwitch.setOn(
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.autoTimerEnabled), 
+      animated: false
+    )
+    boostVolumeSwitch.setOn(
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.boostVolumeEnabled), 
+      animated: false
+    )
+    globalSpeedSwitch.setOn(
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled), 
+      animated: false
+    )
+    chapterTimeSwitch.setOn(
+      viewModel.prefersChapterContext,
+      animated: false
+    )
+    remainingTimeSwitch.setOn(
+      viewModel.prefersRemainingTime,
+      animated: false
+    )
 
     // Retrieve initial skip values from PlayerManager
     self.rewindIntervalLabel.text = TimeParser.formatDuration(PlayerManager.rewindInterval)
@@ -172,6 +193,8 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
       return "settings_skip_description".localized
     case .rewind:
       return "settings_smartrewind_description".localized
+    case .sleepTimer:
+      return "settings_sleeptimer_auto_description".localized
     case .volume:
       return "settings_boostvolume_description".localized
     case .speed:
@@ -185,6 +208,10 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
 
   @objc func rewindToggleDidChange() {
     UserDefaults.standard.set(self.smartRewindSwitch.isOn, forKey: Constants.UserDefaults.smartRewindEnabled)
+  }
+
+  @objc func autoSleepTimerToggleDidChange() {
+    UserDefaults.standard.set(autoSleepTimerSwitch.isOn, forKey: Constants.UserDefaults.autoTimerEnabled)
   }
 
   @objc func boostVolumeToggleDidChange() {

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "حجم ذاكرة التخزين المؤقت للعمل الفني";
 "settings_share_debug_information" = "مشاركة معلومات التصحيح";
 "settings_autlock_section_title" = "القفل التلقائي";
+"settings_sleeptimer_auto_title" = "مؤقت النوم التلقائي";
+"settings_sleeptimer_auto_description" = "أعد تشغيل آخر مؤقت نوم نشط عند استئناف التشغيل";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Velikost mezipaměti uměleckých děl";
 "settings_share_debug_information" = "Sdílejte informace o ladění";
 "settings_autlock_section_title" = "Automatický zámek";
+"settings_sleeptimer_auto_title" = "Časovač automatického vypnutí";
+"settings_sleeptimer_auto_description" = "Po obnovení přehrávání restartujte poslední aktivní časovač vypnutí";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Artwork cache størrelse";
 "settings_share_debug_information" = "Del fejlretningsoplysninger";
 "settings_autlock_section_title" = "Autolås";
+"settings_sleeptimer_auto_title" = "Auto Sleep Timer";
+"settings_sleeptimer_auto_description" = "Genstart den sidst aktive sleep-timer, når afspilningen genoptages";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Größe des Grafik-Cache";
 "settings_share_debug_information" = "Teilen Sie Debug-Informationen";
 "settings_autlock_section_title" = "Automatische Sperre";
+"settings_sleeptimer_auto_title" = "Automatischer Sleep-Timer";
+"settings_sleeptimer_auto_description" = "Starten Sie den zuletzt aktiven Sleep-Timer neu, wenn die Wiedergabe fortgesetzt wird";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -202,8 +202,6 @@
 "error_loading_chapters" = "Chapters couldn't be loaded from: \n%@";
 "error_empty_chapters" = "Chapters are empty, please verify the contents of the folder: %@";
 "sleeptimer_option_custom" = "Custom";
-"sleeptimer_option_sticky_on" = "Sticky ✓";
-"sleeptimer_option_sticky_off" = "Sticky";
 "sleeptimer_custom_alert_title" = "Custom sleep timer";
 "settings_progresslabels_title" = "Progress Labels";
 "settings_playerinterface_list_title" = "Opens";
@@ -305,3 +303,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "storage_artwork_cache_title" = "Artwork cache size";
 "settings_share_debug_information" = "Share debug information";
 "settings_autlock_section_title" = "Autolock";
+"settings_sleeptimer_auto_title" = "Auto Sleep Timer";
+"settings_sleeptimer_auto_description" = "Restart the last active sleep timer when playback is resumed";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Tamaño de caché de ilustraciones";
 "settings_share_debug_information" = "Compartir información de depuración";
 "settings_autlock_section_title" = "Bloqueo automático";
+"settings_sleeptimer_auto_title" = "Temporizador de apagado automático";
+"settings_sleeptimer_auto_description" = "Reinicie el último temporizador de apagado activo cuando se reanude la reproducción";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Taideteoksen välimuistin koko";
 "settings_share_debug_information" = "Jaa virheenkorjaustiedot";
 "settings_autlock_section_title" = "Automaattinen lukitus";
+"settings_sleeptimer_auto_title" = "Automaattinen uniajastin";
+"settings_sleeptimer_auto_description" = "Käynnistä viimeinen aktiivinen uniajastin uudelleen, kun toistoa jatketaan";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Taille du cache des illustrations";
 "settings_share_debug_information" = "Partager les informations de débogage";
 "settings_autlock_section_title" = "Verrouillage automatique";
+"settings_sleeptimer_auto_title" = "Minuterie de mise en veille automatique";
+"settings_sleeptimer_auto_description" = "Redémarrez la dernière minuterie de mise en veille active lorsque la lecture reprend";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Az alkotás gyorsítótár mérete";
 "settings_share_debug_information" = "Ossza meg a hibakeresési információkat";
 "settings_autlock_section_title" = "Automata zár";
+"settings_sleeptimer_auto_title" = "Automatikus elalváskapcsoló";
+"settings_sleeptimer_auto_description" = "A lejátszás folytatásakor indítsa újra az utolsó aktív elalváskapcsolót";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Dimensioni della cache della grafica";
 "settings_share_debug_information" = "Condividi le informazioni di debug";
 "settings_autlock_section_title" = "Chiusura automatica";
+"settings_sleeptimer_auto_title" = "Temporizzatore di spegnimento automatico";
+"settings_sleeptimer_auto_description" = "Riavvia l'ultimo timer di spegnimento attivo quando viene ripresa la riproduzione";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -303,3 +303,5 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "storage_artwork_cache_title" = "Artwork cache-størrelse";
 "settings_share_debug_information" = "Del feilsøkingsinformasjon";
 "settings_autlock_section_title" = "Automatisk lås";
+"settings_sleeptimer_auto_title" = "Auto Sleep Timer";
+"settings_sleeptimer_auto_description" = "Start den siste aktive innsovningstimeren på nytt når avspillingen gjenopptas";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Grootte van de artworkcache";
 "settings_share_debug_information" = "Deel foutopsporingsinformatie";
 "settings_autlock_section_title" = "Automatische vergrendeling";
+"settings_sleeptimer_auto_title" = "Automatische slaaptimer";
+"settings_sleeptimer_auto_description" = "Start de laatste actieve slaaptimer opnieuw wanneer het afspelen wordt hervat";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Rozmiar pamięci podręcznej grafiki";
 "settings_share_debug_information" = "Udostępnij informacje debugowania";
 "settings_autlock_section_title" = "Automatyczna blokada";
+"settings_sleeptimer_auto_title" = "Automatyczny wyłącznik czasowy";
+"settings_sleeptimer_auto_description" = "Po wznowieniu odtwarzania uruchom ponownie ostatni aktywny timer uśpienia";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Tamanho do cache de arte";
 "settings_share_debug_information" = "Compartilhe informações de depuração";
 "settings_autlock_section_title" = "Bloqueio automático";
+"settings_sleeptimer_auto_title" = "Temporizador automático";
+"settings_sleeptimer_auto_description" = "Reinicie o último temporizador ativo quando a reprodução for retomada";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Tamanho do cache de arte";
 "settings_share_debug_information" = "Compartilhe informações de depuração";
 "settings_autlock_section_title" = "Bloqueio automático";
+"settings_sleeptimer_auto_title" = "Temporizador automático";
+"settings_sleeptimer_auto_description" = "Reinicie o último temporizador ativo quando a reprodução for retomada";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Dimensiunea memoriei cache a lucrărilor de artă";
 "settings_share_debug_information" = "Partajați informațiile de depanare";
 "settings_autlock_section_title" = "Închidere automată";
+"settings_sleeptimer_auto_title" = "Temporizator de oprire automată";
+"settings_sleeptimer_auto_description" = "Reporniți ultimul temporizator de repaus activ când redarea este reluată";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Размер кэша иллюстраций";
 "settings_share_debug_information" = "Делитесь отладочной информацией";
 "settings_autlock_section_title" = "Автоматическая блокировка";
+"settings_sleeptimer_auto_title" = "Автоматический таймер сна";
+"settings_sleeptimer_auto_description" = "Перезапустите последний активный таймер сна, когда воспроизведение возобновится.";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -303,3 +303,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "storage_artwork_cache_title" = "Veľkosť vyrovnávacej pamäte obalov kníh";
 "settings_share_debug_information" = "Zdieľať informácie o ladení";
 "settings_autlock_section_title" = "Automatické zamknutie";
+"settings_sleeptimer_auto_title" = "Časovač automatického vypnutia";
+"settings_sleeptimer_auto_description" = "Po obnovení prehrávania reštartujte posledný aktívny časovač spánku";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Artwork cachestorlek";
 "settings_share_debug_information" = "Dela felsökningsinformation";
 "settings_autlock_section_title" = "Auto lås";
+"settings_sleeptimer_auto_title" = "Automatisk insomningstimer";
+"settings_sleeptimer_auto_description" = "Starta om den senast aktiva insomningstimern när uppspelningen återupptas";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Resim önbellek boyutu";
 "settings_share_debug_information" = "Hata ayıklama bilgilerini paylaşın";
 "settings_autlock_section_title" = "Otomatik kilit";
+"settings_sleeptimer_auto_title" = "Otomatik Uyku Zamanlayıcısı";
+"settings_sleeptimer_auto_description" = "Oynatma devam ettirildiğinde son aktif uyku zamanlayıcısını yeniden başlatın";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "Розмір кеша ілюстрації";
 "settings_share_debug_information" = "Поділіться інформацією про налагодження";
 "settings_autlock_section_title" = "Автоблокування";
+"settings_sleeptimer_auto_title" = "Автоматичний таймер сну";
+"settings_sleeptimer_auto_description" = "Перезапустіть останній активний таймер сну, коли відтворення відновиться";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -303,3 +303,5 @@
 "storage_artwork_cache_title" = "艺术品缓存大小";
 "settings_share_debug_information" = "共享调试信息";
 "settings_autlock_section_title" = "自动锁";
+"settings_sleeptimer_auto_title" = "自动睡眠定时器";
+"settings_sleeptimer_auto_description" = "恢复播放时重新启动最后一个活动的睡眠计时器";

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -35,7 +35,7 @@ public enum Constants {
     public static let playerListPrefersBookmarks = "userSettingsPlayerListPrefersBookmarks"
     public static let storageFilesSortOrder = "userSettingsStorageFilesSortOrder"
     public static let customSleepTimerDuration = "userSettingsCustomSleepTimerDuration"
-    public static let stickyTimerEnabled = "userSettingsStickyTimerEnabled"
+    public static let autoTimerEnabled = "userSettingsAutoTimerEnabled"
 
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -35,6 +35,7 @@ public enum Constants {
     public static let playerListPrefersBookmarks = "userSettingsPlayerListPrefersBookmarks"
     public static let storageFilesSortOrder = "userSettingsStorageFilesSortOrder"
     public static let customSleepTimerDuration = "userSettingsCustomSleepTimerDuration"
+    public static let stickyTimerEnabled = "userSettingsStickyTimerEnabled"
 
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"


### PR DESCRIPTION
## Purpose

- Add translations for the sticky timer feature

## Related tasks

#822 
#511

## Approach

- I moved the sticky preference from the sleep timer options, into Settings → Player Controls, as having it between the sleep timer options, and the preference not doing anything by itself, was a bit confusing for users that haven't used it before
- Rebranded sticky to auto timer, as it better represents what it does
- Also added the preference to UserDefaults to persist it across app launches

cc @cvakiitho 

## Screenshots

<img width=350 src="https://github.com/TortugaPower/BookPlayer/assets/14112819/9092b12d-c2bd-4de6-b930-3a3dc2cf2f3c" />

