### PR TITLE
Fix using CoreData background context

### DIFF
--- a/BookPlayer/Coordinators/ItemListCoordinator.swift
+++ b/BookPlayer/Coordinators/ItemListCoordinator.swift
@@ -58,11 +58,7 @@ class ItemListCoordinator: NSObject, Coordinator, AlertPresenter, BPLogger {
       playbackService: playbackService,
       syncService: syncService,
       importManager: importManager,
-      listRefreshService: ListSyncRefreshService(
-        playerManager: playerManager,
-        libraryService: libraryService,
-        syncService: syncService
-      )
+      listRefreshService: listRefreshService
     )
     child.start()
   }

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -90,7 +90,6 @@ class MainCoordinator: NSObject {
       importManager: ImportManager(libraryService: self.libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManager,
-        libraryService: libraryService,
         syncService: syncService
       )
     )

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -515,12 +515,12 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
     }
     var loadChaptersIfNeededRelativePathAssetReceivedArguments: (relativePath: String, asset: AVAsset)?
     var loadChaptersIfNeededRelativePathAssetReceivedInvocations: [(relativePath: String, asset: AVAsset)] = []
-    var loadChaptersIfNeededRelativePathAssetClosure: ((String, AVAsset) -> Void)?
-    func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) {
+    var loadChaptersIfNeededRelativePathAssetClosure: ((String, AVAsset) async -> Void)?
+    func loadChaptersIfNeeded(relativePath: String, asset: AVAsset) async {
         loadChaptersIfNeededRelativePathAssetCallsCount += 1
         loadChaptersIfNeededRelativePathAssetReceivedArguments = (relativePath: relativePath, asset: asset)
         loadChaptersIfNeededRelativePathAssetReceivedInvocations.append((relativePath: relativePath, asset: asset))
-        loadChaptersIfNeededRelativePathAssetClosure?(relativePath, asset)
+        await loadChaptersIfNeededRelativePathAssetClosure?(relativePath, asset)
     }
     //MARK: - createFolder
 
@@ -1761,5 +1761,20 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
         } else {
             return hasUploadTaskForReturnValue
         }
+    }
+    //MARK: - setLibraryLastBook
+
+    var setLibraryLastBookWithCallsCount = 0
+    var setLibraryLastBookWithCalled: Bool {
+        return setLibraryLastBookWithCallsCount > 0
+    }
+    var setLibraryLastBookWithReceivedRelativePath: String?
+    var setLibraryLastBookWithReceivedInvocations: [String?] = []
+    var setLibraryLastBookWithClosure: ((String?) async -> Void)?
+    func setLibraryLastBook(with relativePath: String?) async {
+        setLibraryLastBookWithCallsCount += 1
+        setLibraryLastBookWithReceivedRelativePath = relativePath
+        setLibraryLastBookWithReceivedInvocations.append(relativePath)
+        await setLibraryLastBookWithClosure?(relativePath)
     }
 }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -245,7 +245,7 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     }
 
     if currentItem?.isBoundBook == false {
-      libraryService.loadChaptersIfNeeded(relativePath: chapter.relativePath, asset: asset)
+      await libraryService.loadChaptersIfNeeded(relativePath: chapter.relativePath, asset: asset)
 
       if let libraryItem = libraryService.getSimpleItem(with: chapter.relativePath) {
         currentItem = try playbackService.getPlayableItem(from: libraryItem)

--- a/BookPlayer/Services/ListSyncRefreshService.swift
+++ b/BookPlayer/Services/ListSyncRefreshService.swift
@@ -16,16 +16,13 @@ enum BPSyncRefreshError: Error {
 
 class ListSyncRefreshService: BPLogger {
   let playerManager: PlayerManagerProtocol
-  let libraryService: LibraryServiceProtocol
   let syncService: SyncServiceProtocol
 
   init(
     playerManager: PlayerManagerProtocol,
-    libraryService: LibraryServiceProtocol,
     syncService: SyncServiceProtocol
   ) {
     self.playerManager = playerManager
-    self.libraryService = libraryService
     self.syncService = syncService
   }
 
@@ -60,11 +57,11 @@ class ListSyncRefreshService: BPLogger {
   }
 
   @MainActor
-  private func setSyncedLastPlayedItem(relativePath: String, alertPresenter: AlertPresenter) {
+  private func setSyncedLastPlayedItem(relativePath: String, alertPresenter: AlertPresenter) async {
     /// Only continue overriding local book if it's not currently playing
     guard playerManager.isPlaying == false else { return }
 
-    libraryService.setLibraryLastBook(with: relativePath)
+    await syncService.setLibraryLastBook(with: relativePath)
     AppDelegate.shared?.loadPlayer(
       relativePath,
       autoplay: false,

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -39,7 +39,6 @@ class LibraryListCoordinatorTests: XCTestCase {
       importManager: ImportManager(libraryService: libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
-        libraryService: libraryService,
         syncService: syncServiceMock
       )
     )
@@ -95,7 +94,6 @@ class FolderListCoordinatorTests: XCTestCase {
       importManager: ImportManager(libraryService: libraryService),
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
-        libraryService: libraryService,
         syncService: syncServiceMock
       )
     )

--- a/BookPlayerTests/ItemListViewModelTests.swift
+++ b/BookPlayerTests/ItemListViewModelTests.swift
@@ -35,7 +35,6 @@ class ItemListViewModelTests: XCTestCase {
       importManager: ImportManager(libraryService: libraryService), 
       listRefreshService: ListSyncRefreshService(
         playerManager: playerManagerMock,
-        libraryService: libraryService,
         syncService: syncServiceMock
       ),
       themeAccent: .blue

--- a/Shared/CoreData/CoreDataStack.swift
+++ b/Shared/CoreData/CoreDataStack.swift
@@ -18,6 +18,12 @@ public class CoreDataStack {
     return self.storeContainer.viewContext
   }
 
+  public lazy var backgroundContext: NSManagedObjectContext = {
+    let backgroundContext = self.storeContainer.newBackgroundContext()
+    backgroundContext.automaticallyMergesChangesFromParent = true
+    return backgroundContext
+  }()
+
   public init(modelName: String) {
     self.modelName = modelName
     let storeUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)!.appendingPathComponent("BookPlayer.sqlite")
@@ -51,6 +57,7 @@ public class CoreDataStack {
   public func loadStore(completionHandler: ((NSPersistentStoreDescription, Error?) -> Void)?) {
     self.storeContainer.loadPersistentStores { storeDescription, error in
       self.storeContainer.viewContext.undoManager = nil
+      self.storeContainer.viewContext.automaticallyMergesChangesFromParent = true
       completionHandler?(storeDescription, error)
     }
   }
@@ -66,9 +73,5 @@ public class CoreDataStack {
     } catch let error as NSError {
       fatalError("Unresolved error \(error), \(error.userInfo)")
     }
-  }
-
-  public func getBackgroundContext() -> NSManagedObjectContext {
-    return self.storeContainer.newBackgroundContext()
   }
 }

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -137,7 +137,7 @@ public class DataManager {
   }
 
   public func getBackgroundContext() -> NSManagedObjectContext {
-    return self.coreDataStack.getBackgroundContext()
+    return self.coreDataStack.backgroundContext
   }
 
   public func delete(_ item: NSManagedObject, context: NSManagedObjectContext) {


### PR DESCRIPTION
## Bugfix

- Sync operations were accessing the DB on background threads, but they weren't using CoreData's background context, resulting in race conditions

## Related tasks

#1097