### PR TITLE
Fix bluetooth events for MacOS

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -214,7 +214,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
         return .commandFailed
       }
 
-      playerManager.play()
+      let wasPlaying = playerManager.isPlaying
+      playerManager.playPause()
+
+      if wasPlaying,
+        UIApplication.shared.applicationState == .background
+      {
+        self?.scheduleAppRefresh()
+      }
       return .success
     }
 


### PR DESCRIPTION
## Bugfix

- Bluetooth events from earphones only trigger the play command, never the pause command. This PR changes the play command to behave like the toggle play/pause command