### PR TITLE
Fix crash when importing missing backing files for existing books

### DIFF
--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -55,7 +55,9 @@ final class StorageViewModel: StorageViewModelProtocol {
 
   @Published var publishedFiles = [StorageItem]() {
     didSet {
-      self.showFixAllButton = self.publishedFiles.contains { $0.showWarning }
+      DispatchQueue.main.async {
+        self.showFixAllButton = self.publishedFiles.contains { $0.showWarning }
+      }
     }
   }
   @Published var showFixAllButton = false
@@ -402,7 +404,9 @@ final class StorageViewModel: StorageViewModelProtocol {
           ))
         }
       } else {
-        completionHandler()
+        await MainActor.run {
+          completionHandler()
+        }
       }
     }
   }


### PR DESCRIPTION
## Bugfix

- The app is crashing when trying to add back files that were removed for existing books in the library

## Approach

- Add the same logic to request access to iCloud docs before attempting to move or copy the file

## Things to be aware of / Things to focus on

- This also includes an update to fix the UI being updated on a background thread in the Storage management screen