### PR TITLE
Fix a crash on app launch due to a decimal infinity value

### DIFF
--- a/BookPlayer/Base.lproj/Main.storyboard
+++ b/BookPlayer/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="UvS-mV-Are">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23089" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="UvS-mV-Are">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23077"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -231,11 +231,11 @@
                                     <constraint firstItem="q8y-d7-HKX" firstAttribute="centerX" secondItem="ine-tP-Is6" secondAttribute="centerX" id="rm0-VQ-FCS"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L2f-M1-8fN" customClass="LoadingView" customModule="BookPlayer" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="20" width="375" height="65"/>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L2f-M1-8fN" customClass="LoadingView" customModule="BookPlayer" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="20" width="375" height="0.0"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="65" id="69u-wZ-9DI"/>
+                                    <constraint firstAttribute="height" id="69u-wZ-9DI"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RTy-ml-CPR" customClass="BulkControlsView" customModule="BookPlayer" customModuleProvider="target">
@@ -294,13 +294,13 @@
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -679,7 +679,7 @@ extension ItemListViewController {
   }
 
   func showLoadView(_ show: Bool, title: String? = nil, subtitle: String? = nil) {
-    guard self.isViewLoaded else {
+    guard self.isViewLoaded && self.view.window != nil else {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
         self?.showLoadView(show, title: title, subtitle: subtitle)
       }

--- a/Shared/Realm/Realm+BookPlayer.swift
+++ b/Shared/Realm/Realm+BookPlayer.swift
@@ -12,7 +12,22 @@ import RealmSwift
 extension Object {
   func toDictionaryPayload() -> [String: Any] {
     return objectSchema.properties.reduce(into: [:]) { dict, property in
-      dict[property.name] = self.value(forKeyPath: property.name)
+      var value = self.value(forKeyPath: property.name)
+
+      /// Sanitize infinite values
+      if let doubleValue = value as? Double,
+         !doubleValue.isFinite {
+        switch property.name {
+        case "speed", "lastPlayDateTimestamp":
+          value = nil
+        case "currentTime", "duration", "percentCompleted":
+          value = 0.0
+        default:
+          break
+        }
+      }
+
+      dict[property.name] = value
     }
   }
 }


### PR DESCRIPTION
## Bugfix

- The app is crashing when a stored sync task has a infinity value for one of the decimal properties

## Approach

- Sanitize values when they are mapped into a dictionary

## Things to be aware of / Things to focus on

- This also includes a fix to a warning regarding the library UITableView being forced to load before the view is put into the UIWindow hierarchy