### PR TITLE
Fix custom artwork being lost if the item is moved (for users with no account)

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -842,24 +842,28 @@ extension PlayerManager {
         loadAndRefreshURL(item: currentItem)
         canFetchRemoteURL = false
       } else {
+        /// Avoid showing any alert if playback is not queued, this could be from the initial app launch
+        /// where we preload the player with the last played item
+        if playbackQueued == true {
+          if let nsError = item.error as? NSError {
+            let errorDescription = """
+            \(nsError.localizedDescription)
+
+            Error Domain
+            \(nsError.domain)
+
+            Additional Info
+            \(nsError.userInfo)
+            """
+            showErrorAlert(title: "\("error_title".localized) \(nsError.code)", errorDescription)
+          } else {
+            showErrorAlert(title: "error_title".localized, item.error?.localizedDescription)
+          }
+        }
+
         playbackQueued = nil
         observeStatus = false
         playerItem = nil
-
-        if let nsError = item.error as? NSError {
-          let errorDescription = """
-          \(nsError.localizedDescription)
-
-          Error Domain
-          \(nsError.domain)
-          
-          Additional Info
-          \(nsError.userInfo)
-          """
-          showErrorAlert(title: "\("error_title".localized) \(nsError.code)", errorDescription)
-        } else {
-          showErrorAlert(title: "error_title".localized, item.error?.localizedDescription)
-        }
       }
     case .unknown:
       /// Do not handle .unknown states, as we're only interested in the success and failure states

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -845,7 +845,21 @@ extension PlayerManager {
         playbackQueued = nil
         observeStatus = false
         playerItem = nil
-        showErrorAlert(title: "\("error_title".localized) AVPlayerItem", item.error?.localizedDescription)
+
+        if let nsError = item.error as? NSError {
+          let errorDescription = """
+          \(nsError.localizedDescription)
+
+          Error Domain
+          \(nsError.domain)
+          
+          Additional Info
+          \(nsError.userInfo)
+          """
+          showErrorAlert(title: "\("error_title".localized) \(nsError.code)", errorDescription)
+        } else {
+          showErrorAlert(title: "error_title".localized, item.error?.localizedDescription)
+        }
       }
     case .unknown:
       /// Do not handle .unknown states, as we're only interested in the success and failure states

--- a/Shared/Artwork/AVAudioAssetImageDataProvider.swift
+++ b/Shared/Artwork/AVAudioAssetImageDataProvider.swift
@@ -155,7 +155,14 @@ public struct AVAudioAssetImageDataProvider: ImageDataProvider {
     }
 
     do {
-      return try await extractDataFrom(url: newURL)
+      /// Check if the folder item already has a cached artwork
+      let folderItemCacheKey = cacheKey.appending("/\(newURL.lastPathComponent)")
+      if ArtworkService.isCached(relativePath: folderItemCacheKey),
+         let imageData = try? Data(contentsOf: ArtworkService.getCachedImageURL(for: folderItemCacheKey)) {
+        return imageData
+      } else {
+        return try await extractDataFrom(url: newURL)
+      }
     } catch {
       return try await processNextFolderItem(from: mutableUrls)
     }

--- a/Shared/Artwork/ArtworkService.swift
+++ b/Shared/Artwork/ArtworkService.swift
@@ -91,6 +91,7 @@ public class ArtworkService {
       else { return }
 
       Self.storeInCache(cachedImageData, for: finalRelativePath)
+      Self.removeCache(for: relativePath)
     }
   }
 

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -172,6 +172,8 @@ public final class LibraryService: LibraryServiceProtocol {
   }
 
   private func rebuildRelativePaths(for item: LibraryItem, parentFolder: String?) {
+    let originalPath = item.relativePath!
+
     switch item {
     case let book as Book:
       if let parentPath = parentFolder {
@@ -180,6 +182,8 @@ public final class LibraryService: LibraryServiceProtocol {
       } else {
         book.relativePath = book.originalFileName
       }
+
+      ArtworkService.moveCachedImage(from: originalPath, to: book.relativePath)
     case let folder as Folder:
       /// Get contents before updating relative path
       let contents = fetchRawContents(
@@ -196,6 +200,8 @@ public final class LibraryService: LibraryServiceProtocol {
       } else {
         folder.relativePath = folder.originalFileName
       }
+
+      ArtworkService.moveCachedImage(from: originalPath, to: folder.relativePath)
 
       for nestedItem in contents {
         rebuildRelativePaths(for: nestedItem, parentFolder: folder.relativePath)


### PR DESCRIPTION
## Bugfix

- After updating the artwork for an item (with no account), if it's moved into a folder (or to a different level), the custom artwork is lost, as the cache key is for the previous relative path

## Things to be aware of / Things to focus on

- This also includes a fix for an alert being shown on app launch when trying to load the last book and failing
- It also provides more error details in the alert