### PR TITLE
Add support for dragging and dropping folders for importing

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -641,9 +641,17 @@ extension ItemListViewController: UIDropInteractionDelegate {
       }
     } else if #available(iOS 16.0, *) {
       /// Fallback in case it's a folder
-      _ = item.itemProvider.loadFileRepresentation(for: .folder) { [weak self] url, _, _ in
+      _ = item.itemProvider.loadFileRepresentation(for: .folder) { url, _, _ in
         guard let url else { return }
-        self?.viewModel.importData(from: url)
+
+        let destinationURL = DataManager.getDocumentsFolderURL()
+          .appendingPathComponent(url.lastPathComponent)
+
+        do {
+          try FileManager.default.moveItem(at: url, to: destinationURL)
+        } catch {
+          print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
+        }
       }
     }
   }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -1186,6 +1186,17 @@ extension ItemListViewModel {
       print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
     }
   }
+
+  func importData(from url: URL) {
+    let destinationURL = DataManager.getDocumentsFolderURL()
+      .appendingPathComponent(url.lastPathComponent)
+
+    do {
+      try FileManager.default.moveItem(at: url, to: destinationURL)
+    } catch {
+      print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
+    }
+  }
 }
 
 // MARK: - Network related handlers

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -1186,17 +1186,6 @@ extension ItemListViewModel {
       print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
     }
   }
-
-  func importData(from url: URL) {
-    let destinationURL = DataManager.getDocumentsFolderURL()
-      .appendingPathComponent(url.lastPathComponent)
-
-    do {
-      try FileManager.default.moveItem(at: url, to: destinationURL)
-    } catch {
-      print("Fail to move dropped file to the Documents directory: \(error.localizedDescription)")
-    }
-  }
 }
 
 // MARK: - Network related handlers

--- a/Shared/Services/Events/EventsService.swift
+++ b/Shared/Services/Events/EventsService.swift
@@ -21,7 +21,7 @@ public class EventsService: EventsServiceProtocol, BPLogger {
     self.provider = NetworkProvider(client: client)
   }
 
-  public func sendEvent(_ event: String, payload: [String : Any]) {
+  public func sendEvent(_ event: String, payload: [String: Any]) {
     Task {
       do {
         let _: Empty = try await provider.request(.sendEvent(event: event, payload: payload))

--- a/Shared/Services/Sync/Model/SyncableItem.swift
+++ b/Shared/Services/Sync/Model/SyncableItem.swift
@@ -73,7 +73,7 @@ extension SyncableItem: Decodable {
     self.duration = try container.decodeIfPresent(Double.self, forKey: .duration) ?? 0.0
     self.percentCompleted = try container.decodeIfPresent(Double.self, forKey: .percentCompleted) ?? 0.0
     self.isFinished = try container.decode(Bool.self, forKey: .isFinished)
-    self.orderRank = try container.decode(Int.self, forKey: .orderRank)
+    self.orderRank = try container.decodeIfPresent(Int.self, forKey: .orderRank) ?? 0
     self.lastPlayDateTimestamp = try container.decodeIfPresent(Double.self, forKey: .lastPlayDateTimestamp)
     self.type = try container.decode(SimpleItemType.self, forKey: .type)
   }


### PR DESCRIPTION
## Purpose

- Add support for dragging and dropping folders onto the app, before this, it would fail silently

## Approach

- Add fallback if the dropped items don't conform to `ImportableItem` to load the file representation

## Things to be aware of / Things to focus on

- Specially useful for the Mac Silicon app
- I included a default value of 0 when decoding the orderRank property in case it's nil, but this is also handled in the server
