### PR TITLE
Fix multiple crashes

### DIFF
--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -76,12 +76,6 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
       tabBarController.setViewControllers(newControllersArray, animated: false)
     }
 
-    if let appDelegate = AppDelegate.shared {
-      for action in appDelegate.pendingURLActions {
-        ActionParserService.handleAction(action)
-      }
-    }
-
     self.documentPickerDelegate = vc
 
     AppDelegate.shared?.watchConnectivityService?.startSession()
@@ -91,6 +85,12 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
     loadLastBookIfNeeded()
     syncList()
     bindImportObserverIfNeeded()
+
+    if let appDelegate = AppDelegate.shared {
+      for action in appDelegate.pendingURLActions {
+        ActionParserService.handleAction(action)
+      }
+    }
   }
 
   func bindImportObserverIfNeeded() {

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidget.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidget.swift
@@ -93,11 +93,15 @@ struct SharedWidgetTimelineProvider: TimelineProvider {
       chapterTitle = currentItem.currentChapter.title
     }
 
+    let percentCompleted: Double = currentItem.percentCompleted.isFinite
+    ? currentItem.percentCompleted
+    : 0
+
     return SharedWidgetEntry(
       chapterTitle: chapterTitle,
       bookTitle: currentItem.title,
       details: currentItem.author,
-      percentCompleted: currentItem.percentCompleted / 100
+      percentCompleted: percentCompleted / 100
     )
   }
 

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1488,9 +1488,9 @@ extension LibraryService {
     item.currentTime = time
     item.lastPlayDate = date
     let progress = round((item.currentTime / item.duration) * 100)
-    let percentCompleted = (progress.isNaN || progress.isInfinite)
-    ? 0
-    : progress
+    let percentCompleted = progress.isFinite
+    ? progress
+    : 0
     item.percentCompleted = percentCompleted
 
     if let parentFolderPath = item.folder?.relativePath {

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -39,7 +39,11 @@ public final class PlaybackService: PlaybackServiceProtocol {
     let now = Date()
     item.lastPlayDate = now
     item.currentTime = time
-    item.percentCompleted = round((item.currentTime / item.duration) * 100)
+    let progress = round((item.currentTime / item.duration) * 100)
+    let percentCompleted = progress.isFinite
+    ? progress
+    : 0
+    item.percentCompleted = percentCompleted
     self.libraryService.updatePlaybackTime(relativePath: item.relativePath, time: time, date: now, scheduleSave: true)
   }
 


### PR DESCRIPTION
## Bugfix

- Fix crash on widgets when progress is NaN
- Fix crash when time skipping when progress is NaN
- Fix crash when trying to update views not available yet when launching the app via an URL action

## Things to be aware of / Things to focus on

- Items progress calculation shouldn't be outputting a non finite value, this could be a result of a past folder migration where the duration was botched and left at the default value of 0
