### PR TITLE
Fix showing the import modal on launch for newer phones

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -19,6 +19,7 @@ class FolderListCoordinator: ItemListCoordinator {
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol,
     syncService: SyncServiceProtocol,
+    importManager: ImportManager,
     listRefreshService: ListSyncRefreshService
   ) {
     self.folderRelativePath = folderRelativePath
@@ -28,7 +29,8 @@ class FolderListCoordinator: ItemListCoordinator {
       playerManager: playerManager,
       libraryService: libraryService,
       playbackService: playbackService,
-      syncService: syncService,
+      syncService: syncService, 
+      importManager: importManager,
       listRefreshService: listRefreshService
     )
   }
@@ -42,6 +44,7 @@ class FolderListCoordinator: ItemListCoordinator {
       libraryService: self.libraryService,
       playbackService: self.playbackService,
       syncService: self.syncService, 
+      importManager: self.importManager, 
       listRefreshService: listRefreshService,
       themeAccent: ThemeManager.shared.currentTheme.linkColor
     )

--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -16,6 +16,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
   let libraryService: LibraryServiceProtocol
   let playbackService: PlaybackServiceProtocol
   let syncService: SyncServiceProtocol
+  let importManager: ImportManager
   let listRefreshService: ListSyncRefreshService
   let flow: BPCoordinatorPresentationFlow
 
@@ -27,6 +28,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
     libraryService: LibraryServiceProtocol,
     playbackService: PlaybackServiceProtocol,
     syncService: SyncServiceProtocol,
+    importManager: ImportManager,
     listRefreshService: ListSyncRefreshService
   ) {
     self.flow = flow
@@ -34,6 +36,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
     self.libraryService = libraryService
     self.playbackService = playbackService
     self.syncService = syncService
+    self.importManager = importManager
     self.listRefreshService = listRefreshService
   }
 
@@ -53,6 +56,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
       libraryService: libraryService,
       playbackService: playbackService,
       syncService: syncService,
+      importManager: importManager,
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManager,
         libraryService: libraryService,

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -84,10 +84,10 @@ class MainCoordinator: NSObject {
     let libraryCoordinator = LibraryListCoordinator(
       flow: .pushFlow(navigationController: AppNavigationController.instantiate(from: .Main)),
       playerManager: self.playerManager,
-      importManager: ImportManager(libraryService: self.libraryService),
       libraryService: self.libraryService,
       playbackService: self.playbackService,
       syncService: syncService,
+      importManager: ImportManager(libraryService: self.libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManager,
         libraryService: libraryService,

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -118,11 +118,8 @@ class ItemListViewController: UIViewController, MVVMControllerProtocol, Storyboa
     if didAppearForFirstTime {
       didAppearForFirstTime = false
       viewModel.viewDidAppear()
-      /// Can't do this on viewDidLoad as there's no guarantee that the scene delegate will
-      /// have an 'active' status
       if navigationController?.viewControllers.count == 1 {
         navigationController!.interactivePopGestureRecognizer!.delegate = self
-        viewModel.notifyPendingFiles()
       }
     }
   }

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -33,10 +33,10 @@ class LibraryListCoordinatorTests: XCTestCase {
     self.libraryListCoordinator = LibraryListCoordinator(
       flow: .pushFlow(navigationController: self.presentingController),
       playerManager: playerManagerMock,
-      importManager: ImportManager(libraryService: libraryService),
       libraryService: libraryService,
       playbackService: coreServices.playbackService,
       syncService: syncServiceMock,
+      importManager: ImportManager(libraryService: libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
         libraryService: libraryService,
@@ -91,7 +91,8 @@ class FolderListCoordinatorTests: XCTestCase {
       playerManager: playerManagerMock,
       libraryService: libraryService,
       playbackService: PlaybackService(libraryService: libraryService),
-      syncService: syncServiceMock,
+      syncService: syncServiceMock, 
+      importManager: ImportManager(libraryService: libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
         libraryService: libraryService,

--- a/BookPlayerTests/ItemListViewModelTests.swift
+++ b/BookPlayerTests/ItemListViewModelTests.swift
@@ -32,6 +32,7 @@ class ItemListViewModelTests: XCTestCase {
       libraryService: libraryService,
       playbackService: PlaybackServiceProtocolMock(),
       syncService: syncServiceMock, 
+      importManager: ImportManager(libraryService: libraryService), 
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
         libraryService: libraryService,


### PR DESCRIPTION
## Bugfix

- On newer phones (reproducible on iPhone 15 pro), there are no `UIScene`s with the `foregroundActive` status when the library's `viewDidAppear` event is called. Resulting in the initial scan being called before the import observers are live

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/1074

## Approach

- Move the `notifyPendingFiles` outside of the `viewDidAppear` of the screen, to now be called after the import observers are initialized on the coordinator