### PR TITLE
Fix file references checks

### DIFF
--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -44,6 +44,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
     fatalError("ItemListCoordinator is an abstract class, override this function in the subclass")
   }
 
+  @MainActor
   func getMainCoordinator() -> MainCoordinator? {
     return AppDelegate.shared?.activeSceneDelegate?.mainCoordinator
   }
@@ -117,7 +118,9 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
   }
 
   func showMiniPlayer(flag: Bool) {
-    getMainCoordinator()?.showMiniPlayer(flag)
+    Task { @MainActor in
+      getMainCoordinator()?.showMiniPlayer(flag)
+    }
   }
 
   func syncList() {

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -148,6 +148,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
         $0.lastPathComponent != DataManager.processedFolderName
         && $0.lastPathComponent != DataManager.inboxFolderName
         && $0.lastPathComponent != DataManager.backupFolderName
+        && $0.lastPathComponent != DataManager.trashFolderName
       }
 
     let sharedURLs = (try? FileManager.default.contentsOfDirectory(

--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -44,7 +44,8 @@ final class ImportManager {
   }
 
   public func removeFile(_ item: URL, updateCollection: Bool = true) throws {
-    if FileManager.default.fileExists(atPath: item.path) {
+    if FileManager.default.fileExists(atPath: item.path),
+       FileManager.default.isDeletableFile(atPath: item.path) {
       try FileManager.default.removeItem(at: item)
     }
 

--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -212,12 +212,13 @@ public class ImportOperation: Operation {
     // Add support for iCloud documents
     let accessGranted = currentFile.startAccessingSecurityScopedResource()
 
+    defer { currentFile.stopAccessingSecurityScopedResource() }
+
     let destinationURL = self.getNextAvailableURL(for: currentFile)
 
     do {
       if accessGranted {
         try FileManager.default.copyItem(at: currentFile, to: destinationURL)
-        currentFile.stopAccessingSecurityScopedResource()
       } else {
         try FileManager.default.moveItem(at: currentFile, to: destinationURL)
       }

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -14,6 +14,7 @@ public class DataManager {
   public static let backupFolderName = "BPBackup"
   public static let inboxFolderName = "Inbox"
   public static let sharedFolderName = "SharedBP"
+  public static let trashFolderName = ".Trash"
   public static var loadingDataError: Error?
   private let coreDataStack: CoreDataStack
   private var pendingSaveContext: DispatchWorkItem?


### PR DESCRIPTION
## Bugfix

- When deleting a file from the Files app, the system generates a `.Trash` folder
- Trying to delete an item from the Inbox system folder can throw an error 

## Related tasks

#1094
#1095 

## Approach

- Ignore system trash folder
- Use `.isDeletableFile` check before deleting and cancelling the import operation
