### PR TITLE
Add support for OverDrive chapter markers

### DIFF
--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -284,4 +284,24 @@ public class TimeParser {
 
     return (Double(Int(time * multiplier)) / multiplier)
   }
+
+  /// Get duration in seconds from a string with the format HH:mm:ss or mm:ss
+  public class func getDuration(from formattedTime: String) -> Double {
+    let components = formattedTime.split(separator: ":")
+
+    let hours: Double
+    let minutes: Double
+    let seconds: Double
+    if components.count == 3 {
+      hours = Double(String(components[0])) ?? 0
+      minutes = Double(String(components[1])) ?? 0
+      seconds = Double(String(components[2])) ?? 0
+    } else {
+      hours = 0
+      minutes = Double(String(components[0])) ?? 0
+      seconds = Double(String(components[1])) ?? 0
+    }
+
+    return (hours * 3600) + (minutes * 60) + seconds
+  }
 }


### PR DESCRIPTION
## Purpose

- Overdrive files come with the markers in the ID3 tag TXXX in the following format

```xml
<Markers>
  <Marker>
    <Time>00:12</Time>
    <Name>Chapter I</Name>
  </Marker>
  <Marker>
    <Time>00:22</Time>
    <Name>Chapter II</Name>
  </Marker>
</Markers>
```

## Approach

- If there's not regular chapters, look into the TXXX tag if it's an mp3, and parse the Overdraft format

## Things to be aware of / Things to focus on

- The time included in the tags is the start time of the chapter, the duration that is usually provided we have to calculate ourselves