### PR TITLE
Rework sync tasks storage with Realm

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -360,11 +360,29 @@
 		637DAB0B2AEB3F6D006DC2D1 /* WidgetEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637DAB092AEB3E0D006DC2D1 /* WidgetEntries.swift */; };
 		637DAB0D2AEBEF1B006DC2D1 /* BookPlayerWatchKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */; };
 		63833DFA2AAC139700496246 /* PlaybackPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */; };
+		638E64CB2B8E086400DCFA3B /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E64CA2B8E086400DCFA3B /* RealmManager.swift */; };
+		638E64CC2B8E086400DCFA3B /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E64CA2B8E086400DCFA3B /* RealmManager.swift */; };
+		638E64CE2B8E1CFD00DCFA3B /* SyncTasksCountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E64CD2B8E1CFD00DCFA3B /* SyncTasksCountService.swift */; };
+		638E64CF2B8E1CFD00DCFA3B /* SyncTasksCountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E64CD2B8E1CFD00DCFA3B /* SyncTasksCountService.swift */; };
 		6399F94D2AA03C6C00A5C8EA /* BPSKANManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */; };
 		639AC9892AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
 		639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */; };
 		639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
 		639AC98C2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB20EA229A1BB750021663B /* BPTaskDownloadDelegate.swift */; };
+		639E12BA2B85A4A400C875F7 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 639E12B92B85A4A400C875F7 /* Realm */; };
+		639E12BC2B85A4A400C875F7 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 639E12BB2B85A4A400C875F7 /* RealmSwift */; };
+		639E12BE2B85A58600C875F7 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 639E12BD2B85A58600C875F7 /* Realm */; };
+		639E12C02B85A58D00C875F7 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 639E12BF2B85A58D00C875F7 /* RealmSwift */; };
+		639E12C62B85AACF00C875F7 /* SyncTasksObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E12C52B85AACF00C875F7 /* SyncTasksObject.swift */; };
+		639E12C72B85AACF00C875F7 /* SyncTasksObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E12C52B85AACF00C875F7 /* SyncTasksObject.swift */; };
+		639E12DB2B8AC65B00C875F7 /* RealmMigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E12DA2B8AC65B00C875F7 /* RealmMigrationManager.swift */; };
+		639E12DC2B8AC65B00C875F7 /* RealmMigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E12DA2B8AC65B00C875F7 /* RealmMigrationManager.swift */; };
+		63B2303D2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2303C2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift */; };
+		63B2303E2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2303C2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift */; };
+		63B230422B8CCE8700AEECED /* Realm+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B230412B8CCE8600AEECED /* Realm+BookPlayer.swift */; };
+		63B230432B8CCE8700AEECED /* Realm+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B230412B8CCE8600AEECED /* Realm+BookPlayer.swift */; };
+		63B230452B8CCF1800AEECED /* SyncJobType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B230442B8CCF1800AEECED /* SyncJobType.swift */; };
+		63B230462B8CCF1800AEECED /* SyncJobType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B230442B8CCF1800AEECED /* SyncJobType.swift */; };
 		63B3B6902B1F625B007A367C /* StorageCloudDeletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */; };
 		63B50F052B692E4200BCABBA /* ListSyncRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B50F042B692E4200BCABBA /* ListSyncRefreshService.swift */; };
 		63C1A8AF2B09158600C4B418 /* BookStartPlaybackIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634E67432AFB2DF500595BAC /* BookStartPlaybackIntent.swift */; };
@@ -1093,8 +1111,15 @@
 		63833DF62AAC127900496246 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
 		63833DF72AAC12AB00496246 /* Performance Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Performance Tests.xctestplan"; sourceTree = "<group>"; };
 		63833DF92AAC139700496246 /* PlaybackPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackPerformanceTests.swift; sourceTree = "<group>"; };
+		638E64CA2B8E086400DCFA3B /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
+		638E64CD2B8E1CFD00DCFA3B /* SyncTasksCountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTasksCountService.swift; sourceTree = "<group>"; };
 		6399F94C2AA03C6C00A5C8EA /* BPSKANManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPSKANManager.swift; sourceTree = "<group>"; };
 		639AC9882AD9F1D50053AFC6 /* BPDownloadURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPDownloadURLSession.swift; sourceTree = "<group>"; };
+		639E12C52B85AACF00C875F7 /* SyncTasksObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTasksObject.swift; sourceTree = "<group>"; };
+		639E12DA2B8AC65B00C875F7 /* RealmMigrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmMigrationManager.swift; sourceTree = "<group>"; };
+		63B2303C2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationStoredSyncTasks.swift; sourceTree = "<group>"; };
+		63B230412B8CCE8600AEECED /* Realm+BookPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+BookPlayer.swift"; sourceTree = "<group>"; };
+		63B230442B8CCF1800AEECED /* SyncJobType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncJobType.swift; sourceTree = "<group>"; };
 		63B3B68F2B1F625B007A367C /* StorageCloudDeletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageCloudDeletedView.swift; sourceTree = "<group>"; };
 		63B50F042B692E4200BCABBA /* ListSyncRefreshService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSyncRefreshService.swift; sourceTree = "<group>"; };
 		63C6C2E52B5029BC00FFE0D8 /* SettingsAutolockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAutolockView.swift; sourceTree = "<group>"; };
@@ -1321,6 +1346,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				639E12C02B85A58D00C875F7 /* RealmSwift in Frameworks */,
+				639E12BE2B85A58600C875F7 /* Realm in Frameworks */,
 				9F00F6EA2807B5D300996BBB /* RevenueCat in Frameworks */,
 				62CADBAA2725BCF000A4A98F /* Kingfisher in Frameworks */,
 			);
@@ -1362,6 +1389,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				639E12BC2B85A4A400C875F7 /* RealmSwift in Frameworks */,
+				639E12BA2B85A4A400C875F7 /* Realm in Frameworks */,
 				9F00F6E82807B5CB00996BBB /* RevenueCat in Frameworks */,
 				62CADBA82725BCE800A4A98F /* Kingfisher in Frameworks */,
 			);
@@ -1686,6 +1715,7 @@
 				9FC1E4572814E09700522FA8 /* Network */,
 				62AAE22F274AA6E9001EB9FF /* Services */,
 				C3AA3732207BF7670004DCFD /* CoreData */,
+				63B2303B2B8CCDDB00AEECED /* Realm */,
 				6279361B272CDA8A0097837D /* Artwork */,
 				41A1B106226E9DCA00EA0400 /* Extensions */,
 				41A8941F2652A5DE0032E972 /* Configuration.swift */,
@@ -2079,6 +2109,35 @@
 			path = PerformanceTests;
 			sourceTree = "<group>";
 		};
