### PR TITLE
Add support for pull down to refresh

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		63B3B6902B1F625B007A367C /* StorageCloudDeletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */; };
+		63B50F052B692E4200BCABBA /* ListSyncRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B50F042B692E4200BCABBA /* ListSyncRefreshService.swift */; };
 		63C1A8AF2B09158600C4B418 /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
 		63C1A8B02B0915EE00C4B418 /* WidgetUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418445C2258AE11E0072DD13 /* WidgetUtils.swift */; };
 		63C1A8B12B09165400C4B418 /* RecentBooksWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41ADD6D92570AC6300660C64 /* RecentBooksWidgetView.swift */; };
@@ -1093,6 +1094,7 @@
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
 		639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPDownloadURLSession.swift; sourceTree = "<group>"; };
 		63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCloudDeletedView.swift; sourceTree = "<group>"; };
+		63B50F042B692E4200BCABBA /* ListSyncRefreshService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSyncRefreshService.swift; sourceTree = "<group>"; };
 		63C6C2E52B5029BC00FFE0D8 /* SettingsAutolockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAutolockView.swift; sourceTree = "<group>"; };
 		63C6C2E72B5029FE00FFE0D8 /* SettingsAutolockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAutolockViewModel.swift; sourceTree = "<group>"; };
 		63C6C30B2B538B7A00FFE0D8 /* SyncTasksStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTasksStorage.swift; sourceTree = "<group>"; };
@@ -2120,6 +2122,7 @@
 				41B30A32230232D200025D69 /* CarPlayManager.swift */,
 				4193E201243A91AE004D6A82 /* ActionParserService.swift */,
 				9F82DF9B27DFE46B001B0EA8 /* PhoneWatchConnectivityService.swift */,
+				63B50F042B692E4200BCABBA /* ListSyncRefreshService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -3423,6 +3426,7 @@
 				9F89D89C27EDFCA400F73947 /* SceneDelegate.swift in Sources */,
 				9F3D0CE928C2BFC600E9E8A3 /* ButtonFreeCoordinator.swift in Sources */,
 				416AAC3323F51031005AD04F /* LocalizableButton.swift in Sources */,
+				63B50F052B692E4200BCABBA /* ListSyncRefreshService.swift in Sources */,
 				416A297D2568671F00605395 /* AVPlayer+BookPlayer.swift in Sources */,
 				41E79BEB26C60DC600EA9FFF /* PlayerViewModel.swift in Sources */,
 				635907A02B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift in Sources */,

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -305,3 +305,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "settings_autlock_section_title" = "Autolock";
 "settings_sleeptimer_auto_title" = "Auto Sleep Timer";
 "settings_sleeptimer_auto_description" = "Restart the last active sleep timer when playback is resumed";
+"sync_tasks_inprogress_alert_title" = "Can't sync data while there are queued tasks in progress";
+"sync_tasks_view_title" = "View tasks";

--- a/BookPlayer/Base.lproj/Main.storyboard
+++ b/BookPlayer/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="UvS-mV-Are">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="UvS-mV-Are">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -180,7 +180,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="86" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="TP0-JK-hUQ">
-                                <rect key="frame" x="0.0" y="60" width="375" height="607"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <connections>
                                     <outlet property="dataSource" destination="Ttl-AN-zxZ" id="e90-tb-vT5"/>
                                     <outlet property="delegate" destination="Ttl-AN-zxZ" id="Ddf-9C-fCT"/>
@@ -194,16 +194,16 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oVP-SJ-Vkq" userLabel="Empty Playlist Placeholder">
-                                <rect key="frame" x="0.0" y="60" width="375" height="607"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="emptyPlaylist" translatesAutoresizingMaskIntoConstraints="NO" id="q8y-d7-HKX">
-                                        <rect key="frame" x="63" y="129" width="249" height="249"/>
+                                        <rect key="frame" x="63" y="139" width="249" height="249"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="q8y-d7-HKX" secondAttribute="height" multiplier="1:1" id="aOm-mD-cE3"/>
                                         </constraints>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GAA-F6-6lf" customClass="AddButton" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="12" y="394" width="347" height="44"/>
+                                        <rect key="frame" x="12" y="404" width="347" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="2EV-6X-9Bn"/>
                                         </constraints>
