### PR TITLE
Fix empty value type for last play date timestamp

### DIFF
--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1207,7 +1207,7 @@ extension LibraryService {
     case .folder:
       folder.type = .folder
       folder.lastPlayDate = nil
-      metadataUpdates[#keyPath(LibraryItem.lastPlayDate)] = ""
+      metadataUpdates[#keyPath(LibraryItem.lastPlayDate)] = 0
     case .bound:
       guard let items = folder.items?.allObjects as? [Book] else {
         throw BookPlayerError.runtimeError("The folder needs to only contain book items")
@@ -1221,7 +1221,7 @@ extension LibraryService {
         item.lastPlayDate = nil
         metadataPassthroughPublisher.send([
           #keyPath(LibraryItem.relativePath): item.relativePath!,
-          #keyPath(LibraryItem.lastPlayDate): "",
+          #keyPath(LibraryItem.lastPlayDate): 0,
         ])
       }
 


### PR DESCRIPTION
## Bugfix

- An empty string is being sent instead of a double type value, this will cause a crash when clearing the date of items

## Approach

- Set a 0 instead of an empty string

## Things to be aware of / Things to focus on

- I wasn't expecting for v5.2.3 to get approved just a couple of hours after submitting, this fix will have to go on a hotfix and hopefully Apple will be as fast for v5.2.4