### PR TITLE
Add support for background tasks

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		6357F1192A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6357F1182A8BA084007947FC /* BPURLSession.swift */; };
 		635907A02B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6359079F2B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift */; };
+		63717EAA2B792E350006291E /* RefreshTaskOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63717EA92B792E350006291E /* RefreshTaskOperation.swift */; };
 		637609192ADCD81400A01D5D /* AppShortcuts.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6376091B2ADCD81400A01D5D /* AppShortcuts.strings */; };
 		637DAB0B2AEB3F6D006DC2D1 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		637DAB0D2AEBEF1B006DC2D1 /* BookPlayerWatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */; };
@@ -1066,6 +1067,7 @@
 		6356F9CF2ACB01C700B7A027 /* PausePlaybackIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PausePlaybackIntent.swift; sourceTree = "<group>"; };
 		6357F1182A8BA084007947FC /* BPURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPURLSession.swift; sourceTree = "<group>"; };
 		6359079F2B161B14002FA524 /* DebugInformationFileActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugInformationFileActivityItemProvider.swift; sourceTree = "<group>"; };
+		63717EA92B792E350006291E /* RefreshTaskOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTaskOperation.swift; sourceTree = "<group>"; };
 		6376091A2ADCD81400A01D5D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091C2ADCD82100A01D5D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/AppShortcuts.strings; sourceTree = "<group>"; };
 		6376091D2ADCD82100A01D5D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/AppShortcuts.strings"; sourceTree = "<group>"; };
@@ -2460,6 +2462,7 @@
 				9FB20EB829A479FB0021663B /* BPAlertContent.swift */,
 				9FD8D95729DC53750074C2D8 /* CoreServices.swift */,
 				6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */,
+				63717EA92B792E350006291E /* RefreshTaskOperation.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3284,6 +3287,7 @@
 				C3FA301E20E0024900393DDA /* BPArtworkView.swift in Sources */,
 				41E79BE926C60BF600EA9FFF /* PlayerViewController.swift in Sources */,
 				41188D2226ECFE450017124E /* ChapterCoordinator.swift in Sources */,
+				63717EAA2B792E350006291E /* RefreshTaskOperation.swift in Sources */,
 				4165EE0520A743D500616EDF /* BookPlayer.xcdatamodeld in Sources */,
 				41B2A5DC21CAEE0E00917584 /* PlayerSettingsViewController.swift in Sources */,
 				9FF710B72A212A19006490E0 /* QueuedSyncTasksView.swift in Sources */,

--- a/BookPlayer/Info.plist
+++ b/BookPlayer/Info.plist
@@ -7,7 +7,6 @@
 		<string>$(BP_BUNDLE_IDENTIFIER).background</string>
 		<string>$(BP_BUNDLE_IDENTIFIER).background.cellular</string>
 		<string>$(BP_BUNDLE_IDENTIFIER).background.refresh</string>
-		<string>$(BP_BUNDLE_IDENTIFIER).background.sync.tasksQueue</string>
 	</array>
 	<key>BP_API_DOMAIN</key>
 	<string>$(BP_API_DOMAIN)</string>
@@ -358,7 +357,6 @@
 	<array>
 		<string>audio</string>
 		<string>fetch</string>
-		<string>processing</string>
 	</array>
 	<key>UIBrowsableContentSupportsSectionedBrowsing</key>
 	<true/>

--- a/BookPlayer/Utils/RefreshTaskOperation.swift
+++ b/BookPlayer/Utils/RefreshTaskOperation.swift
@@ -11,7 +11,7 @@ import Combine
 import Foundation
 
 /// Reference: https://www.avanderlee.com/swift/asynchronous-operations/
-class RefreshTaskOperation: Operation, BPLogger {
+class RefreshTaskOperation: Operation {
   /// Sync service
   let syncService: SyncServiceProtocol
   private var syncTasksObserver: NSKeyValueObservation?
@@ -75,10 +75,7 @@ class RefreshTaskOperation: Operation, BPLogger {
       
       Task {
         if await self.syncService.queuedJobsCount() == 0 {
-          Self.logFile(message: "\(Date()): operation 0 queued jobs")
           self.finish()
-        } else {
-          Self.logFile(message: "\(Date()): operation has queued jobs")
         }
       }
     }

--- a/BookPlayer/Utils/RefreshTaskOperation.swift
+++ b/BookPlayer/Utils/RefreshTaskOperation.swift
@@ -1,0 +1,92 @@
+//
+//  RefreshTaskOperation.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 11/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import BookPlayerKit
+import Combine
+import Foundation
+
+/// Reference: https://www.avanderlee.com/swift/asynchronous-operations/
+class RefreshTaskOperation: Operation, BPLogger {
+  /// Sync service
+  let syncService: SyncServiceProtocol
+  private var syncTasksObserver: NSKeyValueObservation?
+
+  private let lockQueue = DispatchQueue(label: "com.bookplayer.asyncoperation.refreshtask", attributes: .concurrent)
+  override var isAsynchronous: Bool { true }
+
+  private var _isExecuting: Bool = false
+  override private(set) var isExecuting: Bool {
+    get {
+      return lockQueue.sync { () -> Bool in
+        return _isExecuting
+      }
+    }
+    set {
+      willChangeValue(forKey: "isExecuting")
+      lockQueue.sync(flags: [.barrier]) {
+        _isExecuting = newValue
+      }
+      didChangeValue(forKey: "isExecuting")
+    }
+  }
+
+  private var _isFinished: Bool = false
+  override private(set) var isFinished: Bool {
+    get {
+      return lockQueue.sync { () -> Bool in
+        return _isFinished
+      }
+    }
+    set {
+      willChangeValue(forKey: "isFinished")
+      lockQueue.sync(flags: [.barrier]) {
+        _isFinished = newValue
+      }
+      didChangeValue(forKey: "isFinished")
+    }
+  }
+
+  init(syncService: SyncServiceProtocol) {
+    self.syncService = syncService
+  }
+
+  override func start() {
+    guard !isCancelled else {
+      finish()
+      return
+    }
+
+    isFinished = false
+    isExecuting = true
+    main()
+  }
+
+  override func main() {
+    syncTasksObserver = UserDefaults.standard.observe(
+      \.userSyncTasksQueue,
+       options: [.initial, .new]
+    ) { [weak self] _, _ in
+      guard let self else { return }
+      
+      Task {
+        if await self.syncService.queuedJobsCount() == 0 {
+          Self.logFile(message: "\(Date()): operation 0 queued jobs")
+          self.finish()
+        } else {
+          Self.logFile(message: "\(Date()): operation has queued jobs")
+        }
+      }
+    }
+  }
+
+  func finish() {
+    syncTasksObserver = nil
+    isExecuting = false
+    isFinished = true
+  }
+}


### PR DESCRIPTION
## Purpose

- The initial batch of sync tasks can be too big to be handled in one session, so we're adding background tasks to help alleviate and complete tasks throughout the day

## Approach

- Register new background app refresh task
- Create new operation that will handle observing the queued tasks, as the sync service should already handle executing the queued tasks one by one