@@ -232,7 +232,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L2f-M1-8fN" customClass="LoadingView" customModule="BookPlayer" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="60" width="375" height="65"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="65"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="65" id="69u-wZ-9DI"/>
@@ -251,17 +251,17 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="oVP-SJ-Vkq" firstAttribute="leading" secondItem="ioY-wv-OwB" secondAttribute="leading" id="8JP-xR-vIY"/>
-                            <constraint firstItem="oVP-SJ-Vkq" firstAttribute="top" secondItem="ZwC-BN-4rl" secondAttribute="bottom" id="9Sv-qP-8sH"/>
-                            <constraint firstItem="ZwC-BN-4rl" firstAttribute="top" secondItem="MQO-lV-qyO" secondAttribute="topMargin" id="B4g-wD-W1G"/>
                             <constraint firstItem="L2f-M1-8fN" firstAttribute="leading" secondItem="ioY-wv-OwB" secondAttribute="leading" id="CMo-xh-I1i"/>
                             <constraint firstItem="RTy-ml-CPR" firstAttribute="centerX" secondItem="ioY-wv-OwB" secondAttribute="centerX" id="DtC-Kv-u06"/>
+                            <constraint firstItem="ZwC-BN-4rl" firstAttribute="top" secondItem="ioY-wv-OwB" secondAttribute="top" id="EZj-QK-0SZ"/>
                             <constraint firstItem="ioY-wv-OwB" firstAttribute="bottom" secondItem="oVP-SJ-Vkq" secondAttribute="bottom" id="Eiz-I6-chs"/>
-                            <constraint firstItem="L2f-M1-8fN" firstAttribute="top" secondItem="ZwC-BN-4rl" secondAttribute="bottom" id="G1Z-ks-59R"/>
                             <constraint firstItem="TP0-JK-hUQ" firstAttribute="bottom" secondItem="RTy-ml-CPR" secondAttribute="bottom" constant="25" id="Hqj-QX-Wcm"/>
+                            <constraint firstItem="L2f-M1-8fN" firstAttribute="top" secondItem="ioY-wv-OwB" secondAttribute="top" id="Ige-qB-Wyr"/>
                             <constraint firstItem="TP0-JK-hUQ" firstAttribute="leading" secondItem="ioY-wv-OwB" secondAttribute="leading" id="L0w-MY-1qA"/>
+                            <constraint firstItem="oVP-SJ-Vkq" firstAttribute="top" secondItem="MQO-lV-qyO" secondAttribute="top" id="ODc-i7-v7i"/>
                             <constraint firstItem="TP0-JK-hUQ" firstAttribute="bottom" secondItem="MQO-lV-qyO" secondAttribute="bottom" id="TgH-ym-qmZ"/>
                             <constraint firstItem="oVP-SJ-Vkq" firstAttribute="trailing" secondItem="ioY-wv-OwB" secondAttribute="trailing" id="Vck-ZE-yVH"/>
-                            <constraint firstItem="TP0-JK-hUQ" firstAttribute="top" secondItem="ZwC-BN-4rl" secondAttribute="bottom" id="b4o-6p-Lsh"/>
+                            <constraint firstItem="TP0-JK-hUQ" firstAttribute="top" secondItem="MQO-lV-qyO" secondAttribute="top" id="WmO-Je-cX3"/>
                             <constraint firstItem="L2f-M1-8fN" firstAttribute="trailing" secondItem="ioY-wv-OwB" secondAttribute="trailing" id="eQe-3U-mMR"/>
                             <constraint firstItem="ioY-wv-OwB" firstAttribute="trailing" secondItem="ZwC-BN-4rl" secondAttribute="trailing" constant="16" id="oxB-xR-1Tx"/>
                             <constraint firstItem="ZwC-BN-4rl" firstAttribute="leading" secondItem="ioY-wv-OwB" secondAttribute="leading" constant="16" id="t7b-IF-Cej"/>

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -41,7 +41,8 @@ class FolderListCoordinator: ItemListCoordinator {
       networkClient: NetworkClient(),
       libraryService: self.libraryService,
       playbackService: self.playbackService,
-      syncService: self.syncService,
+      syncService: self.syncService, 
+      listRefreshService: listRefreshService,
       themeAccent: ThemeManager.shared.currentTheme.linkColor
     )
     viewModel.onTransition = { route in
@@ -64,6 +65,8 @@ class FolderListCoordinator: ItemListCoordinator {
         self.showMiniPlayer(flag: flag)
       case .listDidAppear:
         self.syncList()
+      case .showQueuedTasks:
+        self.showQueuedTasks()
       }
     }
     viewModel.coordinator = self

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -18,7 +18,8 @@ class FolderListCoordinator: ItemListCoordinator {
     playerManager: PlayerManagerProtocol,
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol,
-    syncService: SyncServiceProtocol
+    syncService: SyncServiceProtocol,
+    listRefreshService: ListSyncRefreshService
   ) {
     self.folderRelativePath = folderRelativePath
 
@@ -27,7 +28,8 @@ class FolderListCoordinator: ItemListCoordinator {
       playerManager: playerManager,
       libraryService: libraryService,
       playbackService: playbackService,
-      syncService: syncService
+      syncService: syncService,
+      listRefreshService: listRefreshService
     )
   }
 
