### PR TITLE
Fix autoplay for volumes with artwork files

### DIFF
--- a/BookPlayerTests/StorageViewModelTests.swift
+++ b/BookPlayerTests/StorageViewModelTests.swift
@@ -46,6 +46,9 @@ final class StorageViewModelMissingFileTests: XCTestCase {
   }
 
   func testSetup(with filename: String) {
+    /// Avoid making the second onboarding network call
+    AppDelegate.shared?.accountService = AccountServiceMock(account: nil)
+
     let bookContents = "bookcontents".data(using: .utf8)!
 
     let documentsURL = DataManager.getDocumentsFolderURL()
@@ -77,7 +80,7 @@ final class StorageViewModelMissingFileTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Items load expectation")
     expectation.isInverted = true
-    wait(for: [expectation], timeout: 5.0)
+    wait(for: [expectation], timeout: 3.0)
 
     let loadedItems: [StorageItem] = self.viewModel.publishedFiles
     XCTAssert(loadedItems.count == 1)
@@ -99,7 +102,7 @@ final class StorageViewModelMissingFileTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Items load expectation")
     expectation.isInverted = true
-    wait(for: [expectation], timeout: 5.0)
+    wait(for: [expectation], timeout: 3.0)
 
     let loadedItems: [StorageItem] = viewModel.publishedFiles
     XCTAssert(loadedItems.count == 1)
@@ -116,7 +119,7 @@ final class StorageViewModelMissingFileTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Items load expectation")
     expectation.isInverted = true
-    wait(for: [expectation], timeout: 5.0)
+    wait(for: [expectation], timeout: 3.0)
 
     guard let item = viewModel.publishedFiles.first else {
       return

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -18,20 +18,13 @@ public class DataManager {
   public static var loadingDataError: Error?
   private let coreDataStack: CoreDataStack
   private var pendingSaveContext: DispatchWorkItem?
-
-  public init(coreDataStack: CoreDataStack) {
-    self.coreDataStack = coreDataStack
-  }
-  // MARK: - Folder URLs
-
-  public class func getDocumentsFolderURL() -> URL {
+  private static var documentsFolderURL: URL = {
     return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-  }
+  }()
+  private static var processedFolderURL: URL = {
+    let documentsURL = documentsFolderURL
 
-  public class func getProcessedFolderURL() -> URL {
-    let documentsURL = self.getDocumentsFolderURL()
-
-    let processedFolderURL = documentsURL.appendingPathComponent(self.processedFolderName)
+    let processedFolderURL = documentsURL.appendingPathComponent(processedFolderName)
 
     if !FileManager.default.fileExists(atPath: processedFolderURL.path) {
       do {
@@ -41,6 +34,19 @@ public class DataManager {
       }
     }
 
+    return processedFolderURL
+  }()
+
+  public init(coreDataStack: CoreDataStack) {
+    self.coreDataStack = coreDataStack
+  }
+  // MARK: - Folder URLs
+
+  public class func getDocumentsFolderURL() -> URL {
+    return documentsFolderURL
+  }
+
+  public class func getProcessedFolderURL() -> URL {
     return processedFolderURL
   }
 

--- a/Shared/CoreData/DataManager.swift
+++ b/Shared/CoreData/DataManager.swift
@@ -21,7 +21,8 @@ public class DataManager {
   private static var documentsFolderURL: URL = {
     return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
   }()
-  private static var processedFolderURL: URL = {
+  /// Prefer using this instead of ``getProcessedFolderURL()``, as it's calculated just once
+  public static var processedFolderURL: URL = {
     let documentsURL = documentsFolderURL
 
     let processedFolderURL = documentsURL.appendingPathComponent(processedFolderName)
@@ -46,7 +47,18 @@ public class DataManager {
     return documentsFolderURL
   }
 
+  /// Keeping original implementation due to unit tests behaviors
   public class func getProcessedFolderURL() -> URL {
+    let processedFolderURL = documentsFolderURL.appendingPathComponent(processedFolderName)
+
+    if !FileManager.default.fileExists(atPath: processedFolderURL.path) {
+      do {
+        try FileManager.default.createDirectory(at: processedFolderURL, withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        fatalError("Couldn't create Processed folder")
+      }
+    }
+
     return processedFolderURL
   }
 

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -39,7 +39,7 @@ public struct SimpleLibraryItem: Hashable, Identifiable {
   }
 
   public var fileURL: URL {
-    return DataManager.getProcessedFolderURL().appendingPathComponent(relativePath)
+    return DataManager.processedFolderURL.appendingPathComponent(relativePath)
   }
 
   public static func == (lhs: SimpleLibraryItem, rhs: SimpleLibraryItem) -> Bool {

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -287,7 +287,7 @@ public final class PlaybackService: PlaybackServiceProtocol {
     }
 
     var currentDuration = 0.0
-    var index = 0
+    var index: Int16 = 0
 
     return items
       .compactMap({ book in
@@ -310,7 +310,7 @@ public final class PlaybackService: PlaybackServiceProtocol {
           duration: truncatedDuration,
           relativePath: book.relativePath,
           remoteURL: book.remoteURL,
-          index: Int16(index)
+          index: index
         )
 
         currentDuration = TimeParser.truncateTime(currentDuration + truncatedDuration)


### PR DESCRIPTION
## Bugfix

- Artwork files are being included as part of the playable item struct, this is causing playback and autoplay to get stuck when it tries to go to the next chapter, and the next one is the artwork

## Approach

- Filter out based on the file extension for each 'chapter' in the volume