### PR TITLE
Fix sleep timer option: End of Chapter when finishing a file

### DIFF
--- a/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerWidgetsPhone.xcscheme
+++ b/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerWidgetsPhone.xcscheme
@@ -90,6 +90,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -438,7 +438,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
     if currentItem.isBoundBook {
       currentTime += currentItem.currentChapter.start
     } else if currentTime >= currentItem.currentChapter.end || currentTime < currentItem.currentChapter.start,
-              let newChapter = currentItem.getChapter(at: currentTime) {
+              let newChapter = currentItem.getChapter(at: currentTime),
+              newChapter != currentItem.currentChapter {
+      /// Avoid setting the same chapter, as it would publish an update event
       currentItem.currentChapter = newChapter
     }
 


### PR DESCRIPTION
## Bugfix

- When a book finishes (or a chapter for mp3 volumes), the update timer function is setting the same chapter, generating an extra event that disables the timer prior to the finished callback where we check the sleep timer status

## Approach

- Check if we're trying to set the same final chapter in the player manager

## Things to be aware of / Things to focus on

- This is caused due to the precision of the floating number for the duration, since we store just 5 or 6 digits, and at times the final time of a book/file could be (slightly) greater at the decimal points than what we store
