### PR TITLE
Show a warning when offloading items with queued upload tasks

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -309,3 +309,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "sync_tasks_view_title" = "View tasks";
 "settings_datausage_title" = "Data Usage";
 "datausage_upload_wifionly_title" = "Upload using cellular data";
+"warning_title" = "Warning";
+"sync_tasks_item_upload_queued" = "There's a queued upload task for:\n%@\nRemoving the file will prevent the app from uploading it";

--- a/BookPlayer/Coordinators/SettingsCoordinator.swift
+++ b/BookPlayer/Coordinators/SettingsCoordinator.swift
@@ -86,13 +86,16 @@ class SettingsCoordinator: Coordinator, AlertPresenter {
   func showStorageManagement() {
     let viewModel = StorageViewModel(
       libraryService: libraryService,
+      syncService: syncService,
       folderURL: DataManager.getProcessedFolderURL()
     )
 
     viewModel.onTransition = { [weak self] route in
       switch route {
-      case .showAlert(let title, let message):
-        self?.showAlert(title, message: message)
+      case .showAlert(let content):
+        self?.flow.navigationController
+          .getTopVisibleViewController()?
+          .showAlert(content)
       case .dismiss:
         self?.flow.navigationController.dismiss(animated: true)
       }

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1742,4 +1742,24 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
             return getDownloadStateForReturnValue
         }
     }
+    //MARK: - hasUploadTask
+
+    var hasUploadTaskForCallsCount = 0
+    var hasUploadTaskForCalled: Bool {
+        return hasUploadTaskForCallsCount > 0
+    }
+    var hasUploadTaskForReceivedRelativePath: String?
+    var hasUploadTaskForReceivedInvocations: [String] = []
+    var hasUploadTaskForReturnValue: Bool!
+    var hasUploadTaskForClosure: ((String) async -> Bool)?
+    func hasUploadTask(for relativePath: String) async -> Bool {
+        hasUploadTaskForCallsCount += 1
+        hasUploadTaskForReceivedRelativePath = relativePath
+        hasUploadTaskForReceivedInvocations.append(relativePath)
+        if let hasUploadTaskForClosure = hasUploadTaskForClosure {
+            return await hasUploadTaskForClosure(relativePath)
+        } else {
+            return hasUploadTaskForReturnValue
+        }
+    }
 }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -806,8 +806,8 @@ class ItemListViewModel: ViewModelProtocol {
       if await syncService.hasUploadTask(for: item.relativePath) {
         sendEvent(.showAlert(
           content: BPAlertContent(
-            title: "Warning",
-            message: "There's a queued upload task for:\n\(item.relativePath)\nRemoving the file will prevent the app from uploading it",
+            title: "warning_title".localized,
+            message: String(format: "sync_tasks_item_upload_queued".localized, item.relativePath),
             style: .alert,
             actionItems: [
               BPActionItem.cancelAction,

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -395,8 +395,8 @@ final class StorageViewModel: StorageViewModelProtocol {
       if await syncService.hasUploadTask(for: item.path) {
         onTransition?(.showAlert(
           BPAlertContent(
-            title: "Warning",
-            message: "There's a queued upload task for:\n\(item.path)\nRemoving the file will prevent the app from uploading it",
+            title: "warning_title".localized,
+            message: String(format: "sync_tasks_item_upload_queued".localized, item.path),
             style: .alert,
             actionItems: [
               BPActionItem.cancelAction,

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -43,12 +43,13 @@ enum BPStorageAlert {
 final class StorageViewModel: StorageViewModelProtocol {
   /// Available routes
   enum Routes {
-    case showAlert(title: String, message: String)
+    case showAlert(BPAlertContent)
     case dismiss
   }
 
   // MARK: - Properties
   let libraryService: LibraryServiceProtocol
+  let syncService: SyncServiceProtocol
   let folderURL: URL
   let artworkCacheFolderURL = ArtworkService.cacheDirectoryURL
 
@@ -96,8 +97,13 @@ final class StorageViewModel: StorageViewModelProtocol {
     libraryService.getLibrary()
   }()
 
-  init(libraryService: LibraryServiceProtocol, folderURL: URL) {
+  init(
+    libraryService: LibraryServiceProtocol,
+    syncService: SyncServiceProtocol,
+    folderURL: URL
+  ) {
     self.libraryService = libraryService
+    self.syncService = syncService
     self.folderURL = folderURL
 
     self.sortBy = BPStorageSortBy(rawValue: UserDefaults.standard.integer(forKey: Constants.UserDefaults.storageFilesSortOrder)) ?? .size
@@ -178,8 +184,14 @@ final class StorageViewModel: StorageViewModelProtocol {
     if FileManager.default.fileExists(atPath: fetchedBookURL.path) {
       try FileManager.default.removeItem(at: item.fileURL)
       onTransition?(.showAlert(
-        title: "storage_duplicate_item_title".localized,
-        message: String.localizedStringWithFormat("storage_duplicate_item_description".localized, fetchedBook.relativePath!)
+        BPAlertContent(
+          title: "storage_duplicate_item_title".localized,
+          message: String.localizedStringWithFormat("storage_duplicate_item_description".localized, fetchedBook.relativePath!),
+          style: .alert,
+          actionItems: [
+            BPActionItem.okAction
+          ]
+        )
       ))
       if shouldReloadItems {
         self.loadItems()
@@ -195,11 +207,13 @@ final class StorageViewModel: StorageViewModelProtocol {
   }
 
   func deleteSelectedItem(_ item: StorageItem) {
-    do {
-      try handleDelete(for: item)
-    } catch {
-      storageAlert = .error(errorMessage: error.localizedDescription)
-      showAlert = true
+    verifyUploadTask(for: item) { [unowned self] in
+      do {
+        try handleDelete(for: item)
+      } catch {
+        storageAlert = .error(errorMessage: error.localizedDescription)
+        showAlert = true
+      }
     }
   }
 
@@ -374,6 +388,25 @@ final class StorageViewModel: StorageViewModelProtocol {
     try FileManager.default.removeItem(at: item.fileURL)
     let filteredFiles = publishedFiles.filter { $0.fileURL != item.fileURL }
     publishedFiles = self.sortedItems(items: filteredFiles)
+  }
+
+  func verifyUploadTask(for item: StorageItem, completionHandler: @escaping () -> Void) {
+    Task { @MainActor in
+      if await syncService.hasUploadTask(for: item.path) {
+        onTransition?(.showAlert(
+          BPAlertContent(
+            title: "Warning",
+            message: "There's a queued upload task for:\n\(item.path)\nRemoving the file will prevent the app from uploading it",
+            style: .alert,
+            actionItems: [
+              BPActionItem.cancelAction,
+              BPActionItem(title: "Continue", handler: completionHandler)
+            ])
+        ))
+      } else {
+        completionHandler()
+      }
+    }
   }
 
   private func handleFix(for items: [StorageItem], completion: @escaping () -> Void) throws {

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "عرض المهام";
 "settings_datausage_title" = "استخدام البيانات";
 "datausage_upload_wifionly_title" = "تحميل باستخدام البيانات الخلوية";
+"warning_title" = "تحذير";
+"sync_tasks_item_upload_queued" = "توجد مهمة تحميل في قائمة الانتظار لـ: \n %@ \n ستؤدي إزالة الملف إلى منع التطبيق من تحميله";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Zobrazit úkoly";
 "settings_datausage_title" = "Využití dat";
 "datausage_upload_wifionly_title" = "Nahrajte pomocí mobilních dat";
+"warning_title" = "Varování";
+"sync_tasks_item_upload_queued" = "Ve frontě je úloha nahrávání pro: \n %@ \n Odebráním souboru zabráníte aplikaci v jeho nahrání";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Se opgaver";
 "settings_datausage_title" = "Dataforbrug";
 "datausage_upload_wifionly_title" = "Upload ved hjælp af mobildata";
+"warning_title" = "Advarsel";
+"sync_tasks_item_upload_queued" = "Der er en uploadopgave i kø for: \n %@ \n Fjernelse af filen forhindrer appen i at uploade den";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Aufgaben anzeigen";
 "settings_datausage_title" = "Datenverbrauch";
 "datausage_upload_wifionly_title" = "Hochladen mit Mobilfunkdaten";
+"warning_title" = "Warnung";
+"sync_tasks_item_upload_queued" = "Es gibt eine Upload-Aufgabe in der Warteschlange für: \n %@ \n Durch das Entfernen der Datei wird verhindert, dass die App sie hochlädt";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -309,3 +309,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "sync_tasks_view_title" = "View tasks";
 "settings_datausage_title" = "Data Usage";
 "datausage_upload_wifionly_title" = "Upload using cellular data";
+"warning_title" = "Warning";
+"sync_tasks_item_upload_queued" = "There's a queued upload task for:\n%@\nRemoving the file will prevent the app from uploading it";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Ver tareas";
 "settings_datausage_title" = "Uso de datos";
 "datausage_upload_wifionly_title" = "Subir usando datos móviles";
+"warning_title" = "Advertencia";
+"sync_tasks_item_upload_queued" = "Hay una tarea de carga en cola para: \n %@ \n Eliminar el archivo evitará que la aplicación lo cargue";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Näytä tehtävät";
 "settings_datausage_title" = "Datan käyttö";
 "datausage_upload_wifionly_title" = "Lataa mobiilidatan avulla";
+"warning_title" = "Varoitus";
+"sync_tasks_item_upload_queued" = "Jonossa on lähetystehtävä kohteelle: \n %@ \n Tiedoston poistaminen estää sovellusta lataamasta sitä";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Afficher les tâches";
 "settings_datausage_title" = "L'utilisation de données";
 "datausage_upload_wifionly_title" = "Télécharger à l'aide de données cellulaires";
+"warning_title" = "Avertissement";
+"sync_tasks_item_upload_queued" = "Il existe une tâche de téléchargement en file d'attente pour : \n %@ \n La suppression du fichier empêchera l'application de le télécharger";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Feladatok megtekintése";
 "settings_datausage_title" = "Adathasználat";
 "datausage_upload_wifionly_title" = "Feltöltés mobiladat-kapcsolaton keresztül";
+"warning_title" = "Figyelem";
+"sync_tasks_item_upload_queued" = "Várakozóban van egy feltöltési feladat a következőhöz: \n %@ \n A fájl eltávolításával az alkalmazás nem tudja feltölteni";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Visualizza attività";
 "settings_datausage_title" = "Utilizzo dei dati";
 "datausage_upload_wifionly_title" = "Carica utilizzando la rete dati";
+"warning_title" = "Avvertimento";
+"sync_tasks_item_upload_queued" = "È presente un'attività di caricamento in coda per: \n %@ \n La rimozione del file impedirà all'app di caricarlo";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -309,3 +309,5 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "sync_tasks_view_title" = "Se oppgaver";
 "settings_datausage_title" = "Databruk";
 "datausage_upload_wifionly_title" = "Last opp ved hjelp av mobildata";
+"warning_title" = "Advarsel";
+"sync_tasks_item_upload_queued" = "Det er en opplastingsoppgave i kø for: \n %@ \n Fjerning av filen vil hindre appen i å laste den opp";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Bekijk taken";
 "settings_datausage_title" = "Data gebruik";
 "datausage_upload_wifionly_title" = "Uploaden met mobiele data";
+"warning_title" = "Waarschuwing";
+"sync_tasks_item_upload_queued" = "Er staat een uploadtaak in de wachtrij voor: \n %@ \n Als u het bestand verwijdert, kan de app het niet uploaden";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Zobacz zadania";
 "settings_datausage_title" = "Użycie danych";
 "datausage_upload_wifionly_title" = "Przesyłaj, korzystając z komórkowej transmisji danych";
+"warning_title" = "Ostrzeżenie";
+"sync_tasks_item_upload_queued" = "W kolejce znajduje się zadanie przesyłania dla: \n %@ \n Usunięcie pliku uniemożliwi przesyłanie go przez aplikację";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Ver tarefas";
 "settings_datausage_title" = "Uso de dados";
 "datausage_upload_wifionly_title" = "Fazer upload usando dados de celular";
+"warning_title" = "Aviso";
+"sync_tasks_item_upload_queued" = "Há uma tarefa de upload na fila para: \n %@ \n A remoção do arquivo impedirá que o aplicativo o carregue";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Ver tarefas";
 "settings_datausage_title" = "Uso de dados";
 "datausage_upload_wifionly_title" = "Fazer upload usando dados de celular";
+"warning_title" = "Aviso";
+"sync_tasks_item_upload_queued" = "Há uma tarefa de upload na fila para: \n %@ \n A remoção do arquivo impedirá que o aplicativo o carregue";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Vizualizați sarcini";
 "settings_datausage_title" = "Utilizarea de date";
 "datausage_upload_wifionly_title" = "Încărcați folosind date celulare";
+"warning_title" = "Avertizare";
+"sync_tasks_item_upload_queued" = "Există o sarcină de încărcare în coadă pentru: \n %@ \n Eliminarea fișierului va împiedica aplicația să îl încarce";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Просмотр задач";
 "settings_datausage_title" = "Использование данных";
 "datausage_upload_wifionly_title" = "Загрузка с использованием сотовых данных";
+"warning_title" = "Предупреждение";
+"sync_tasks_item_upload_queued" = "Существует задача загрузки в очередь для: \n %@ \n Удаление файла не позволит приложению загрузить его.";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -309,3 +309,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "sync_tasks_view_title" = "Zobraziť úlohy";
 "settings_datausage_title" = "Využitie dát";
 "datausage_upload_wifionly_title" = "Nahrajte pomocou mobilných dát";
+"warning_title" = "POZOR";
+"sync_tasks_item_upload_queued" = "Vo fronte je úloha nahrávania pre: \n %@ \n Odstránením súboru zabránite aplikácii nahrať ho";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Visa uppgifter";
 "settings_datausage_title" = "Dataanvändning";
 "datausage_upload_wifionly_title" = "Ladda upp med mobildata";
+"warning_title" = "Varning";
+"sync_tasks_item_upload_queued" = "Det finns en uppladdningsuppgift i kö för: \n %@ \n Om du tar bort filen förhindrar appen att ladda upp den";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Görevleri görüntüle";
 "settings_datausage_title" = "Veri kullanımı";
 "datausage_upload_wifionly_title" = "Hücresel verileri kullanarak yükleme";
+"warning_title" = "Uyarı";
+"sync_tasks_item_upload_queued" = "Şunun için sıraya alınmış bir yükleme görevi var: \n %@ \n Dosyanın kaldırılması uygulamanın onu yüklemesini engelleyecektir";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "Переглянути завдання";
 "settings_datausage_title" = "Використання даних";
 "datausage_upload_wifionly_title" = "Завантажувати за допомогою мобільних даних";
+"warning_title" = "УВАГА";
+"sync_tasks_item_upload_queued" = "Є завдання завантаження в черзі для: \n %@ \n Видалення файлу не дозволить програмі завантажити його";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -309,3 +309,5 @@
 "sync_tasks_view_title" = "查看任务";
 "settings_datausage_title" = "数据使用";
 "datausage_upload_wifionly_title" = "使用蜂窝数据上传";
+"warning_title" = "警告";
+"sync_tasks_item_upload_queued" = "有一个排队上传任务： \n %@ \n删除文件将阻止应用程序上传该文件";

--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -38,8 +38,11 @@ final class StorageViewModelMissingFileTests: XCTestCase {
 
     let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: self.testPath))
     let libraryService = LibraryService(dataManager: dataManager)
-    self.viewModel = StorageViewModel(libraryService: libraryService,
-                                      folderURL: self.directoryURL)
+    self.viewModel = StorageViewModel(
+      libraryService: libraryService,
+      syncService: SyncServiceProtocolMock(),
+      folderURL: self.directoryURL
+    )
   }
 
   func testSetup(with filename: String) {
@@ -62,8 +65,11 @@ final class StorageViewModelMissingFileTests: XCTestCase {
     let dataManager = DataManager(coreDataStack: CoreDataStack(testPath: self.testPath))
     let libraryService = LibraryService(dataManager: dataManager)
     _ = libraryService.getLibrary()
-    self.viewModel = StorageViewModel(libraryService: libraryService,
-                                      folderURL: self.directoryURL)
+    self.viewModel = StorageViewModel(
+      libraryService: libraryService,
+      syncService: SyncServiceProtocolMock(),
+      folderURL: self.directoryURL
+    )
   }
 
   func testGetBrokenItems() {

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -36,6 +36,8 @@ public protocol JobSchedulerProtocol {
   func getAllQueuedJobs() async -> [SyncTask]
   /// Cancel all stored and ongoing jobs
   func cancelAllJobs()
+  /// Check if there's an upload task queued for the item
+  func hasUploadTask(for relativePath: String) async -> Bool
 }
 
 public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
@@ -238,6 +240,11 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
     } catch {
       Self.logger.error("Failed to persist task")
     }
+  }
+
+  /// Check if there's an upload task queued for the item
+  public func hasUploadTask(for relativePath: String) async -> Bool {
+    return await taskStore.hasUploadTask(for: relativePath)
   }
 
   private func queueNextTask() {

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -79,6 +79,9 @@ public protocol SyncServiceProtocol {
   func cancelDownload(of item: SimpleLibraryItem) throws
 
   func getDownloadState(for item: SimpleLibraryItem) -> DownloadState
+
+  /// Check if there's an upload task queued for the item
+  func hasUploadTask(for relativePath: String) async -> Bool
 }
 
 public final class SyncService: SyncServiceProtocol, BPLogger {
@@ -472,6 +475,11 @@ extension SyncService {
 
       await handleItemsToUpload(itemsToUpload)
     }
+  }
+
+  /// Check if there's an upload task queued for the item
+  public func hasUploadTask(for relativePath: String) async -> Bool {
+    return await jobManager.hasUploadTask(for: relativePath)
   }
 }
 


### PR DESCRIPTION
## Purpose

- Show a warning when offloading items with queued upload tasks, as the app won't be able to upload the file item if it's removed

## Approach

- Show a confirmation alert prior to removing the backing file

## Things to be aware of / Things to focus on

- I also included logic to merge queued sync tasks that only update metadata (most likely from playback), to avoid unnecessary multiple requests to the backend