+		63B2303B2B8CCDDB00AEECED /* Realm */ = {
+			isa = PBXGroup;
+			children = (
+				63B2303F2B8CCE5800AEECED /* Migrations */,
+				63B230402B8CCE6200AEECED /* Models */,
+				638E64CA2B8E086400DCFA3B /* RealmManager.swift */,
+				63B230412B8CCE8600AEECED /* Realm+BookPlayer.swift */,
+			);
+			path = Realm;
+			sourceTree = "<group>";
+		};
+		63B2303F2B8CCE5800AEECED /* Migrations */ = {
+			isa = PBXGroup;
+			children = (
+				639E12DA2B8AC65B00C875F7 /* RealmMigrationManager.swift */,
+				63B2303C2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift */,
+			);
+			path = Migrations;
+			sourceTree = "<group>";
+		};
+		63B230402B8CCE6200AEECED /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				639E12C52B85AACF00C875F7 /* SyncTasksObject.swift */,
+				63B230442B8CCF1800AEECED /* SyncJobType.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		63C6C2E42B50299D00FFE0D8 /* Autolock */ = {
 			isa = PBXGroup;
 			children = (
@@ -2343,6 +2402,7 @@
 		9FBDBC7B287940AD00D315A2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				63C6C3172B5E0FE700FFE0D8 /* SyncTask.swift */,
 				9FBDBC782879409600D315A2 /* SyncableItem.swift */,
 				9F9C7B5229F9672700E257B0 /* SyncableBookmark.swift */,
 				9FBDBC7F2879C6C900D315A2 /* UploadItemResponse.swift */,
@@ -2398,9 +2458,9 @@
 				9FC1E46A2815A8A800522FA8 /* LibraryAPI.swift */,
 				9F9F3B6F280E4E4B004359DA /* SyncService.swift */,
 				9FDDD2DD289BEE590020C428 /* SyncJobScheduler.swift */,
-				63C6C30F2B54F14800FFE0D8 /* LibraryItemSyncOperation.swift */,
 				63C6C30B2B538B7A00FFE0D8 /* SyncTasksStorage.swift */,
-				63C6C3172B5E0FE700FFE0D8 /* SyncTask.swift */,
+				63C6C30F2B54F14800FFE0D8 /* LibraryItemSyncOperation.swift */,
+				638E64CD2B8E1CFD00DCFA3B /* SyncTasksCountService.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -2655,6 +2715,8 @@
 			packageProductDependencies = (
 				62CADBA92725BCF000A4A98F /* Kingfisher */,
 				9F00F6E92807B5D300996BBB /* RevenueCat */,
+				639E12BD2B85A58600C875F7 /* Realm */,
+				639E12BF2B85A58D00C875F7 /* RealmSwift */,
 			);
 			productName = BookPlayerWatchKit;
 			productReference = 4140EA5E227289720009F794 /* BookPlayerWatchKit.framework */;
@@ -2750,6 +2812,8 @@
 			packageProductDependencies = (
 				62CADBA72725BCE800A4A98F /* Kingfisher */,
 				9F00F6E72807B5CB00996BBB /* RevenueCat */,
+				639E12B92B85A4A400C875F7 /* Realm */,
+				639E12BB2B85A4A400C875F7 /* RealmSwift */,
 			);
 			productName = BookPlayerKit;
 			productReference = 41A1B0D2226E9BC400EA0400 /* BookPlayerKit.framework */;
@@ -2898,6 +2962,7 @@
 				41F1A214254B0AA40043FCF3 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				41F1A226254B0C6C0043FCF3 /* XCRemoteSwiftPackageReference "ZipArchive" */,
 				9FE8188D2805BCE40089A41E /* XCRemoteSwiftPackageReference "purchases-ios" */,
+				639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = 418B6CF91D2707F800F974FB /* Products */;
 			projectDirPath = "";
@@ -3143,7 +3208,9 @@
 				639AC98A2AD9F1D50053AFC6 /* BPDownloadURLSession.swift in Sources */,
 				41A90C4927564DAA00C30394 /* BookPlayerError.swift in Sources */,
 				41C23402272E1960006BC7B8 /* SimpleTheme.swift in Sources */,
+				638E64CF2B8E1CFD00DCFA3B /* SyncTasksCountService.swift in Sources */,
 				4140EA7D227289CB0009F794 /* LibraryItem+CoreDataProperties.swift in Sources */,
+				63B230462B8CCF1800AEECED /* SyncJobType.swift in Sources */,
 				4140EA73227289A80009F794 /* Notification+BookPlayerKit.swift in Sources */,
 				41A894212652A5DE0032E972 /* Configuration.swift in Sources */,
 				9FACAC6A2970F2F500D01EB7 /* SyncableItem.swift in Sources */,
@@ -3175,6 +3242,7 @@
 				9F49072D2903663800054AD6 /* SortType.swift in Sources */,
 				6357F11A2A8BA084007947FC /* BPURLSession.swift in Sources */,
 				9FBDBC7E287940D900D315A2 /* ContentsResponse.swift in Sources */,
+				63B2303E2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift in Sources */,
 				4140EA7C227289C70009F794 /* LibraryItem+CoreDataClass.swift in Sources */,
 				63C6C3122B54F16800FFE0D8 /* LibraryItemSyncOperation.swift in Sources */,
 				4140EA74227289AE0009F794 /* Theme+CoreDataClass.swift in Sources */,
@@ -3182,6 +3250,7 @@
 				9F6BC86727E6D03E002CF2A6 /* WatchApplicationContext.swift in Sources */,
 				9FAFC9F52995BB5C00FD531E /* RemoteFileURLResponse.swift in Sources */,
 				4140EA77227289B90009F794 /* Chapter+CoreDataProperties.swift in Sources */,
+				639E12DC2B8AC65B00C875F7 /* RealmMigrationManager.swift in Sources */,
 				4140EA7B227289C40009F794 /* Book+CoreDataProperties.swift in Sources */,
 				4140EA81227289D80009F794 /* Folder+CoreDataProperties.swift in Sources */,
 				41EB07192752F1BA00EFEE13 /* PlayableChapter.swift in Sources */,
@@ -3189,6 +3258,7 @@
 				41D20DB325D5F5A100AAEE30 /* MappingModel_v1_to_v2.xcmappingmodel in Sources */,
 				63C6C31A2B5E102200FFE0D8 /* SyncTask.swift in Sources */,
 				9F07B79929B770B7005A939D /* BPTaskUploadDelegate.swift in Sources */,
+				63B230432B8CCE8700AEECED /* Realm+BookPlayer.swift in Sources */,
 				4124AB1825DFE07E0007C839 /* DataMigrationManager.swift in Sources */,
 				41C3394A25E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */,
 				9F56C84E287B734C00EA9751 /* BPLogger.swift in Sources */,
@@ -3200,12 +3270,14 @@
 				9F7B64752803217400895ECC /* Account+CoreDataClass.swift in Sources */,
 				9FBF33ED29F6293C00501639 /* SimpleBookmark.swift in Sources */,
 				639AC98B2AD9F2840053AFC6 /* BPTaskDownloadDelegate.swift in Sources */,
+				639E12C72B85AACF00C875F7 /* SyncTasksObject.swift in Sources */,
 				4140EA75227289B20009F794 /* Theme+CoreDataProperties.swift in Sources */,
 				9FBDBC812879C6C900D315A2 /* UploadItemResponse.swift in Sources */,
 				41A90C4627563F5A00C30394 /* ItemType.swift in Sources */,
 				9F2E00932A568F800001FE20 /* IdentifiersResponse.swift in Sources */,
 				4140EA7E227289CE0009F794 /* Library+CoreDataClass.swift in Sources */,
 				41C233FE272E1958006BC7B8 /* SimpleLibraryItem.swift in Sources */,
+				638E64CC2B8E086400DCFA3B /* RealmManager.swift in Sources */,
 				416AAC3523F515B0005AD04F /* String+BookPlayer.swift in Sources */,
 				6308260B2AF5B66D002ACE0D /* UserDefaults+BookPlayer.swift in Sources */,
 				41A8942B2652A7DF0032E972 /* Bundle+BookPlayer.swift in Sources */,
@@ -3509,6 +3581,7 @@
 				4138CE1126E5542C0014F11E /* Bookmark+CoreDataClass.swift in Sources */,
 				41A90C4827564DAA00C30394 /* BookPlayerError.swift in Sources */,
 				41C23401272E1960006BC7B8 /* SimpleTheme.swift in Sources */,
+				639E12DB2B8AC65B00C875F7 /* RealmMigrationManager.swift in Sources */,
 				41A1B124226F88C500EA0400 /* Book+CoreDataProperties.swift in Sources */,
 				41A1B108226E9DF800EA0400 /* DataManager.swift in Sources */,
 				41A1B131226FE33500EA0400 /* Constants.swift in Sources */,
@@ -3519,9 +3592,11 @@
 				41A359C5276232E00020D5F5 /* MappingModel_v7_to_v8.xcmappingmodel in Sources */,
 				41A1B125226F88C500EA0400 /* LibraryItem+CoreDataClass.swift in Sources */,
 				62CADBA52725BCB200A4A98F /* AVAudioAssetImageDataProvider.swift in Sources */,
+				63B2303D2B8CCDFD00AEECED /* MigrationStoredSyncTasks.swift in Sources */,
 				9FC1E4592814E0B000522FA8 /* NetworkUtils.swift in Sources */,
 				41C23403272E1965006BC7B8 /* PlaybackState.swift in Sources */,
 				41A1B120226F88C500EA0400 /* Chapter+CoreDataProperties.swift in Sources */,
+				63B230422B8CCE8700AEECED /* Realm+BookPlayer.swift in Sources */,
 				41CE44A9227215B500C900AF /* Notification+BookPlayerKit.swift in Sources */,
 				41C233FF272E195B006BC7B8 /* SimpleItemType.swift in Sources */,
 				9FDDD2D8289B64440020C428 /* SyncStatus.swift in Sources */,
@@ -3545,6 +3620,7 @@
 				41C3394925E04091003ED2B0 /* MappingModel_v2_to_v3.xcmappingmodel in Sources */,
 				41640A452441ACE2004FB97B /* Intents.intentdefinition in Sources */,
 				41D20DB225D5F5A100AAEE30 /* MappingModel_v1_to_v2.xcmappingmodel in Sources */,
+				638E64CB2B8E086400DCFA3B /* RealmManager.swift in Sources */,
 				412AB71527017ABE00969618 /* DBVersion.swift in Sources */,
 				9F6BC86627E6D03D002CF2A6 /* WatchApplicationContext.swift in Sources */,
 				4138CE1326E554320014F11E /* Bookmark+CoreDataProperties.swift in Sources */,
@@ -3558,6 +3634,7 @@
 				41EB07182752F1BA00EFEE13 /* PlayableChapter.swift in Sources */,
 				9F1345BA2938E0130089B1DE /* Spacing.swift in Sources */,
 				5126F122258E9F18009965DC /* URL+BookPlayer.swift in Sources */,
+				639E12C62B85AACF00C875F7 /* SyncTasksObject.swift in Sources */,
 				9F56C84D287B734C00EA9751 /* BPLogger.swift in Sources */,
 				418CABB425EF28FC00D8C878 /* MappingModel_v3_to_v4.xcmappingmodel in Sources */,
 				41A1B121226F88C500EA0400 /* PlaybackRecord+CoreDataClass.swift in Sources */,
@@ -3573,7 +3650,9 @@
 				41A1B129226F88C500EA0400 /* Folder+CoreDataClass.swift in Sources */,
 				41C233FD272E1957006BC7B8 /* SimpleLibraryItem.swift in Sources */,
 				41A1B12A226F88C500EA0400 /* Folder+CoreDataProperties.swift in Sources */,
+				638E64CE2B8E1CFD00DCFA3B /* SyncTasksCountService.swift in Sources */,
 				63C6C30D2B538D8500FFE0D8 /* SyncTasksStorage.swift in Sources */,
+				63B230452B8CCF1800AEECED /* SyncJobType.swift in Sources */,
 				41EB07152752F17B00EFEE13 /* PlayableItem.swift in Sources */,
 				41A1B11E226F88C500EA0400 /* Theme+CoreDataProperties.swift in Sources */,
 				9F1345B62938DF070089B1DE /* Fonts.swift in Sources */,
@@ -4586,7 +4665,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BookPlayerKit/Info.plist;
@@ -4632,7 +4711,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BookPlayerKit/Info.plist;
@@ -4676,7 +4755,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BookPlayerKit/Info.plist;
@@ -5218,6 +5297,14 @@
 				minimumVersion = 2.3.0;
 			};
 		};
