### PR TITLE
Add support for privacy manifests

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 		63C6C3122B54F16800FFE0D8 /* LibraryItemSyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6C30F2B54F14800FFE0D8 /* LibraryItemSyncOperation.swift */; };
 		63C6C3192B5E102200FFE0D8 /* SyncTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6C3172B5E0FE700FFE0D8 /* SyncTask.swift */; };
 		63C6C31A2B5E102200FFE0D8 /* SyncTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6C3172B5E0FE700FFE0D8 /* SyncTask.swift */; };
+		63F1C7892BB91260006B164C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 63F1C7882BB91259006B164C /* PrivacyInfo.xcprivacy */; };
+		63F1C78B2BB91E21006B164C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 63F1C78A2BB91E1B006B164C /* PrivacyInfo.xcprivacy */; };
 		63F828572AED56FA00B5CE0C /* CornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F828562AED56FA00B5CE0C /* CornerView.swift */; };
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
@@ -1127,6 +1129,8 @@
 		63C6C30B2B538B7A00FFE0D8 /* SyncTasksStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTasksStorage.swift; sourceTree = "<group>"; };
 		63C6C30F2B54F14800FFE0D8 /* LibraryItemSyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryItemSyncOperation.swift; sourceTree = "<group>"; };
 		63C6C3172B5E0FE700FFE0D8 /* SyncTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTask.swift; sourceTree = "<group>"; };
+		63F1C7882BB91259006B164C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		63F1C78A2BB91E1B006B164C /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		63F828562AED56FA00B5CE0C /* CornerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerView.swift; sourceTree = "<group>"; };
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
@@ -1587,6 +1591,7 @@
 				416A29CE256A442200605395 /* BookPlayerWidgets.entitlements */,
 				416A29AB2569658300605395 /* Assets.xcassets */,
 				416A29AD2569658300605395 /* Info.plist */,
+				63F1C78A2BB91E1B006B164C /* PrivacyInfo.xcprivacy */,
 				63005A442AE7FD8100A4CA2C /* Watch-Info.plist */,
 			);
 			path = BookPlayerWidgets;
@@ -1657,6 +1662,7 @@
 				419196341D47CC4E007A3AF3 /* BookPlayer.entitlements */,
 				416BF8A526537A4C00239166 /* BookPlayer-NoCarPlay.entitlements */,
 				418B6D091D2707F800F974FB /* Info.plist */,
+				63F1C7882BB91259006B164C /* PrivacyInfo.xcprivacy */,
 				41640A3624416EE8004FB97B /* Intents.intentdefinition */,
 				C37A6872209F0F830063AEAC /* Credits.html */,
 				4160A09423F2DE130039166B /* Localizable.stringsdict */,
@@ -3010,6 +3016,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63F1C78B2BB91E21006B164C /* PrivacyInfo.xcprivacy in Resources */,
 				416A29AC2569658300605395 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3048,6 +3055,7 @@
 				4111FBEB25EDEFDD0096954F /* forest-green@2x.png in Resources */,
 				41AD3D9E221C750E00DC41E1 /* Icons.json in Resources */,
 				41E79BF526C6255C00EA9FFF /* PlayPauseIconView.xib in Resources */,
+				63F1C7892BB91260006B164C /* PrivacyInfo.xcprivacy in Resources */,
 				41E562ED2239531E00C06BC9 /* neon-ipad@3x.png in Resources */,
 				41E562E222394FB900C06BC9 /* songs@3x.png in Resources */,
 				C30B66AE20E2D8CF00FC0030 /* ArtworkControl.xib in Resources */,

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -100,7 +100,7 @@ class DataInitializerCoordinator: BPLogger {
   private func getLibraryFiles() -> [URL] {
     let enumerator = FileManager.default.enumerator(
       at: DataManager.getProcessedFolderURL(),
-      includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+      includingPropertiesForKeys: [.isDirectoryKey],
       options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants], errorHandler: { (url, error) -> Bool in
         print("directoryEnumerator error at \(url): ", error)
         return true

--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -121,7 +121,7 @@ public class ImportOperation: Operation {
 
       let enumerator = FileManager.default.enumerator(
         at: tempDirectoryURL,
-        includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+        includingPropertiesForKeys: [.isDirectoryKey],
         options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants], errorHandler: { (url, error) -> Bool in
           print("directoryEnumerator error at \(url): ", error)
           return true

--- a/BookPlayer/PrivacyInfo.xcprivacy
+++ b/BookPlayer/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/BookPlayerWidgets/PrivacyInfo.xcprivacy
+++ b/BookPlayerWidgets/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Shared/Artwork/AVAudioAssetImageDataProvider.swift
+++ b/Shared/Artwork/AVAudioAssetImageDataProvider.swift
@@ -120,7 +120,7 @@ public struct AVAudioAssetImageDataProvider: ImageDataProvider {
       Task {
         let enumerator = FileManager.default.enumerator(
           at: self.fileURL,
-          includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+          includingPropertiesForKeys: [.isDirectoryKey],
           options: [.skipsHiddenFiles], errorHandler: { (url, error) -> Bool in
             print("directoryEnumerator error at \(url): ", error)
             return true

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -540,7 +540,7 @@ extension LibraryService {
   private func handleDirectory(_ folderURL: URL) {
     let enumerator = FileManager.default.enumerator(
       at: folderURL,
-      includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+      includingPropertiesForKeys: [.isDirectoryKey],
       options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants], errorHandler: { (url, error) -> Bool in
         print("directoryEnumerator error at \(url): ", error)
         return true


### PR DESCRIPTION
## Purpose

- Apple requires we adopt the privacy manifests introduced on WWDC 23 starting next month

## Approach

- Add privacy info files to describe the reason related to UserDefaults usage, and disk space information access