### PR TITLE
Avoid storing S3 error downloads as files

### DIFF
--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -36,11 +36,13 @@ class DataInitializerCoordinator: BPLogger {
       || error.code == NSFileWriteOutOfSpaceError
     ) {
       // CoreData may fail if device doesn't have space
-      alertPresenter.showAlert(
-        "error_title".localized,
-        message: "coredata_error_diskfull_description".localized,
-        completion: nil
-      )
+      await MainActor.run {
+        alertPresenter.showAlert(
+          "error_title".localized,
+          message: "coredata_error_diskfull_description".localized,
+          completion: nil
+        )
+      }
     } catch let error as NSError where (
       error.code == NSMigrationError ||
       error.code == NSMigrationConstraintViolationError ||
@@ -55,11 +57,13 @@ class DataInitializerCoordinator: BPLogger {
     ) {
       // TODO: We can handle `isRecoveryAttempt` to show a different error message
       Self.logger.warning("Failed to perform migration, attempting recovery with the loading library sequence")
-      alertPresenter.showAlert(
-        "error_title".localized,
-        message: "coredata_error_migration_description".localized
-      ) { [unowned self] in
-        recoverLibraryFromFailedMigration()
+      await MainActor.run {
+        alertPresenter.showAlert(
+          "error_title".localized,
+          message: "coredata_error_migration_description".localized
+        ) { [unowned self] in
+          recoverLibraryFromFailedMigration()
+        }
       }
     } catch {
       let error = error as NSError

--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -85,6 +85,7 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
     loadLastBookIfNeeded()
     syncList()
     bindImportObserverIfNeeded()
+    bindDownloadErrorObserver()
 
     if let appDelegate = AppDelegate.shared {
       for action in appDelegate.pendingURLActions {
@@ -134,6 +135,13 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
     })
 
     notifyPendingFiles()
+  }
+
+  func bindDownloadErrorObserver() {
+    syncService.downloadErrorPublisher.sink { (relativePath, error) in
+      self.showAlert("network_error_title".localized, message: "\(relativePath)\n\(error.localizedDescription)")
+    }
+    .store(in: &disposeBag)
   }
 
   @MainActor

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -211,12 +211,12 @@ class ItemListViewModel: ViewModelProtocol {
       ))
     }
 
-    singleDownloadProgressDelegateInterface.didFinishDownloadingTask = { [weak self] (task, fileURL) in
-      self?.handleSingleDownloadTaskFinished(task, fileURL: fileURL)
-    }
-
-    singleDownloadProgressDelegateInterface.didFinishTaskWithError = { [weak self] (task, error) in
-      self?.handleSingleDownloadTaskFinishedWithError(task, error: error)
+    singleDownloadProgressDelegateInterface.didFinishDownloadingTask = { [weak self] (task, fileURL, error) in
+      if let error {
+        self?.handleSingleDownloadTaskFinishedWithError(task, error: error)
+      } else if let fileURL {
+        self?.handleSingleDownloadTaskFinished(task, fileURL: fileURL)
+      }
     }
   }
 

--- a/Shared/Network/BPDownloadURLSession.swift
+++ b/Shared/Network/BPDownloadURLSession.swift
@@ -19,7 +19,7 @@ public class BPDownloadURLSession {
   ///   - didFinishDownloadingTask: Callback triggered when the download task is finished
   public init(
     downloadProgressUpdated: @escaping ((URLSessionDownloadTask, Double) -> Void),
-    didFinishDownloadingTask: @escaping ((URLSessionDownloadTask, URL) -> Void)
+    didFinishDownloadingTask: @escaping ((URLSessionTask, URL?, Error?) -> Void)
   ) {
     let bundleIdentifier: String = Bundle.main.configurationValue(for: .bundleIdentifier)
 


### PR DESCRIPTION
## Bugfix

- When there's an error downloading a cloud file, due to expired links, or the file not being available, the URLSession does not throw an error, it just completes

## Related tasks

#1081

## Approach

- Check for the status code of the URLSessionTask, and manually determine the error from there

## Things to be aware of / Things to focus on

- This also fixes some issues with alerts being shown in a background thread on the Storage management screen, and if there was an error initializing the database on launch