### PR TITLE
Fix download from URL for Google Drive and Dropbox

### DIFF
--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -925,11 +925,13 @@ class ItemListViewModel: ViewModelProtocol {
           BPActionItem(
             title: "download_title".localized,
             inputHandler: { [weak self] url in
-              if let bookUrl = URL(string: url) {
-                self?.handleDownload(bookUrl)
-              } else {
+              do {
+                if let bookUrl = try self?.getDownloadURL(for: url) {
+                  self?.handleDownload(bookUrl)
+                }
+              } catch {
                 self?.sendEvent(.showAlert(
-                  content: BPAlertContent.errorAlert(message: String.localizedStringWithFormat("invalid_url_title".localized, url))
+                  content: BPAlertContent.errorAlert(message: error.localizedDescription)
                 ))
               }
             }
@@ -1310,6 +1312,51 @@ extension ItemListViewModel {
         message: "Code \(statusCode)\n\(HTTPURLResponse.localizedString(forStatusCode: statusCode))"
       )
     ))
+  }
+
+  func getDownloadURL(for givenString : String) throws -> URL {
+    guard
+      let givenUrl = URL(string: givenString),
+      let hostname = givenUrl.host
+    else {
+      throw String.localizedStringWithFormat("invalid_url_title".localized, givenString)
+    }
+    switch hostname {
+    case "drive.google.com" :
+      return getGoogleDriveURL(for: givenUrl)
+    case "dropbox.com", "www.dropbox.com":
+      return try getDropboxURL(for: givenUrl)
+    default:
+      return givenUrl
+    }
+  }
+
+  func getGoogleDriveURL(for url: URL) -> URL {
+    let pathComponents = url.pathComponents
+    guard
+      let index = pathComponents.firstIndex(of: "d"),
+      index + 1 < pathComponents.count ,
+      let newUrl = URL(string: "https://drive.google.com/uc?export=download&id=" + pathComponents[index + 1])
+    else {
+      return url
+    }
+    return newUrl;
+  }
+
+  func getDropboxURL (for url : URL) throws -> URL {
+    guard
+      var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    else {
+      throw String.localizedStringWithFormat("invalid_url_title".localized, url.absoluteString)
+    }
+    var queryItems = urlComponents.queryItems ?? []
+    if let index = queryItems.firstIndex(where: {$0.name == "dl"}) {
+      queryItems[index].value = "1"
+    } else {
+      queryItems.append(URLQueryItem(name: "dl", value: "1"))
+    }
+    urlComponents.queryItems = queryItems
+    return urlComponents.url ?? url
   }
 }
 


### PR DESCRIPTION
## Bugfix

For URLs to download books in Google Drive and Dropbox, the URL provided by the user needs to be fixed up before a download can be attempted.

Tested book download from Google Drive and Dropbox URLs for individual files and zip files.

## Related tasks

Fixes: #1077

## Things to be aware of

The fix is for Google Drive and Dropbox only; OneDrive download URLs are non-trivial.