### PR TITLE
Fix sticky sleep timer persisting across app launches

### DIFF
--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -38,6 +38,7 @@ public enum Constants {
     public static let storageFilesSortOrder = "userSettingsStorageFilesSortOrder"
     public static let customSleepTimerDuration = "userSettingsCustomSleepTimerDuration"
     public static let autoTimerEnabled = "userSettingsAutoTimerEnabled"
+    public static let lastEnabledTimer = "userSettingsLastEnabledTimer"
 
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"


### PR DESCRIPTION
## Bugfix

- If the app was killed in the background, the last active sleep timer wouldn't load on the next launch, breaking sticky timer functionality

## Approach

- User UserDefaults to store the last active timer, and set it when initializing the SleepTimer object