+		639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.47.0;
+			};
+		};
 		9FE8188D2805BCE40089A41E /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
@@ -5273,6 +5360,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 41F1A214254B0AA40043FCF3 /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		639E12B92B85A4A400C875F7 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		639E12BB2B85A4A400C875F7 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
+		639E12BD2B85A58600C875F7 /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		639E12BF2B85A58D00C875F7 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 639E12B82B85A4A400C875F7 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
 		};
 		9F00F6E72807B5CB00996BBB /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BookPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BookPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -55,6 +55,24 @@
       }
     },
     {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "a5e87a39cffdcc591f3203c11cfca68100d0b9a6",
+        "version" : "13.26.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "revision" : "55466ae0fb29c5f21866792f05c1fc0c590d7c29",
+        "version" : "10.47.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -232,7 +232,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       playerManager?.load(item, autoplay: autoplay)
 
       if recordAsLastBook {
-        await libraryService?.setLibraryLastBook(with: item.relativePath)
+        await MainActor.run {
+          libraryService?.setLibraryLastBook(with: item.relativePath)
+        }
       }
 
       showPlayer?()

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -15,13 +15,14 @@ import DirectoryWatcher
 import Intents
 import MediaPlayer
 import Sentry
+import RealmSwift
 import RevenueCat
 import StoreKit
 import UIKit
 import WatchConnectivity
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
   static weak var shared: AppDelegate?
   var pendingURLActions = [Action]()
 
@@ -75,6 +76,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     self.setupRevenueCat()
     // Setup Sentry
     self.setupSentry()
+    // Setup Realm
+    self.setupRealm()
     // Setup observer for interactive widgets
     self.setupSharedWidgetActionObserver()
 
@@ -404,6 +407,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     handleSentryPreference(
       isDisabled: userDefaults.bool(forKey: Constants.UserDefaults.crashReportsDisabled)
     )
+  }
+
+  /// Initialize Realm empty database
+  func setupRealm() {
+    /// Tasks database
+    let tasksRealmURL = DataManager.getSyncTasksRealmURL()
+    if !FileManager.default.fileExists(atPath: tasksRealmURL.path) {
+      _ = try! Realm(configuration: Realm.Configuration(fileURL: tasksRealmURL))
+    }
   }
 
   func setupSharedWidgetActionObserver() {

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -11,7 +11,6 @@ import Combine
 import CoreData
 import Foundation
 
-@MainActor
 class DataInitializerCoordinator: BPLogger {
   let databaseInitializer: DatabaseInitializer = DatabaseInitializer()
   let alertPresenter: AlertPresenter
@@ -89,7 +88,9 @@ class DataInitializerCoordinator: BPLogger {
       libraryService.insertItems(from: files)
     }
 
-    onFinish?(stack)
+    DispatchQueue.main.async {
+      self.onFinish?(stack)
+    }
   }
 
   private func getLibraryFiles() -> [URL] {

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -139,8 +139,6 @@ class DataInitializerCoordinator: BPLogger {
     setupDefaultTheme(libraryService: libraryService)
 
     setupBlankAccount(dataManager: dataManager)
-
-    migrateSyncTasksIfNecessary()
   }
 
   private func migratePlayerPreferences(sharedDefaults: UserDefaults) {
@@ -219,36 +217,5 @@ class DataInitializerCoordinator: BPLogger {
     )
 
     UserDefaults.standard.set(nil, forKey: Constants.UserDefaults.donationMade)
-  }
-
-  /// Migrate queued tasks
-  private func migrateSyncTasksIfNecessary() {
-    let store = UserDefaults.standard
-
-    let values: [String: [String: String]] = store.value(forKey: "LibraryItemSyncJob") as? [String: [String: String]] ?? [:]
-    let dictionaryTasks: [String: String] = values["GLOBAL"] ?? [:]
-    let storedTasks = Array(dictionaryTasks.values)
-
-    guard !storedTasks.isEmpty else { return }
-
-    let migratedTasks: [Data] = storedTasks.compactMap { task in
-      guard
-        let taskData = task.data(using: .utf8),
-        let taskDictionary = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
-        let taskRawParams = taskDictionary["params"] as? String,
-        let taskParamsData = taskRawParams.data(using: .utf8),
-        var taskParams = try? JSONSerialization.jsonObject(with: taskParamsData) as? [String: Any]
-      else {
-        return nil
-      }
-      
-      taskParams["id"] = UUID().uuidString
-
-      return try? JSONSerialization.data(withJSONObject: taskParams)
-    }
-
-    store.set(migratedTasks, forKey: Constants.UserDefaults.syncTasksQueue)
-    store.removeObject(forKey: "LibraryItemSyncJob")
-    store.removeObject(forKey: "userSettingsHasQueuedJobs")
   }
 }

--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -80,9 +80,11 @@ class FolderListCoordinator: ItemListCoordinator {
   }
 
   override func syncList() {
-    guard syncService.canSyncListContents(at: folderRelativePath, ignoreLastTimestamp: false) else { return }
-
     Task {
+      guard
+        await syncService.canSyncListContents(at: folderRelativePath, ignoreLastTimestamp: false)
+      else { return }
+
       await listRefreshService.syncList(at: folderRelativePath, alertPresenter: self)
       await MainActor.run {
         self.reloadItemsWithPadding()

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -242,14 +242,20 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
       reloadItemsWithPadding()
     }
 
-    guard syncService.canSyncListContents(at: nil, ignoreLastTimestamp: false) else { return }
+    Task {
+//      guard
+//        await syncService.canSyncListContents(at: nil, ignoreLastTimestamp: false)
+//      else { return }
 
-    /// Create new task to sync the library and the last played
-    contentsFetchTask?.cancel()
-    contentsFetchTask = Task {
-      await listRefreshService.syncList(at: nil, alertPresenter: self)
+      /// Create new task to sync the library and the last played
       await MainActor.run {
-        self.reloadItemsWithPadding()
+        contentsFetchTask?.cancel()
+        contentsFetchTask = Task {
+          await listRefreshService.syncList(at: nil, alertPresenter: self)
+          await MainActor.run {
+            self.reloadItemsWithPadding()
+          }
+        }
       }
     }
   }

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -243,9 +243,9 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
     }
 
     Task {
-//      guard
-//        await syncService.canSyncListContents(at: nil, ignoreLastTimestamp: false)
-//      else { return }
+      guard
+        await syncService.canSyncListContents(at: nil, ignoreLastTimestamp: false)
+      else { return }
 
       /// Create new task to sync the library and the last played
       await MainActor.run {

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1430,6 +1430,22 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
             return queuedJobsCountReturnValue
         }
     }
+    //MARK: - observeTasksCount
+
+    var observeTasksCountCallsCount = 0
+    var observeTasksCountCalled: Bool {
+        return observeTasksCountCallsCount > 0
+    }
+    var observeTasksCountReturnValue: AnyPublisher<Int, Never>!
+    var observeTasksCountClosure: (() -> AnyPublisher<Int, Never>)?
+    func observeTasksCount() -> AnyPublisher<Int, Never> {
+        observeTasksCountCallsCount += 1
+        if let observeTasksCountClosure = observeTasksCountClosure {
+            return observeTasksCountClosure()
+        } else {
+            return observeTasksCountReturnValue
+        }
+    }
     //MARK: - canSyncListContents
 
     var canSyncListContentsAtIgnoreLastTimestampCallsCount = 0
@@ -1439,13 +1455,13 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     var canSyncListContentsAtIgnoreLastTimestampReceivedArguments: (relativePath: String?, ignoreLastTimestamp: Bool)?
     var canSyncListContentsAtIgnoreLastTimestampReceivedInvocations: [(relativePath: String?, ignoreLastTimestamp: Bool)] = []
     var canSyncListContentsAtIgnoreLastTimestampReturnValue: Bool!
-    var canSyncListContentsAtIgnoreLastTimestampClosure: ((String?, Bool) -> Bool)?
-    func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) -> Bool {
+    var canSyncListContentsAtIgnoreLastTimestampClosure: ((String?, Bool) async -> Bool)?
+    func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) async -> Bool {
         canSyncListContentsAtIgnoreLastTimestampCallsCount += 1
         canSyncListContentsAtIgnoreLastTimestampReceivedArguments = (relativePath: relativePath, ignoreLastTimestamp: ignoreLastTimestamp)
         canSyncListContentsAtIgnoreLastTimestampReceivedInvocations.append((relativePath: relativePath, ignoreLastTimestamp: ignoreLastTimestamp))
         if let canSyncListContentsAtIgnoreLastTimestampClosure = canSyncListContentsAtIgnoreLastTimestampClosure {
-            return canSyncListContentsAtIgnoreLastTimestampClosure(relativePath, ignoreLastTimestamp)
+            return await canSyncListContentsAtIgnoreLastTimestampClosure(relativePath, ignoreLastTimestamp)
         } else {
             return canSyncListContentsAtIgnoreLastTimestampReturnValue
         }
@@ -1682,9 +1698,9 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
     var getAllQueuedJobsCalled: Bool {
         return getAllQueuedJobsCallsCount > 0
     }
-    var getAllQueuedJobsReturnValue: [SyncTask]!
-    var getAllQueuedJobsClosure: (() async -> [SyncTask])?
-    func getAllQueuedJobs() async -> [SyncTask] {
+    var getAllQueuedJobsReturnValue: [SyncTaskReference]!
+    var getAllQueuedJobsClosure: (() async -> [SyncTaskReference])?
+    func getAllQueuedJobs() async -> [SyncTaskReference] {
         getAllQueuedJobsCallsCount += 1
         if let getAllQueuedJobsClosure = getAllQueuedJobsClosure {
             return await getAllQueuedJobsClosure()

--- a/BookPlayer/Loading/LoadingViewModel.swift
+++ b/BookPlayer/Loading/LoadingViewModel.swift
@@ -13,7 +13,6 @@ import Foundation
 class LoadingViewModel: ViewModelProtocol {
   weak var coordinator: LoadingCoordinator!
 
-  @MainActor
   func initializeDataIfNeeded() {
     let dataInitializerCoordinator = DataInitializerCoordinator(alertPresenter: self.coordinator)
 

--- a/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
+++ b/BookPlayer/Profile/Profile Screen/ProfileViewModel.swift
@@ -49,7 +49,6 @@ class ProfileViewModel: ProfileViewModelProtocol {
   @Published var bottomOffset: CGFloat = ModelConstants.defaultBottomOffset
 
   /// Reference for observer
-  private var syncTasksObserver: NSKeyValueObservation?
   private var disposeBag = Set<AnyCancellable>()
 
   init(
@@ -69,12 +68,10 @@ class ProfileViewModel: ProfileViewModelProtocol {
   }
 
   func bindObservers() {
-    syncTasksObserver = UserDefaults.standard.observe(\.userSyncTasksQueue, options: [.initial, .new]) { [unowned self] _, _ in
-      Task { @MainActor in
-        let count = await self.syncService.queuedJobsCount()
-        self.tasksButtonText = String(format: "queued_sync_tasks_title".localized, count)
-      }
+    syncService.observeTasksCount().sink { [unowned self] count in
+      self.tasksButtonText = String(format: "queued_sync_tasks_title".localized, count)
     }
+    .store(in: &disposeBag)
 
     NotificationCenter.default.publisher(for: .accountUpdate, object: nil)
       .sink(receiveValue: { [weak self] _ in

--- a/BookPlayer/Profile/Profile Screen/QueuedSyncTasksView.swift
+++ b/BookPlayer/Profile/Profile Screen/QueuedSyncTasksView.swift
@@ -18,7 +18,7 @@ struct QueuedSyncTasksView<Model: QueuedSyncTasksViewModelProtocol>: View {
       Section {
         ForEach(viewModel.queuedJobs) { job in
           QueuedSyncTaskRowView(
-            imageName: .constant(parseImageName(job)),
+            imageName: .constant(parseImageName(job.jobType)),
             title: .constant(job.relativePath)
           )
           .listRowBackground(themeViewModel.secondarySystemBackgroundColor)
@@ -43,8 +43,8 @@ struct QueuedSyncTasksView<Model: QueuedSyncTasksViewModelProtocol>: View {
     }
   }
 
-  func parseImageName(_ job: SyncTask) -> String {
-    switch job.jobType {
+  func parseImageName(_ jobType: SyncJobType) -> String {
+    switch jobType {
     case .upload:
       return "arrow.up.to.line"
     case .update:
@@ -81,18 +81,16 @@ struct QueuedSyncTasksView<Model: QueuedSyncTasksViewModelProtocol>: View {
 struct QueuedSyncTasksView_Previews: PreviewProvider {
   class MockQueuedSyncTasksViewModel: QueuedSyncTasksViewModelProtocol, ObservableObject {
     var allowsCellularData: Bool = false
-    var queuedJobs: [BookPlayerKit.SyncTask] = [
-      SyncTask(
+    var queuedJobs: [BookPlayerKit.SyncTaskReference] = [
+      SyncTaskReference(
         id: "1",
         relativePath: "test/path.mp3",
-        jobType: .upload,
-        parameters: [:]
+        jobType: .upload
       ),
-      SyncTask(
+      SyncTaskReference(
         id: "2",
         relativePath: "test/path2.mp3",
-        jobType: .upload,
-        parameters: [:]
+        jobType: .upload
       )
     ]
   }

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -11,6 +11,7 @@ public enum Constants {
     public static let appIcon = "userSettingsAppIcon"
     public static let donationMade = "userSettingsDonationMade"
     public static let showPlayer = "userSettingsShowPlayer"
+    /// Deprecated
     public static let syncTasksQueue = "userSyncTasksQueue"
     public static let lastSyncTimestamp = "lastSyncTimestamp"
     public static let hasScheduledLibraryContents = "hasScheduledLibraryContents"

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -44,6 +44,26 @@ public class DataManager {
     return processedFolderURL
   }
 
+  public class func getSyncTasksRealmURL() -> URL {
+    let hiddenFolderURL = self.getDocumentsFolderURL()
+      .appendingPathComponent(self.processedFolderName)
+      .appendingPathComponent(".dbRealm")
+
+    if !FileManager.default.fileExists(atPath: hiddenFolderURL.path) {
+      do {
+        try FileManager.default.createDirectory(
+          at: hiddenFolderURL,
+          withIntermediateDirectories: true,
+          attributes: nil
+        )
+      } catch {
+        fatalError("Couldn't create Realm folder")
+      }
+    }
+
+    return hiddenFolderURL.appendingPathComponent("bookplayer-synctasks.realm")
+  }
+
   public class func getBackupFolderURL() -> URL {
     let documentsURL = self.getDocumentsFolderURL()
 

--- a/Shared/CoreData/DatabaseInitializer.swift
+++ b/Shared/CoreData/DatabaseInitializer.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 /// Wrapper for `DataMigrationManager` to simplify handling all the migrations
-@MainActor
 public class DatabaseInitializer: BPLogger {
   private let dataMigrationManager: DataMigrationManager
 

--- a/Shared/Extensions/UserDefaults+BookPlayer.swift
+++ b/Shared/Extensions/UserDefaults+BookPlayer.swift
@@ -30,8 +30,4 @@ public extension UserDefaults {
   @objc dynamic var userSettingsAllowCellularData: Bool {
     return bool(forKey: Constants.UserDefaults.allowCellularData)
   }
-
-  @objc dynamic var userSyncTasksQueue: [Data]? {
-    return array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data]
-  }
 }

--- a/Shared/Realm/Migrations/MigrationStoredSyncTasks.swift
+++ b/Shared/Realm/Migrations/MigrationStoredSyncTasks.swift
@@ -1,0 +1,141 @@
+//
+//  MigrationStoredSyncTasks.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 26/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+class MigrationStoredSyncTasks: MigrationHandler {
+  let version: UInt64 = 1
+
+  func migrate(_ migration: RealmSwift.Migration, _ oldSchemaVersion: UInt64) {
+    guard oldSchemaVersion < version else { return }
+
+    let taskObjects1 = migrateSyncTasksFromThirdParty(migration)
+    let taskObjects2 = migrateSyncTasksFromUserDefaults(migration)
+
+    let tasks = taskObjects1 + taskObjects2
+
+    migration.create("SyncTasksObject", value: ["tasks": tasks])
+  }
+
+  /// Migrate tasks from stored sync task from third party library
+  private func migrateSyncTasksFromThirdParty(_ migration: RealmSwift.Migration) -> [MigrationObject] {
+    let store = UserDefaults.standard
+    let values: [String: [String: String]] = store.value(forKey: "LibraryItemSyncJob") as? [String: [String: String]] ?? [:]
+    let dictionaryTasks: [String: String] = values["GLOBAL"] ?? [:]
+    let storedTasks = Array(dictionaryTasks.values)
+
+    guard !storedTasks.isEmpty else { return [] }
+
+    var tasks = [MigrationObject]()
+
+    for storedTask in storedTasks {
+      autoreleasepool {
+        if let taskData = storedTask.data(using: .utf8),
+           let taskDictionary = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
+           let taskRawParams = taskDictionary["params"] as? String,
+           let taskParamsData = taskRawParams.data(using: .utf8),
+           var taskParams = try? JSONSerialization.jsonObject(with: taskParamsData) as? [String: Any],
+           let relativePath = taskParams["relativePath"] as? String,
+           let jobTypeRaw = taskParams["jobType"] as? String,
+           let jobType = SyncJobType(rawValue: jobTypeRaw) {
+          let taskId = UUID().uuidString
+          taskParams["id"] = taskId
+
+          let task = migrateTask(
+            taskParams,
+            id: taskId,
+            relativePath: relativePath,
+            jobType: jobType,
+            migration: migration
+          )
+          tasks.append(task)
+        }
+      }
+    }
+
+    store.removeObject(forKey: "LibraryItemSyncJob")
+    store.removeObject(forKey: "userSettingsHasQueuedJobs")
+
+    return tasks
+  }
+
+  private func migrateSyncTasksFromUserDefaults(_ migration: RealmSwift.Migration) -> [MigrationObject] {
+    let store = UserDefaults.standard
+
+    guard
+      let storedTasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data],
+      !storedTasks.isEmpty
+    else { return [] }
+
+    var tasks = [MigrationObject]()
+
+    for taskData in storedTasks {
+      autoreleasepool {
+        if let taskParams = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
+           let taskId = taskParams["id"] as? String,
+           let relativePath = taskParams["relativePath"] as? String,
+           let jobTypeRaw = taskParams["jobType"] as? String,
+           let jobType = SyncJobType(rawValue: jobTypeRaw) {
+          let task = migrateTask(
+            taskParams,
+            id: taskId,
+            relativePath: relativePath,
+            jobType: jobType,
+            migration: migration
+          )
+          tasks.append(task)
+        }
+      }
+    }
+
+    store.removeObject(forKey: Constants.UserDefaults.syncTasksQueue)
+
+    return tasks
+  }
+
+  private func migrateTask(
+    _ parameters: [String: Any],
+    id: String,
+    relativePath: String,
+    jobType: SyncJobType,
+    migration: RealmSwift.Migration
+  ) -> MigrationObject {
+    let className: String
+    switch jobType {
+    case .upload:
+      className = "UploadTaskObject"
+    case .update:
+      className = "UpdateTaskObject"
+    case .move:
+      className = "MoveTaskObject"
+    case .delete, .shallowDelete:
+      className = "DeleteTaskObject"
+    case .deleteBookmark:
+      className = "DeleteBookmarkTaskObject"
+    case .setBookmark:
+      className = "SetBookmarkTaskObject"
+    case .renameFolder:
+      className = "RenameFolderTaskObject"
+    case .uploadArtwork:
+      className = "ArtworkUploadTaskObject"
+    }
+
+    migration.create(className, value: parameters)
+
+    return migration.create(
+      "SyncTaskReferenceObject",
+      value: [
+        "id": ObjectId.generate(),
+        "taskID": id,
+        "relativePath": relativePath,
+        "jobType": jobType.rawValue
+      ]
+    )
+  }
+}

--- a/Shared/Realm/Migrations/RealmMigrationManager.swift
+++ b/Shared/Realm/Migrations/RealmMigrationManager.swift
@@ -1,0 +1,27 @@
+//
+//  RealmMigrationManager.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 24/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+protocol MigrationHandler {
+  func migrate(_ migration: Migration, _ oldSchemaVersion: UInt64)
+}
+
+class RealmMigrationManager: MigrationHandler {
+
+  private var handlers: [MigrationHandler] = [
+    MigrationStoredSyncTasks()
+  ]
+
+  func migrate(_ migration: RealmSwift.Migration, _ oldSchemaVersion: UInt64) {
+    for handler in handlers {
+      handler.migrate(migration, oldSchemaVersion)
+    }
+  }
+}

--- a/Shared/Realm/Models/SyncJobType.swift
+++ b/Shared/Realm/Models/SyncJobType.swift
@@ -1,0 +1,22 @@
+//
+//  SyncJobType.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 26/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public enum SyncJobType: String, PersistableEnum {
+  case upload
+  case update
+  case move
+  case renameFolder
+  case delete
+  case shallowDelete
+  case setBookmark
+  case deleteBookmark
+  case uploadArtwork
+}

--- a/Shared/Realm/Models/SyncTasksObject.swift
+++ b/Shared/Realm/Models/SyncTasksObject.swift
@@ -1,0 +1,92 @@
+//
+//  SyncTasksObject.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 20/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+/// Model that holds the ordered list of queued tasks
+class SyncTasksObject: Object {
+  @Persisted var tasks = List<SyncTaskReferenceObject>()
+}
+
+/// Object with type and task id reference to the real task
+class SyncTaskReferenceObject: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted var relativePath: String
+  @Persisted var taskID: String
+  @Persisted var jobType: SyncJobType
+}
+
+class UploadTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var originalFileName: String
+  @Persisted var title: String
+  @Persisted var details: String
+  @Persisted var speed: Double?
+  @Persisted var currentTime: Double
+  @Persisted var duration: Double
+  @Persisted var percentCompleted: Double
+  @Persisted var isFinished: Bool
+  @Persisted var orderRank: Int
+  @Persisted var lastPlayDateTimestamp: Double?
+  @Persisted var type: Int16
+}
+
+class UpdateTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var title: String?
+  @Persisted var details: String?
+  @Persisted var speed: Double?
+  @Persisted var currentTime: Double?
+  @Persisted var duration: Double?
+  @Persisted var percentCompleted: Double?
+  @Persisted var isFinished: Bool?
+  @Persisted var orderRank: Int?
+  @Persisted var lastPlayDateTimestamp: Double?
+  @Persisted var type: Int16?
+}
+
+class MoveTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var origin: String
+  @Persisted var destination: String
+}
+
+class DeleteTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  /// Can only be `delete` or `shallowDelete`
+  @Persisted var jobType: SyncJobType
+}
+
+class DeleteBookmarkTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var time: Double
+}
+
+class SetBookmarkTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var time: Double
+  @Persisted var note: String?
+}
+
+class RenameFolderTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+  @Persisted var name: String
+}
+
+class ArtworkUploadTaskObject: Object {
+  @Persisted(primaryKey: true) var id: String
+  @Persisted var relativePath: String
+}

--- a/Shared/Realm/Realm+BookPlayer.swift
+++ b/Shared/Realm/Realm+BookPlayer.swift
@@ -1,0 +1,18 @@
+//
+//  Realm+BookPlayer.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 26/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+extension Object {
+  func toDictionaryPayload() -> [String: Any] {
+    return objectSchema.properties.reduce(into: [:]) { dict, property in
+      dict[property.name] = self.value(forKeyPath: property.name)
+    }
+  }
+}

--- a/Shared/Realm/RealmManager.swift
+++ b/Shared/Realm/RealmManager.swift
@@ -1,0 +1,36 @@
+//
+//  RealmManager.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 27/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+public class RealmManager {
+  public static let shared = RealmManager()
+
+  private let migrationManager = RealmMigrationManager()
+
+  private lazy var tasksConfiguration = Realm.Configuration(
+    fileURL: DataManager.getSyncTasksRealmURL(),
+    schemaVersion: 1
+  ) { migration, oldSchemaVersion in
+    self.migrationManager.migrate(migration, oldSchemaVersion)
+  }
+
+  func initializeRealm(in actor: Actor) async throws -> Realm {
+    return try await Realm(configuration: tasksConfiguration, actor: actor)
+  }
+
+  func publisher<Element: RealmFetchable>(
+    for type: Element.Type,
+    keyPaths: [String]?,
+    block: @escaping (RealmCollectionChange<Results<Element>>) -> Void
+  ) -> NotificationToken {
+    let realm = try! Realm(configuration: tasksConfiguration)
+    return realm.objects(type).observe(keyPaths: keyPaths, on: DispatchQueue.main, block)
+  }
+}

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -27,7 +27,7 @@ public protocol LibrarySyncProtocol {
   func removeItems(notIn identifiers: [String], parentFolder: String?) async
 
   /// Get last played library item
-  func getLibraryLastItem() -> SimpleLibraryItem?
+  func fetchLibraryLastItem() async -> SimpleLibraryItem?
   /// Set the last played book
   func updateLibraryLastBook(with relativePath: String?) async
   /// Returns boolean determining if the item exists for the relativePath
@@ -51,6 +51,16 @@ extension LibraryService: LibrarySyncProtocol {
       context.perform { [unowned self, context] in
         setLibraryLastBook(with: relativePath, context: context)
         continuation.resume()
+      }
+    }
+  }
+
+  public func fetchLibraryLastItem() async -> SimpleLibraryItem? {
+    return await withCheckedContinuation { continuation in
+      let context = dataManager.getBackgroundContext()
+      context.perform { [unowned self, context] in
+        let lastItem = getLibraryLastItem(context: context)
+        continuation.resume(returning: lastItem)
       }
     }
   }

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -418,18 +418,23 @@ extension LibraryService {
 
   public func getLibraryLastItem() -> SimpleLibraryItem? {
     let context = self.dataManager.getContext()
+    return getLibraryLastItem(context: context)
+  }
+
+  func getLibraryLastItem(context: NSManagedObjectContext) -> SimpleLibraryItem? {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "Library")
-    fetchRequest.propertiesToFetch = ["lastPlayedItem.relativePath"]
+    fetchRequest.propertiesToFetch = ["lastPlayedItem"]
     fetchRequest.resultType = .dictionaryResultType
 
     guard
-      let dict = (try? context.fetch(fetchRequest))?.first as? [String: String],
-      let relativePath = dict["lastPlayedItem.relativePath"]
+      let dict = (try? context.fetch(fetchRequest))?.first as? [String: NSManagedObjectID],
+      let itemId = dict["lastPlayedItem"],
+      let item = try? context.existingObject(with: itemId) as? LibraryItem
     else {
       return nil
     }
 
-    return getSimpleItem(with: relativePath)
+    return SimpleLibraryItem(from: item)
   }
 
   public func getLibraryCurrentTheme() -> SimpleTheme? {

--- a/Shared/Services/Sync/Model/SyncTask.swift
+++ b/Shared/Services/Sync/Model/SyncTask.swift
@@ -22,14 +22,14 @@ public struct SyncTask: Identifiable {
   }
 }
 
-public enum SyncJobType: String {
-  case upload
-  case update
-  case move
-  case renameFolder
-  case delete
-  case shallowDelete
-  case setBookmark
-  case deleteBookmark
-  case uploadArtwork
+public struct SyncTaskReference: Identifiable {
+  public let id: String
+  public let relativePath: String
+  public let jobType: SyncJobType
+
+  public init(id: String, relativePath: String, jobType: SyncJobType) {
+    self.id = id
+    self.relativePath = relativePath
+    self.jobType = jobType
+  }
 }

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -80,7 +80,10 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
       .store(in: &disposeBag)
 
     /// This will start the loop where it will periodically check for queued tasks to execute
-    queueNextTask()
+    Task {
+      await taskStore.initializeData()
+      queueNextTask()
+    }
   }
 
   private func createHardLink(for item: SyncableItem) {

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -266,7 +266,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
 
   func handleSyncedLastPlayed(item: SyncableItem) async throws {
     guard
-      let localLastItem = libraryService.getLibraryLastItem(),
+      let localLastItem = await libraryService.fetchLibraryLastItem(),
       let localLastPlayDateTimestamp = localLastItem.lastPlayDate?.timeIntervalSince1970
     else {
       await libraryService.updateInfo(for: item)

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -30,8 +30,10 @@ public protocol SyncServiceProtocol {
 
   /// Count of the currently queued sync jobs
   func queuedJobsCount() async -> Int
+  /// Observe the queued jobs count
+  func observeTasksCount() -> AnyPublisher<Int, Never>
   /// Check if we can safely fetch the list contents
-  func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) -> Bool
+  func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) async -> Bool
 
   /// Fetch the contents at the relativePath and override local contents with the remote repsonse
   func syncListContents(at relativePath: String?) async throws
@@ -71,7 +73,7 @@ public protocol SyncServiceProtocol {
   func scheduleUploadArtwork(relativePath: String)
 
   /// Get all queued jobs
-  func getAllQueuedJobs() async -> [SyncTask]
+  func getAllQueuedJobs() async -> [SyncTaskReference]
   /// Cancel all scheduled jobs
   func cancelAllJobs()
 
@@ -88,6 +90,7 @@ public protocol SyncServiceProtocol {
 
 public final class SyncService: SyncServiceProtocol, BPLogger {
   let libraryService: LibrarySyncProtocol
+  private let tasksCountService: SyncTasksCountServiceProtocol
   var jobManager: JobSchedulerProtocol
   let client: NetworkClientProtocol
   public var isActive: Bool
@@ -124,11 +127,13 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
   public init(
     isActive: Bool,
     libraryService: LibrarySyncProtocol,
+    tasksCountService: SyncTasksCountServiceProtocol = SyncTasksCountService(),
     jobManager: JobSchedulerProtocol = SyncJobScheduler(),
     client: NetworkClientProtocol = NetworkClient()
   ) {
     self.isActive = isActive
     self.libraryService = libraryService
+    self.tasksCountService = tasksCountService
     self.jobManager = jobManager
     self.client = client
     self.provider = NetworkProvider(client: client)
@@ -163,15 +168,17 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     return await jobManager.queuedJobsCount()
   }
 
-  public func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) -> Bool {
+  public func observeTasksCount() -> AnyPublisher<Int, Never> {
+    return tasksCountService.observeTasksCount()
+  }
+
+  public func canSyncListContents(at relativePath: String?, ignoreLastTimestamp: Bool) async -> Bool {
     guard isActive else {
       Self.logger.trace("Sync is not enabled")
       return false
     }
 
-    let queuedTasksArray = UserDefaults.standard.array(forKey: Constants.UserDefaults.syncTasksQueue) ?? []
-
-    guard queuedTasksArray.count == 0 else {
+    guard await jobManager.queuedJobsCount() == 0 else {
       Self.logger.trace("Can't fetch items while there are sync operations in progress")
       return false
     }
@@ -401,7 +408,7 @@ public final class SyncService: SyncServiceProtocol, BPLogger {
     }
   }
 
-  public func getAllQueuedJobs() async -> [SyncTask] {
+  public func getAllQueuedJobs() async -> [SyncTaskReference] {
     return await jobManager.getAllQueuedJobs()
   }
 

--- a/Shared/Services/Sync/SyncTasksCountService.swift
+++ b/Shared/Services/Sync/SyncTasksCountService.swift
@@ -1,0 +1,43 @@
+//
+//  SyncTasksCountService.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 27/2/24.
+//  Copyright © 2024 Tortuga Power. All rights reserved.
+//
+
+import Combine
+import Foundation
+import RealmSwift
+
+public protocol SyncTasksCountServiceProtocol {
+  func observeTasksCount() -> AnyPublisher<Int, Never>
+}
+
+public class SyncTasksCountService: SyncTasksCountServiceProtocol {
+  private var token: NotificationToken?
+  private var tasksCountPublisher = CurrentValueSubject<Int?, Never>(nil)
+
+  public init() {}
+
+  public func observeTasksCount() -> AnyPublisher<Int, Never> {
+    if token == nil {
+      token = RealmManager.shared.publisher(
+        for: SyncTasksObject.self,
+        keyPaths: ["tasks"],
+        block: { [weak self] change in
+          switch change {
+          case .initial(let results), .update(let results, _, _, _):
+            self?.tasksCountPublisher.value = results.first?.tasks.count ?? 0
+          case .error:
+            /// Deprecated by Realm
+            break
+          }
+      })
+    }
+
+    return tasksCountPublisher
+      .compactMap({ $0 })
+      .eraseToAnyPublisher()
+  }
+}

--- a/Shared/Services/Sync/SyncTasksStorage.swift
+++ b/Shared/Services/Sync/SyncTasksStorage.swift
@@ -6,203 +6,164 @@
 //  Copyright © 2024 Tortuga Power. All rights reserved.
 //
 
+import Combine
 import Foundation
+import RealmSwift
 
 public protocol BPTasksStorageProtocol: AnyActor {
-  func initializeData() async
   func appendTask(parameters: [String: Any]) async throws
   func getNextTask() async throws -> SyncTask?
   func finishedTask(id: String) async throws
-  func getAllTasks() async -> [SyncTask]
+  func getAllTasks() async -> [SyncTaskReference]
   func getTasksCount() async -> Int
-  func clearAll() async
+  func clearAll() async throws
   /// Check if there's an upload task queued for the item
   func hasUploadTask(for relativePath: String) async -> Bool
 }
 
 /// Persist jobs in UserDefaults
 public actor SyncTasksStorage: BPTasksStorageProtocol {
-  private let store = UserDefaults.standard
-  private lazy var uploadTasks: [String: Any] = {
-    guard let tasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data] else { return [:] }
+  private var realm: Realm!
 
-    return autoreleasepool {
-      tasks.reduce(into: [:], { dict, taskData in
-        guard
-          let taskParams = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
-          let rawJobType = taskParams["jobType"] as? String,
-          let jobType = SyncJobType(rawValue: rawJobType),
-          jobType == .upload,
-          let relativePath = taskParams["relativePath"] as? String
-        else { return }
-
-        dict[relativePath] = taskParams
-      })
-    }
-  }()
-
-  public init() {}
-
-  public func initializeData() {
-    migrateSyncTasksIfNecessary()
+  public init() async throws {
+    self.realm = try await RealmManager.shared.initializeRealm(in: self)
   }
 
-  private func migrateSyncTasksIfNecessary() {
-    let values: [String: [String: String]] = store.value(forKey: "LibraryItemSyncJob") as? [String: [String: String]] ?? [:]
-    let dictionaryTasks: [String: String] = values["GLOBAL"] ?? [:]
-    let storedTasks = Array(dictionaryTasks.values)
-
-    guard !storedTasks.isEmpty else { return }
-
-    for storedTask in storedTasks {
-      autoreleasepool {
-        if let taskData = storedTask.data(using: .utf8),
-           let taskDictionary = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
-           let taskRawParams = taskDictionary["params"] as? String,
-           let taskParamsData = taskRawParams.data(using: .utf8),
-           var taskParams = try? JSONSerialization.jsonObject(with: taskParamsData) as? [String: Any] {
-          taskParams["id"] = UUID().uuidString
-
-          if let migratedTask = try? JSONSerialization.data(withJSONObject: taskParams) {
-            var tasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue) ?? []
-            tasks.append(migratedTask)
-            store.set(tasks, forKey: Constants.UserDefaults.syncTasksQueue)
-          }
-        }
-      }
+  public func appendTask(parameters: [String: Any]) async throws {
+    guard 
+      let taskId = parameters["id"] as? String,
+      let relativePath = parameters["relativePath"] as? String,
+      let rawJobType = parameters["jobType"] as? String,
+      let jobType = SyncJobType(rawValue: rawJobType)
+    else {
+      throw BookPlayerError.runtimeError("Missing id or job type when creating task")
     }
 
-    store.removeObject(forKey: "LibraryItemSyncJob")
-    store.removeObject(forKey: "userSettingsHasQueuedJobs")
-  }
+    if jobType == .update,
+       (realm.objects(SyncTasksObject.self).first?.tasks.count ?? 0) > 1,
+       let existingTask = realm.objects(UpdateTaskObject.self).last(where: {
+         $0.relativePath == relativePath
+       }) {
+      var parameters = parameters
+      parameters["id"] = existingTask.id
 
-  public func appendTask(parameters: [String: Any]) throws {
-    try autoreleasepool {
-      var storedJobs = store.array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data] ?? []
-
-      let finalParameters: [String: Any]
-
-      /// Merge update tasks when it's for the same item
-      if storedJobs.count >= 2,
-         let lastTaskData = storedJobs.last,
-         let taskParams = try JSONSerialization.jsonObject(with: lastTaskData) as? [String: Any],
-         let relativePath = taskParams["relativePath"] as? String,
-         parameters["relativePath"] as? String == relativePath,
-         let rawJobType = parameters["jobType"] as? String,
-         let jobType = SyncJobType(rawValue: rawJobType),
-         jobType == .update {
-        finalParameters = taskParams.merging(parameters) { (_, new) in new }
-        /// Remove the last item we are replacing
-        storedJobs.removeLast()
-      } else {
-        finalParameters = parameters
+      try await realm.asyncWrite {
+        realm.create(UpdateTaskObject.self, value: parameters, update: .modified)
       }
-
-      let data = try JSONSerialization.data(withJSONObject: finalParameters)
-      storedJobs.append(data)
-
-      if let rawJobType = parameters["jobType"] as? String,
-         let jobType = SyncJobType(rawValue: rawJobType),
-         jobType == .upload,
-         let relativePath = parameters["relativePath"] as? String {
-        uploadTasks[relativePath] = parameters
-      }
-
-      store.set(storedJobs, forKey: Constants.UserDefaults.syncTasksQueue)
-    }
-  }
-
-  public func getNextTask() throws -> SyncTask? {
-    return try autoreleasepool {
-      guard
-        let tasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data],
-        let taskData = tasks.first
-      else { return nil }
-
-      guard
-        let taskParams = try JSONSerialization.jsonObject(with: taskData) as? [String: Any],
-        let taskId = taskParams["id"] as? String,
-        let relativePath = taskParams["relativePath"] as? String,
-        let rawJobType = taskParams["jobType"] as? String,
-        let jobType = SyncJobType(rawValue: rawJobType)
-      else {
-        throw BookPlayerError.runtimeError("Failed to decode task")
-      }
-
-      return SyncTask(
-        id: taskId,
-        relativePath: relativePath,
-        jobType: jobType,
-        parameters: taskParams
-      )
-    }
-  }
-
-  public func finishedTask(id: String) throws {
-    try autoreleasepool {
-      var tasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue)
-
-      guard let taskData = tasks?.removeFirst() as? Data else {
-        throw BookPlayerError.runtimeError("No task queued")
-      }
-
-      guard let taskParams = try JSONSerialization.jsonObject(with: taskData) as? [String: Any] else {
-        throw BookPlayerError.runtimeError("Failed to decode task")
-      }
-
-      if let rawJobType = taskParams["jobType"] as? String,
-         let jobType = SyncJobType(rawValue: rawJobType),
-         jobType == .upload,
-         let relativePath = taskParams["relativePath"] as? String {
-        uploadTasks.removeValue(forKey: relativePath)
-      }
-
-      let taskId = taskParams["id"] as? String
-
-      guard taskId == id else {
-        throw BookPlayerError.runtimeError("Finished task is not the next in the queue")
-      }
-
-      store.set(tasks, forKey: Constants.UserDefaults.syncTasksQueue)
-    }
-  }
-
-  public func getAllTasks() -> [SyncTask] {
-    guard let tasks = store.array(forKey: Constants.UserDefaults.syncTasksQueue) as? [Data] else { return [] }
-
-    return autoreleasepool {
-      tasks.compactMap({ data in
-        guard
-          let taskParams = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-          let taskId = taskParams["id"] as? String,
-          let relativePath = taskParams["relativePath"] as? String,
-          let rawJobType = taskParams["jobType"] as? String,
-          let jobType = SyncJobType(rawValue: rawJobType)
-        else {
-          return nil
-        }
-        
-        return SyncTask(
-          id: taskId,
-          relativePath: relativePath,
-          jobType: jobType,
-          parameters: taskParams
+    } else {
+      try await realm.asyncWrite {
+        let objectType = getRealmObjectType(for: jobType)
+        realm.create(objectType, value: parameters)
+        let taskReference = realm.create(
+          SyncTaskReferenceObject.self,
+          value: [
+            "id": ObjectId.generate(),
+            "relativePath": relativePath,
+            "taskID": taskId,
+            "jobType": jobType.rawValue
+          ]
         )
-      })
+
+        let controller = realm.objects(SyncTasksObject.self).first
+        ?? realm.create(SyncTasksObject.self)
+        controller.tasks.append(taskReference)
+      }
     }
+  }
+
+  public func getNextTask() async throws -> SyncTask? {
+    guard
+      let controller = realm.objects(SyncTasksObject.self).first,
+      let task = controller.tasks.first
+    else {
+      return nil
+    }
+
+    guard 
+      let storedObject = getRealmObject(with: task.taskID, jobType: task.jobType)
+    else {
+      try await realm.asyncWrite {
+        controller.tasks.removeFirst()
+      }
+      return nil
+    }
+
+    return SyncTask(
+      id: task.taskID,
+      relativePath: task.relativePath,
+      jobType: task.jobType,
+      parameters: storedObject.toDictionaryPayload()
+    )
+  }
+
+  private func getRealmObjectType(for jobType: SyncJobType) -> Object.Type {
+    switch jobType {
+    case .upload:
+      return UploadTaskObject.self
+    case .update:
+      return UpdateTaskObject.self
+    case .move:
+      return MoveTaskObject.self
+    case .delete, .shallowDelete:
+      return DeleteTaskObject.self
+    case .deleteBookmark:
+      return DeleteBookmarkTaskObject.self
+    case .setBookmark:
+      return SetBookmarkTaskObject.self
+    case .renameFolder:
+      return RenameFolderTaskObject.self
+    case .uploadArtwork:
+      return ArtworkUploadTaskObject.self
+    }
+  }
+
+  private func getRealmObject(with id: String, jobType: SyncJobType) -> Object? {
+    let type = getRealmObjectType(for: jobType)
+
+    return realm.object(ofType: type, forPrimaryKey: id)
+  }
+
+  public func finishedTask(id: String) async throws {
+    guard
+      let controller = realm.objects(SyncTasksObject.self).first,
+      let task = controller.tasks.first
+    else { return }
+
+    try await realm.asyncWrite {
+      if let storedObject = getRealmObject(with: task.taskID, jobType: task.jobType) {
+        realm.delete(storedObject)
+      }
+
+      controller.tasks.removeFirst()
+      realm.delete(task)
+    }
+  }
+
+  public func getAllTasks() -> [SyncTaskReference] {
+    guard
+      let tasks = realm.objects(SyncTasksObject.self).first?.tasks
+    else { return [] }
+
+    return tasks.map { SyncTaskReference(
+      id: $0.taskID,
+      relativePath: $0.relativePath,
+      jobType: $0.jobType
+    ) }
   }
 
   public func getTasksCount() -> Int {
-    return store.array(forKey: Constants.UserDefaults.syncTasksQueue)?.count ?? 0
+    return realm.objects(SyncTasksObject.self).first?.tasks.count ?? 0
   }
 
-  public func clearAll() {
-    store.removeObject(forKey: Constants.UserDefaults.syncTasksQueue)
-    uploadTasks = [:]
+  public func clearAll() async throws {
+    try await realm.asyncWrite {
+      realm.deleteAll()
+    }
   }
 
   /// Check if there's an upload task queued for the item
   public func hasUploadTask(for relativePath: String) -> Bool {
-    return uploadTasks[relativePath] != nil
+    return realm.objects(UploadTaskObject.self)
+      .first { $0.relativePath == relativePath } != nil
   }
 }


### PR DESCRIPTION
## Bugfix

- Limitations with UserDefaults to store arrays made the memory usage of the app spike

## Approach

- Add Realm framework to the app and define new models for each task
- Rework `SyncTasksStorage` to use an actor isolated Realm for accessing and updating the tasks
- Setup first migration to handle moving the tasks from UserDefaults into Realm

## Things to be aware of / Things to focus on

- We'll eventually move away from CoreData and fully migrate to Realm
