### PR TITLE
Fix auto sleep timer & initial migration for synced tasks

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -704,6 +704,10 @@ extension PlayerManager {
   }
 
   func play() {
+    play(autoPlayed: false)
+  }
+
+  func play(autoPlayed: Bool) {
     playTask?.cancel()
     playTask = Task { @MainActor in
       /// Ignore play commands if there's no item loaded,
@@ -739,7 +743,9 @@ extension PlayerManager {
 
       handleSmartRewind(currentItem)
 
-      handleAutoTimer()
+      if !autoPlayed {
+        handleAutoTimer()
+      }
 
       fadeTimer?.invalidate()
       shakeMotionService.stopMotionUpdates()
@@ -815,7 +821,7 @@ extension PlayerManager {
       self.observeStatus = false
 
       if self.playbackQueued == true {
-        self.play()
+        self.play(autoPlayed: true)
       }
       // Clean up flag
       self.playbackQueued = nil
@@ -1119,7 +1125,7 @@ extension PlayerManager {
       }
       let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
       if options.contains(.shouldResume) {
-        play()
+        play(autoPlayed: true)
       }
     @unknown default:
       break

--- a/Shared/Realm/Migrations/MigrationStoredSyncTasks.swift
+++ b/Shared/Realm/Migrations/MigrationStoredSyncTasks.swift
@@ -47,6 +47,10 @@ class MigrationStoredSyncTasks: MigrationHandler {
           let taskId = UUID().uuidString
           taskParams["id"] = taskId
 
+          if taskParams["lastPlayDateTimestamp"] is String {
+            taskParams["lastPlayDateTimestamp"] = 0
+          }
+
           let task = migrateTask(
             taskParams,
             id: taskId,
@@ -77,11 +81,16 @@ class MigrationStoredSyncTasks: MigrationHandler {
 
     for taskData in storedTasks {
       autoreleasepool {
-        if let taskParams = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
+        if var taskParams = try? JSONSerialization.jsonObject(with: taskData) as? [String: Any],
            let taskId = taskParams["id"] as? String,
            let relativePath = taskParams["relativePath"] as? String,
            let jobTypeRaw = taskParams["jobType"] as? String,
            let jobType = SyncJobType(rawValue: jobTypeRaw) {
+
+          if taskParams["lastPlayDateTimestamp"] is String {
+            taskParams["lastPlayDateTimestamp"] = 0
+          }
+
           let task = migrateTask(
             taskParams,
             id: taskId,


### PR DESCRIPTION
## Bugfix

- Fix auto sleep timer being reset after changing a chapter on a bound book, or when the next books is autoplayed
- Fix Realm migration for queued task with invalid value type for the last played timestamp (related to the fix on v5.2.4)

## Related tasks

https://github.com/TortugaPower/BookPlayer/issues/1104

## Approach

- Make a distinction for the `play` function when something is autoplayed, and when it's from user input to trigger the auto sleep timer reset
- Catch string values in the Realm migrations for the last played timestamp, and override with `0`