### PR TITLE
Fix crash when importing files after some delay 

### DIFF
--- a/BookPlayer/Coordinators/LibraryListCoordinator.swift
+++ b/BookPlayer/Coordinators/LibraryListCoordinator.swift
@@ -203,8 +203,17 @@ class LibraryListCoordinator: ItemListCoordinator, UINavigationControllerDelegat
   }
 
   func processFiles(urls: [URL]) {
+    let temporaryDirectoryPath = FileManager.default.temporaryDirectory.absoluteString
+    let documentsFolder = DataManager.getDocumentsFolderURL()
+
     for url in urls {
-      self.importManager.process(url)
+      /// At some point (iOS 17?), the OS stopped sending the picked files to the Documents/Inbox folder, instead
+      /// it's now sent to a temp folder that can't be relied on to keep the file existing until the import is finished
+      if url.absoluteString.contains(temporaryDirectoryPath) {
+        try! FileManager.default.moveItem(at: url, to: documentsFolder)
+      } else {
+        importManager.process(url)
+      }
     }
   }
 

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -992,8 +992,20 @@ class ItemListViewModel: ViewModelProtocol {
 // MARK: - Import related functions
 extension ItemListViewModel {
   func handleNewFiles(_ urls: [URL]) {
+    let temporaryDirectoryPath = FileManager.default.temporaryDirectory.absoluteString
+    let documentsFolder = DataManager.getDocumentsFolderURL()
+
     for url in urls {
-      importManager.process(url)
+      /// At some point (iOS 17?), the OS stopped sending the picked files to the Documents/Inbox folder, instead
+      /// it's now sent to a temp folder that can't be relied on to keep the file existing until the import is finished
+      if url.absoluteString.contains(temporaryDirectoryPath) {
+        let destinationURL = documentsFolder.appendingPathComponent(url.lastPathComponent)
+        if !FileManager.default.fileExists(atPath: destinationURL.path) {
+          try! FileManager.default.copyItem(at: url, to: destinationURL)
+        }
+      } else {
+        importManager.process(url)
+      }
     }
   }
 

--- a/BookPlayer/PrivacyInfo.xcprivacy
+++ b/BookPlayer/PrivacyInfo.xcprivacy
@@ -5,6 +5,14 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>


### PR DESCRIPTION
## Bugfix

- iOS changed at some point, and it now puts the selected files into a temp directory, which is very short lived, and will crash the app when trying to access those files

## Related tasks

#1127 

## Approach

- Check if the incoming files are inside a temp folder, if so, move them to the Documents folder, so our file listener will pick them up and kickstart the same import process

## Things to be aware of / Things to focus on

- Looks like there will no longer be a system Inbox folder at the root of the Documents folder