### PR TITLE
Fix widgets not showing up

### DIFF
--- a/BookPlayerWidgets/BookPlayerWidgets.swift
+++ b/BookPlayerWidgets/BookPlayerWidgets.swift
@@ -37,7 +37,7 @@ struct BookPlayerBundle: WidgetBundle {
     LastPlayedWidget()
     RecentBooksWidget()
     TimeListenedWidget()
-    if #available(iOSApplicationExtension 16.0, *) {
+    if #available(iOSApplicationExtension 16.1, *) {
       SharedWidget()
       SharedIconWidget()
     }

--- a/BookPlayerWidgets/Shared/SharedIconWidget/SharedIconWidget.swift
+++ b/BookPlayerWidgets/Shared/SharedIconWidget/SharedIconWidget.swift
@@ -36,7 +36,7 @@ struct SharedIconWidgetTimelineProvider: TimelineProvider {
   typealias Entry = SharedIconWidgetEntry
 }
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct SharedIconWidget: Widget {
   let kind: String = Constants.Widgets.sharedIconWidget.rawValue
   #if os(watchOS)

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/CircularView.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/CircularView.swift
@@ -14,7 +14,7 @@ import BookPlayerWatchKit
 import BookPlayerKit
 #endif
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct CircularView: View {
   let title: String
   let fillFraction: Double

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/CornerView.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/CornerView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import WidgetKit
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct CornerView: View {
   let title: String
   let fillFraction: Double

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/RectangularView.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/RectangularView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import WidgetKit
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct RectangularView: View {
   let chapterTitle: String
   let bookTitle: String

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidget.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidget.swift
@@ -145,7 +145,7 @@ struct SharedWidgetTimelineProvider: TimelineProvider {
   }
 }
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct SharedWidget: Widget {
   let kind: String = Constants.Widgets.sharedNowPlayingWidget.rawValue
 

--- a/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidgetContainerView.swift
+++ b/BookPlayerWidgets/Shared/SharedNowPlayingWidget/SharedWidgetContainerView.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-@available(iOSApplicationExtension 16.0, watchOS 9.0, *)
+@available(iOSApplicationExtension 16.1, watchOS 9.0, *)
 struct SharedWidgetContainerView: View {
   let entry: SharedWidgetEntry
 


### PR DESCRIPTION
## Bugfix

- At some point, the available check on iOSApplicationExtension for 16.0 started throwing a warning, and testing now, it crashes (see screenshot). I thought that the widgets disappearing was just a quirk about the iOS 18 beta I was running, but just changing 16.0 to 16.1 made them appear again

<img width="375" alt="Screenshot 2024-09-10 at 11 20 04 PM" src="https://github.com/user-attachments/assets/d46c987d-da9c-4c83-885a-0b8ffa7c4ce5">