@@ -72,14 +74,12 @@ class FolderListCoordinator: ItemListCoordinator {
   }
 
   override func syncList() {
-    Task { @MainActor in
-      guard await syncService.canSyncListContents(at: folderRelativePath) else { return }
+    guard syncService.canSyncListContents(at: folderRelativePath, ignoreLastTimestamp: false) else { return }
 
-      do {
-        _ = try await syncService.syncListContents(at: folderRelativePath)
-        reloadItemsWithPadding()
-      } catch {
-        Self.logger.trace("Sync contents error: \(error.localizedDescription)")
+    Task {
+      await listRefreshService.syncList(at: folderRelativePath, alertPresenter: self)
+      await MainActor.run {
+        self.reloadItemsWithPadding()
       }
     }
   }

--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -16,6 +16,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
   let libraryService: LibraryServiceProtocol
   let playbackService: PlaybackServiceProtocol
   let syncService: SyncServiceProtocol
+  let listRefreshService: ListSyncRefreshService
   let flow: BPCoordinatorPresentationFlow
 
   weak var documentPickerDelegate: UIDocumentPickerDelegate?
@@ -25,13 +26,15 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
     playerManager: PlayerManagerProtocol,
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol,
-    syncService: SyncServiceProtocol
+    syncService: SyncServiceProtocol,
+    listRefreshService: ListSyncRefreshService
   ) {
     self.flow = flow
     self.playerManager = playerManager
     self.libraryService = libraryService
     self.playbackService = playbackService
     self.syncService = syncService
+    self.listRefreshService = listRefreshService
   }
 
   func start() {
@@ -49,7 +52,12 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
       playerManager: playerManager,
       libraryService: libraryService,
       playbackService: playbackService,
-      syncService: syncService
+      syncService: syncService,
+      listRefreshService: ListSyncRefreshService(
+        playerManager: playerManager,
+        libraryService: libraryService,
+        syncService: syncService
+      )
     )
     child.start()
   }

--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -62,6 +62,13 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
     child.start()
   }
 
+  func showQueuedTasks() {
+    let viewModel = QueuedSyncTasksViewModel(syncService: syncService)
+    let vc = QueuedSyncTasksViewController(viewModel: viewModel)
+    let nav = AppNavigationController(rootViewController: vc)
+    flow.navigationController.present(nav, animated: true)
+  }
+
   func showPlayer() {
     let playerCoordinator = PlayerCoordinator(
       flow: .modalOnlyFlow(presentingController: flow.navigationController, modalPresentationStyle: .overFullScreen),

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -54,6 +54,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
       libraryService: self.libraryService,
       playbackService: self.playbackService,
       syncService: self.syncService,
+      listRefreshService: listRefreshService,
       themeAccent: ThemeManager.shared.currentTheme.linkColor
     )
     viewModel.onTransition = { route in
@@ -76,6 +77,8 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
         self.showMiniPlayer(flag: flag)
       case .listDidAppear:
         self.handleLibraryLoaded()
+      case .showQueuedTasks:
+        self.showQueuedTasks()
       }
     }
     viewModel.coordinator = self

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -87,7 +87,12 @@ class MainCoordinator: NSObject {
       importManager: ImportManager(libraryService: self.libraryService),
       libraryService: self.libraryService,
       playbackService: self.playbackService,
-      syncService: syncService
+      syncService: syncService,
+      listRefreshService: ListSyncRefreshService(
+        playerManager: playerManager,
+        libraryService: libraryService,
+        syncService: syncService
+      )
     )
     playerManager.syncProgressDelegate = libraryCoordinator
     self.libraryCoordinator = libraryCoordinator

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1432,22 +1432,22 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     }
     //MARK: - canSyncListContents
 
