### PR TITLE
Fix crash on launch due to memory usage spike

### DIFF
--- a/Shared/Artwork/AVAudioAssetImageDataProvider.swift
+++ b/Shared/Artwork/AVAudioAssetImageDataProvider.swift
@@ -110,8 +110,9 @@ public struct AVAudioAssetImageDataProvider: ImageDataProvider {
   private func handleDirectory(at url: URL, handler: @escaping (Result<Data, Error>) -> Void) {
     /// Process any image file from within the folder
     if let contents = try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil),
-       let imageURL = contents.first(where: {
-         UTType(filenameExtension: $0.pathExtension, conformingTo: .image) != nil
+       let imageURL = contents.first(where: { file in
+         let type = UTType(filenameExtension: file.pathExtension)
+         return type?.isSubtype(of: .image) == true
        }),
        let imageData = try? Data(contentsOf: imageURL) {
       handler(.success(imageData))


### PR DESCRIPTION
## Bugfix

- The app keeps getting killed by iOS due to high memory usage, this is because the current logic to load a folder's artwork was letting any file pass in like it was an image (like the mp3s or the m4bs), so it would load up the entire file in memory for each folder that didn't have the artwork cached, leading to the spike in memory usage

## Related tasks

#1118 

## Approach

- Fix validation when checking for an internal image file