-    var canSyncListContentsAtCallsCount = 0
-    var canSyncListContentsAtCalled: Bool {
-        return canSyncListContentsAtCallsCount > 0
+    var canSyncListContentsAtIgnoreLastTimestampCallsCount = 0
+    var canSyncListContentsAtIgnoreLastTimestampCalled: Bool {
+        return canSyncListContentsAtIgnoreLastTimestampCallsCount > 0
     }
-    var canSyncListContentsAtReceivedRelativePath: String?
-    var canSyncListContentsAtReceivedInvocations: [String?] = []
-    var canSyncListContentsAtReturnValue: Bool!
-    var canSyncListContentsAtClosure: ((String?) async -> Bool)?
-    func canSyncListContents(at relativePath: String?) async -> Bool {
-        canSyncListContentsAtCallsCount += 1
-        canSyncListContentsAtReceivedRelativePath = relativePath
-        canSyncListContentsAtReceivedInvocations.append(relativePath)
-        if let canSyncListContentsAtClosure = canSyncListContentsAtClosure {
-            return await canSyncListContentsAtClosure(relativePath)
+    var canSyncListContentsAtIgnoreLastTimestampReceivedArguments: (relativePath: String?, ignoreLastTimestamp: Bool)?
+    var canSyncListContentsAtIgnoreLastTimestampReceivedInvocations: [(relativePath: String?, ignoreLastTimestamp: Bool)] = []
+    var canSyncListContentsAtIgnoreLastTimestampReturnValue: Bool!
+    var canSyncListContentsAtIgnoreLastTimestampClosure: ((String?, Bool) -> Bool)?
+    func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) -> Bool {
+        canSyncListContentsAtIgnoreLastTimestampCallsCount += 1
+        canSyncListContentsAtIgnoreLastTimestampReceivedArguments = (relativePath: relativePath, ignoreLastTimestamp: ignoreLastTimestamp)
+        canSyncListContentsAtIgnoreLastTimestampReceivedInvocations.append((relativePath: relativePath, ignoreLastTimestamp: ignoreLastTimestamp))
+        if let canSyncListContentsAtIgnoreLastTimestampClosure = canSyncListContentsAtIgnoreLastTimestampClosure {
+            return canSyncListContentsAtIgnoreLastTimestampClosure(relativePath, ignoreLastTimestamp)
         } else {
-            return canSyncListContentsAtReturnValue
+            return canSyncListContentsAtIgnoreLastTimestampReturnValue
         }
     }
     //MARK: - syncListContents

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -37,6 +37,7 @@ class ItemListViewModel: ViewModelProtocol {
     case showAlert(content: BPAlertContent)
     case showLoader(flag: Bool)
     case showProcessingView(Bool, title: String?, subtitle: String?)
+    case refreshedData
   }
 
   weak var coordinator: ItemListCoordinator!
@@ -940,6 +941,13 @@ class ItemListViewModel: ViewModelProtocol {
 
   private func sendEvent(_ event: ItemListViewModel.Events) {
     eventsPublisher.send(event)
+  }
+
+  func refreshAppState() {
+    /// Check if there's any pending file to import
+    notifyPendingFiles()
+    /// TODO: sync list
+    sendEvent(.refreshedData)
   }
 }
 

--- a/BookPlayer/Services/ListSyncRefreshService.swift
+++ b/BookPlayer/Services/ListSyncRefreshService.swift
@@ -9,6 +9,11 @@
 import BookPlayerKit
 import Foundation
 
+enum BPSyncRefreshError: Error {
+  /// There are queued tasks and can't fetch remote data
+  case scheduledTasks
+}
+
 class ListSyncRefreshService: BPLogger {
   let playerManager: PlayerManagerProtocol
   let libraryService: LibraryServiceProtocol
@@ -43,7 +48,7 @@ class ListSyncRefreshService: BPLogger {
   }
 
   @MainActor
-  func reloadLastBook(relativePath: String, alertPresenter: AlertPresenter) {
+  private func reloadLastBook(relativePath: String, alertPresenter: AlertPresenter) {
     let wasPlaying = playerManager.isPlaying
     playerManager.stop()
     AppDelegate.shared?.loadPlayer(
@@ -55,7 +60,7 @@ class ListSyncRefreshService: BPLogger {
   }
 
   @MainActor
-  func setSyncedLastPlayedItem(relativePath: String, alertPresenter: AlertPresenter) {
+  private func setSyncedLastPlayedItem(relativePath: String, alertPresenter: AlertPresenter) {
     /// Only continue overriding local book if it's not currently playing
     guard playerManager.isPlaying == false else { return }
 

--- a/BookPlayer/Services/ListSyncRefreshService.swift
+++ b/BookPlayer/Services/ListSyncRefreshService.swift
@@ -1,0 +1,70 @@
+//
+//  ListSyncRefreshService.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 30/1/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+
+class ListSyncRefreshService: BPLogger {
+  let playerManager: PlayerManagerProtocol
+  let libraryService: LibraryServiceProtocol
+  let syncService: SyncServiceProtocol
+
+  init(
+    playerManager: PlayerManagerProtocol,
+    libraryService: LibraryServiceProtocol,
+    syncService: SyncServiceProtocol
+  ) {
+    self.playerManager = playerManager
+    self.libraryService = libraryService
+    self.syncService = syncService
+  }
+
+  func syncList(at relativePath: String?, alertPresenter: AlertPresenter) async {
+    do {
+      if let relativePath {
+        try await syncService.syncListContents(at: relativePath)
+      } else if UserDefaults.standard.bool(forKey: Constants.UserDefaults.hasScheduledLibraryContents) == true {
+        try await syncService.syncListContents(at: nil)
+      } else {
+        try await syncService.syncLibraryContents()
+      }
+    } catch BPSyncError.reloadLastBook(let relativePath) {
+      await reloadLastBook(relativePath: relativePath, alertPresenter: alertPresenter)
+    } catch BPSyncError.differentLastBook(let relativePath) {
+      await setSyncedLastPlayedItem(relativePath: relativePath, alertPresenter: alertPresenter)
+    } catch {
+      Self.logger.trace("Sync contents error: \(error.localizedDescription)")
+    }
+  }
+
+  @MainActor
+  func reloadLastBook(relativePath: String, alertPresenter: AlertPresenter) {
+    let wasPlaying = playerManager.isPlaying
+    playerManager.stop()
+    AppDelegate.shared?.loadPlayer(
+      relativePath,
+      autoplay: wasPlaying,
+      showPlayer: nil,
+      alertPresenter: alertPresenter
+    )
+  }
+
+  @MainActor
+  func setSyncedLastPlayedItem(relativePath: String, alertPresenter: AlertPresenter) {
+    /// Only continue overriding local book if it's not currently playing
+    guard playerManager.isPlaying == false else { return }
+
+    libraryService.setLibraryLastBook(with: relativePath)
+    AppDelegate.shared?.loadPlayer(
+      relativePath,
+      autoplay: false,
+      showPlayer: nil,
+      alertPresenter: alertPresenter
+    )
+  }
+}

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "القفل التلقائي";
 "settings_sleeptimer_auto_title" = "مؤقت النوم التلقائي";
 "settings_sleeptimer_auto_description" = "أعد تشغيل آخر مؤقت نوم نشط عند استئناف التشغيل";
+"sync_tasks_inprogress_alert_title" = "لا يمكن مزامنة البيانات أثناء وجود مهام في قائمة الانتظار قيد التقدم";
+"sync_tasks_view_title" = "عرض المهام";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automatický zámek";
 "settings_sleeptimer_auto_title" = "Časovač automatického vypnutí";
 "settings_sleeptimer_auto_description" = "Po obnovení přehrávání restartujte poslední aktivní časovač vypnutí";
+"sync_tasks_inprogress_alert_title" = "Nelze synchronizovat data, když probíhají úlohy ve frontě";
+"sync_tasks_view_title" = "Zobrazit úkoly";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Autolås";
 "settings_sleeptimer_auto_title" = "Auto Sleep Timer";
 "settings_sleeptimer_auto_description" = "Genstart den sidst aktive sleep-timer, når afspilningen genoptages";
+"sync_tasks_inprogress_alert_title" = "Kan ikke synkronisere data, mens der er igangværende opgaver i kø";
+"sync_tasks_view_title" = "Se opgaver";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automatische Sperre";
 "settings_sleeptimer_auto_title" = "Automatischer Sleep-Timer";
 "settings_sleeptimer_auto_description" = "Starten Sie den zuletzt aktiven Sleep-Timer neu, wenn die Wiedergabe fortgesetzt wird";
+"sync_tasks_inprogress_alert_title" = "Daten können nicht synchronisiert werden, während Aufgaben in der Warteschlange ausgeführt werden";
+"sync_tasks_view_title" = "Aufgaben anzeigen";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -305,3 +305,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "settings_autlock_section_title" = "Autolock";
 "settings_sleeptimer_auto_title" = "Auto Sleep Timer";
 "settings_sleeptimer_auto_description" = "Restart the last active sleep timer when playback is resumed";
+"sync_tasks_inprogress_alert_title" = "Can't sync data while there are queued tasks in progress";
+"sync_tasks_view_title" = "View tasks";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Bloqueo automático";
 "settings_sleeptimer_auto_title" = "Temporizador de apagado automático";
 "settings_sleeptimer_auto_description" = "Reinicie el último temporizador de apagado activo cuando se reanude la reproducción";
+"sync_tasks_inprogress_alert_title" = "No se pueden sincronizar datos mientras hay tareas en cola en progreso";
+"sync_tasks_view_title" = "Ver tareas";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automaattinen lukitus";
 "settings_sleeptimer_auto_title" = "Automaattinen uniajastin";
 "settings_sleeptimer_auto_description" = "Käynnistä viimeinen aktiivinen uniajastin uudelleen, kun toistoa jatketaan";
+"sync_tasks_inprogress_alert_title" = "Tietoja ei voi synkronoida, kun jonossa on tehtäviä kesken";
+"sync_tasks_view_title" = "Näytä tehtävät";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Verrouillage automatique";
 "settings_sleeptimer_auto_title" = "Minuterie de mise en veille automatique";
 "settings_sleeptimer_auto_description" = "Redémarrez la dernière minuterie de mise en veille active lorsque la lecture reprend";
+"sync_tasks_inprogress_alert_title" = "Impossible de synchroniser les données alors que des tâches en file d'attente sont en cours";
+"sync_tasks_view_title" = "Afficher les tâches";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automata zár";
 "settings_sleeptimer_auto_title" = "Automatikus elalváskapcsoló";
 "settings_sleeptimer_auto_description" = "A lejátszás folytatásakor indítsa újra az utolsó aktív elalváskapcsolót";
+"sync_tasks_inprogress_alert_title" = "Nem lehet szinkronizálni az adatokat, amíg vannak folyamatban lévő feladatok";
+"sync_tasks_view_title" = "Feladatok megtekintése";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Chiusura automatica";
 "settings_sleeptimer_auto_title" = "Temporizzatore di spegnimento automatico";
 "settings_sleeptimer_auto_description" = "Riavvia l'ultimo timer di spegnimento attivo quando viene ripresa la riproduzione";
+"sync_tasks_inprogress_alert_title" = "Impossibile sincronizzare i dati mentre sono presenti attività in coda in corso";
+"sync_tasks_view_title" = "Visualizza attività";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -305,3 +305,5 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "settings_autlock_section_title" = "Automatisk lås";
 "settings_sleeptimer_auto_title" = "Auto Sleep Timer";
 "settings_sleeptimer_auto_description" = "Start den siste aktive innsovningstimeren på nytt når avspillingen gjenopptas";
+"sync_tasks_inprogress_alert_title" = "Kan ikke synkronisere data mens det pågår oppgaver i kø";
+"sync_tasks_view_title" = "Se oppgaver";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automatische vergrendeling";
 "settings_sleeptimer_auto_title" = "Automatische slaaptimer";
 "settings_sleeptimer_auto_description" = "Start de laatste actieve slaaptimer opnieuw wanneer het afspelen wordt hervat";
+"sync_tasks_inprogress_alert_title" = "Kan gegevens niet synchroniseren terwijl er taken in de wachtrij staan";
+"sync_tasks_view_title" = "Bekijk taken";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Automatyczna blokada";
 "settings_sleeptimer_auto_title" = "Automatyczny wyłącznik czasowy";
 "settings_sleeptimer_auto_description" = "Po wznowieniu odtwarzania uruchom ponownie ostatni aktywny timer uśpienia";
+"sync_tasks_inprogress_alert_title" = "Nie można zsynchronizować danych, gdy w kolejce znajdują się zadania w toku";
+"sync_tasks_view_title" = "Zobacz zadania";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Bloqueio automático";
 "settings_sleeptimer_auto_title" = "Temporizador automático";
 "settings_sleeptimer_auto_description" = "Reinicie o último temporizador ativo quando a reprodução for retomada";
+"sync_tasks_inprogress_alert_title" = "Não é possível sincronizar dados enquanto há tarefas na fila em andamento";
+"sync_tasks_view_title" = "Ver tarefas";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Bloqueio automático";
 "settings_sleeptimer_auto_title" = "Temporizador automático";
 "settings_sleeptimer_auto_description" = "Reinicie o último temporizador ativo quando a reprodução for retomada";
+"sync_tasks_inprogress_alert_title" = "Não é possível sincronizar dados enquanto há tarefas na fila em andamento";
+"sync_tasks_view_title" = "Ver tarefas";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Închidere automată";
 "settings_sleeptimer_auto_title" = "Temporizator de oprire automată";
 "settings_sleeptimer_auto_description" = "Reporniți ultimul temporizator de repaus activ când redarea este reluată";
+"sync_tasks_inprogress_alert_title" = "Nu se pot sincroniza datele în timp ce sunt sarcini în coadă în desfășurare";
+"sync_tasks_view_title" = "Vizualizați sarcini";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Автоматическая блокировка";
 "settings_sleeptimer_auto_title" = "Автоматический таймер сна";
 "settings_sleeptimer_auto_description" = "Перезапустите последний активный таймер сна, когда воспроизведение возобновится.";
+"sync_tasks_inprogress_alert_title" = "Невозможно синхронизировать данные, пока выполняются задачи в очереди.";
+"sync_tasks_view_title" = "Просмотр задач";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -305,3 +305,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "settings_autlock_section_title" = "Automatické zamknutie";
 "settings_sleeptimer_auto_title" = "Časovač automatického vypnutia";
 "settings_sleeptimer_auto_description" = "Po obnovení prehrávania reštartujte posledný aktívny časovač spánku";
+"sync_tasks_inprogress_alert_title" = "Nie je možné synchronizovať údaje, kým prebiehajú úlohy vo fronte";
+"sync_tasks_view_title" = "Zobraziť úlohy";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Auto lås";
 "settings_sleeptimer_auto_title" = "Automatisk insomningstimer";
 "settings_sleeptimer_auto_description" = "Starta om den senast aktiva insomningstimern när uppspelningen återupptas";
+"sync_tasks_inprogress_alert_title" = "Det går inte att synkronisera data medan det pågår uppgifter i kö";
+"sync_tasks_view_title" = "Visa uppgifter";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Otomatik kilit";
 "settings_sleeptimer_auto_title" = "Otomatik Uyku Zamanlayıcısı";
 "settings_sleeptimer_auto_description" = "Oynatma devam ettirildiğinde son aktif uyku zamanlayıcısını yeniden başlatın";
+"sync_tasks_inprogress_alert_title" = "Devam eden sıraya alınmış görevler varken veriler senkronize edilemez";
+"sync_tasks_view_title" = "Görevleri görüntüle";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "Автоблокування";
 "settings_sleeptimer_auto_title" = "Автоматичний таймер сну";
 "settings_sleeptimer_auto_description" = "Перезапустіть останній активний таймер сну, коли відтворення відновиться";
+"sync_tasks_inprogress_alert_title" = "Неможливо синхронізувати дані, поки виконуються завдання в черзі";
+"sync_tasks_view_title" = "Переглянути завдання";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -305,3 +305,5 @@
 "settings_autlock_section_title" = "自动锁";
 "settings_sleeptimer_auto_title" = "自动睡眠定时器";
 "settings_sleeptimer_auto_description" = "恢复播放时重新启动最后一个活动的睡眠计时器";
+"sync_tasks_inprogress_alert_title" = "有正在进行的排队任务时无法同步数据";
+"sync_tasks_view_title" = "查看任务";

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -28,6 +28,7 @@ class LibraryListCoordinatorTests: XCTestCase {
     playerManagerMock.currentItemPublisherReturnValue = Just(nil).eraseToAnyPublisher()
     playerManagerMock.currentSpeedPublisherReturnValue = Just(1.0).eraseToAnyPublisher()
     playerManagerMock.isPlayingPublisherReturnValue = Just(false).eraseToAnyPublisher()
+    let syncServiceMock = SyncServiceProtocolMock()
 
     self.libraryListCoordinator = LibraryListCoordinator(
       flow: .pushFlow(navigationController: self.presentingController),
@@ -35,7 +36,12 @@ class LibraryListCoordinatorTests: XCTestCase {
       importManager: ImportManager(libraryService: libraryService),
       libraryService: libraryService,
       playbackService: coreServices.playbackService,
-      syncService: SyncServiceProtocolMock()
+      syncService: syncServiceMock,
+      listRefreshService: ListSyncRefreshService(
+        playerManager: playerManagerMock,
+        libraryService: libraryService,
+        syncService: syncServiceMock
+      )
     )
 
     self.libraryListCoordinator.start()
@@ -77,6 +83,7 @@ class FolderListCoordinatorTests: XCTestCase {
     let folder = try! StubFactory.folder(dataManager: dataManager, title: "folder 1")
     let playerManagerMock = PlayerManagerProtocolMock()
     playerManagerMock.currentItemPublisherReturnValue = Just(nil).eraseToAnyPublisher()
+    let syncServiceMock = SyncServiceProtocolMock()
 
     self.folderListCoordinator = FolderListCoordinator(
       flow: .pushFlow(navigationController: self.presentingController),
@@ -84,7 +91,12 @@ class FolderListCoordinatorTests: XCTestCase {
       playerManager: playerManagerMock,
       libraryService: libraryService,
       playbackService: PlaybackService(libraryService: libraryService),
-      syncService: SyncServiceProtocolMock()
+      syncService: syncServiceMock,
+      listRefreshService: ListSyncRefreshService(
+        playerManager: playerManagerMock,
+        libraryService: libraryService,
+        syncService: syncServiceMock
+      )
     )
 
     self.folderListCoordinator.start()

--- a/BookPlayerTests/ItemListViewModelTests.swift
+++ b/BookPlayerTests/ItemListViewModelTests.swift
@@ -23,6 +23,7 @@ class ItemListViewModelTests: XCTestCase {
     let libraryService = LibraryService(dataManager: dataManager)
     let playerManagerMock = PlayerManagerProtocolMock()
     playerManagerMock.currentItemPublisherReturnValue = Just(nil).eraseToAnyPublisher()
+    let syncServiceMock = SyncServiceProtocolMock()
 
     self.sut = ItemListViewModel(
       folderRelativePath: nil,
@@ -30,7 +31,12 @@ class ItemListViewModelTests: XCTestCase {
       networkClient: NetworkClient(),
       libraryService: libraryService,
       playbackService: PlaybackServiceProtocolMock(),
-      syncService: SyncServiceProtocolMock(),
+      syncService: syncServiceMock, 
+      listRefreshService: ListSyncRefreshService(
+        playerManager: playerManagerMock,
+        libraryService: libraryService,
+        syncService: syncServiceMock
+      ),
       themeAccent: .blue
     )
 

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1097,9 +1097,13 @@ extension LibraryService {
     }
 
     try? removeFolderIfNeeded(destinationURL, context: context)
+
+    /// If the folder already exists, `withIntermediateDirectories` being true will not throw the error
+    let destinationFolderExists = FileManager.default.fileExists(atPath: destinationURL.path)
+
     try FileManager.default.createDirectory(
       at: destinationURL,
-      withIntermediateDirectories: true,
+      withIntermediateDirectories: !destinationFolderExists,
       attributes: nil
     )
   }

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -179,11 +179,6 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
       return false
     }
 
-    UserDefaults.standard.set(
-      Date().timeIntervalSince1970,
-      forKey: userDefaultsKey
-    )
-
     return true
   }
 
@@ -195,6 +190,11 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     let response = try await fetchContents(at: relativePath)
 
     try await processContentsResponse(response, parentFolder: relativePath, canDelete: true)
+
+    UserDefaults.standard.set(
+      Date().timeIntervalSince1970,
+      forKey: "\(Constants.UserDefaults.lastSyncTimestamp)_\(relativePath ?? "library")"
+    )
   }
 
   public func syncLibraryContents() async throws {


### PR DESCRIPTION
## Purpose

- Add pull down to refresh to:
  - Scan local files in case there's something pending import
  - Fetch remote data

## Related tasks

#1074

## Approach

- Add refresh control to the table view
- Rework fetching the data and the last played book update into a separate service
- Use new service to be reused between the coordinators and the item list view model

## Things to be aware of / Things to focus on

- There was a bug introduced by setting the flag `withIntermediateDirectories` to true when creating a folder on disk, this would make the FileManager not throw an error if there was already a folder with the exact name
