### PR TITLE
Add loop option for books

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -319,3 +319,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "Rewind ${interval}" = "Rewind ${interval}";
 "settings_lock_orientation_title" = "Orientation Locked";
 "more_title" = "More";
+"repeat_turn_on_title" = "Turn on Repeat for this book";
+"repeat_turn_off_title" = "Turn off Repeat for this book";

--- a/BookPlayer/Coordinators/Coordinator.swift
+++ b/BookPlayer/Coordinators/Coordinator.swift
@@ -20,6 +20,10 @@ extension AlertPresenter where Self: Coordinator {
     flow.navigationController.showAlert(title, message: message, completion: completion)
   }
 
+  func showAlert(_ content: BPAlertContent) {
+    flow.navigationController.showAlert(content)
+  }
+
   func showLoader() {
     LoadingUtils.loadAndBlock(in: flow.navigationController)
   }

--- a/BookPlayer/Coordinators/DataInitializerCoordinator.swift
+++ b/BookPlayer/Coordinators/DataInitializerCoordinator.swift
@@ -74,17 +74,31 @@ class DataInitializerCoordinator: BPLogger {
           \(error.localizedDescription)
 
           Error Domain
-          \(error.domain)
+          \(error.domain) (\(error.code)
 
           Additional Info
           \(error.userInfo)
           """
-        alertPresenter.showAlert(
-          "error_title".localized,
-          message: errorDescription
-        ) {
-          fatalError("Unresolved error \(error.localizedDescription)")
-        }
+        alertPresenter.showAlert(BPAlertContent(
+          title: "error_title".localized,
+          message: errorDescription,
+          style: .alert,
+          actionItems: [
+            BPActionItem(
+              title: "ok_button".localized,
+              handler: {
+                fatalError("Unresolved error \(error.domain) (\(error.code)): \(error.localizedDescription)")
+              }
+            ),
+            .init(
+              title: "Reset and recover database",
+              style: .destructive,
+              handler: {
+                self.recoverLibraryFromFailedMigration()
+              }
+            )
+          ]
+        ))
       }
     }
   }

--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -238,6 +238,10 @@ extension MainCoordinator: AlertPresenter {
     navigationController.showAlert(title, message: message, completion: completion)
   }
 
+  func showAlert(_ content: BPAlertContent) {
+    navigationController.showAlert(content)
+  }
+
   func showLoader() {
     LoadingUtils.loadAndBlock(in: navigationController)
   }

--- a/BookPlayer/Library/ItemDetails Screen/ItemDetailsFormViewModel.swift
+++ b/BookPlayer/Library/ItemDetails Screen/ItemDetailsFormViewModel.swift
@@ -20,6 +20,8 @@ class ItemDetailsFormViewModel: ObservableObject {
   @Published var author: String
   /// Artwork image
   @Published var selectedImage: UIImage?
+  /// Progress of the current item
+  let progress: Double
   /// Original item title
   var titlePlaceholder: String
   /// Original item author
@@ -37,6 +39,7 @@ class ItemDetailsFormViewModel: ObservableObject {
     self.titlePlaceholder = item.title
     self.author = item.details
     self.authorPlaceholder = item.details
+    self.progress = item.progress
     self.originalFileName = item.originalFileName
     self.showAuthor = item.type == .book
     self.originalImageDataProvider = ArtworkService.getArtworkProvider(for: item.relativePath)

--- a/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
+++ b/BookPlayer/Library/ItemDetails Screen/Views/ItemDetailsForm.swift
@@ -66,9 +66,14 @@ struct ItemDetailsForm: View {
       Section {
         EmptyView()
       } footer: {
-        Text(viewModel.originalFileName)
-          .font(Font(Fonts.body))
-          .foregroundColor(themeViewModel.secondaryColor)
+        VStack(alignment: .leading) {
+          Text(viewModel.originalFileName)
+            .font(Font(Fonts.body))
+            .foregroundColor(themeViewModel.secondaryColor)
+          Text("\(Int(viewModel.progress * 100))%")
+            .font(Font(Fonts.body))
+            .foregroundColor(themeViewModel.secondaryColor)
+        }
       }
     }
     .onChange(of: viewModel.selectedImage, perform: { _ in

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -1372,7 +1372,11 @@ extension ItemListViewModel: AlertPresenter {
       )
     ))
   }
-  
+
+  func showAlert(_ content: BPAlertContent) {
+    sendEvent(.showAlert(content: content))
+  }
+
   func showLoader() {
     sendEvent(.showLoader(flag: true))
   }

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -604,6 +604,17 @@ extension PlayerViewController {
       )
     )
 
+    actionSheet.addAction(
+      UIAlertAction(
+        title: self.viewModel.isRepeatEnabled()
+          ? "repeat_turn_off_title".localized : "repeat_turn_on_title".localized,
+        style: .default,
+        handler: { [weak self] _ in
+          self?.viewModel.handleEnableRepeat()
+        }
+      )
+    )
+
     actionSheet.addAction(UIAlertAction(title: "cancel_button".localized, style: .cancel, handler: nil))
 
     if let popoverPresentationController = actionSheet.popoverPresentationController {

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -128,7 +128,8 @@ class PlayerViewModel: ViewModelProtocol {
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 
     if let currentChapter = self.playerManager.currentItem?.currentChapter,
-       let previousChapter = self.playerManager.currentItem?.previousChapter(before: currentChapter) {
+      let previousChapter = self.playerManager.currentItem?.previousChapter(before: currentChapter)
+    {
       self.playerManager.jumpToChapter(previousChapter)
       sendEvent(.updateProgress(getCurrentProgressState()))
     } else {
@@ -140,7 +141,8 @@ class PlayerViewModel: ViewModelProtocol {
     UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 
     if let currentChapter = self.playerManager.currentItem?.currentChapter,
-       let nextChapter = self.playerManager.currentItem?.nextChapter(after: currentChapter) {
+      let nextChapter = self.playerManager.currentItem?.nextChapter(after: currentChapter)
+    {
       self.playerManager.jumpToChapter(nextChapter)
       sendEvent(.updateProgress(getCurrentProgressState()))
     } else {
@@ -152,26 +154,33 @@ class PlayerViewModel: ViewModelProtocol {
     return self.playerManager.currentItem?.isFinished ?? false
   }
 
+  func isRepeatEnabled() -> Bool {
+    guard let currentItem = self.playerManager.currentItem else { return false }
+    return UserDefaults.standard.bool(
+      forKey: currentItem.filename + Constants.UserDefaults.repeatEnabledSuffix
+    )
+  }
+
   func getBookCurrentTime() -> TimeInterval {
     return self.playerManager.currentItem?.currentTimeInContext(self.prefersChapterContext) ?? 0
   }
 
   func getCurrentTimeVoiceOverPrefix() -> String {
     return self.prefersChapterContext
-    ? "voiceover_chapter_time_title".localized
-    : "book_time_current_title".localized
+      ? "voiceover_chapter_time_title".localized
+      : "book_time_current_title".localized
   }
 
   func getMaxTimeVoiceOverPrefix() -> String {
     if self.prefersChapterContext {
       return self.prefersRemainingTime
-      ? "chapter_time_remaining_title".localized
-      : "chapter_duration_title".localized
+        ? "chapter_time_remaining_title".localized
+        : "chapter_duration_title".localized
     }
 
     return self.prefersRemainingTime
-    ? "book_time_remaining_title".localized
-    : "book_duration_title".localized
+      ? "book_time_remaining_title".localized
+      : "book_duration_title".localized
   }
 
   func handlePlayPauseAction() {
@@ -202,6 +211,14 @@ class PlayerViewModel: ViewModelProtocol {
     self.playerManager.markAsCompleted(!self.isBookFinished())
   }
 
+  func handleEnableRepeat() {
+    guard let filename = self.playerManager.currentItem?.filename else { return }
+    UserDefaults.standard.set(
+      !isRepeatEnabled(),
+      forKey: filename + Constants.UserDefaults.repeatEnabledSuffix
+    )
+  }
+
   func processToggleMaxTime() -> ProgressObject {
     self.prefersRemainingTime = !self.prefersRemainingTime
     sharedDefaults.set(self.prefersRemainingTime, forKey: Constants.UserDefaults.remainingTimeEnabled)
@@ -225,9 +242,14 @@ class PlayerViewModel: ViewModelProtocol {
     let currentItem = item ?? self.playerManager.currentItem
 
     if self.prefersChapterContext,
-       let currentItem = currentItem,
-       let currentChapter = currentItem.currentChapter {
-      progress = String.localizedStringWithFormat("player_chapter_description".localized, currentChapter.index, currentItem.chapters.count)
+      let currentItem = currentItem,
+      let currentChapter = currentItem.currentChapter
+    {
+      progress = String.localizedStringWithFormat(
+        "player_chapter_description".localized,
+        currentChapter.index,
+        currentItem.chapters.count
+      )
       sliderValue = Float((currentItem.currentTime - currentChapter.start) / currentChapter.duration)
     } else {
       progress = "\(Int(round((currentItem?.progressPercentage ?? 0) * 100)))%"
@@ -237,12 +259,14 @@ class PlayerViewModel: ViewModelProtocol {
     // Update local chapter
     self.chapterBeforeSliderValueChange = currentItem?.currentChapter
 
-    let prevChapterImageName = self.hasChapter(before: currentItem?.currentChapter)
-    ? "chevron.left"
-    : "chevron.left.2"
-    let nextChapterImageName = self.hasChapter(after: currentItem?.currentChapter)
-    ? "chevron.right"
-    : "chevron.right.2"
+    let prevChapterImageName =
+      self.hasChapter(before: currentItem?.currentChapter)
+      ? "chevron.left"
+      : "chevron.left.2"
+    let nextChapterImageName =
+      self.hasChapter(after: currentItem?.currentChapter)
+      ? "chevron.right"
+      : "chevron.right.2"
 
     return ProgressObject(
       currentTime: currentTime,
@@ -252,8 +276,8 @@ class PlayerViewModel: ViewModelProtocol {
       prevChapterImageName: prevChapterImageName,
       nextChapterImageName: nextChapterImageName,
       chapterTitle: currentItem?.currentChapter?.title
-      ?? currentItem?.title
-      ?? ""
+        ?? currentItem?.title
+        ?? ""
     )
   }
 
@@ -273,7 +297,8 @@ class PlayerViewModel: ViewModelProtocol {
     var nextChapterImageName = "chevron.right.2"
     var newCurrentTime: TimeInterval
     if self.prefersChapterContext,
-       let currentChapter = self.chapterBeforeSliderValueChange {
+      let currentChapter = self.chapterBeforeSliderValueChange
+    {
       newCurrentTime = TimeInterval(value) * currentChapter.duration
       chapterTitle = currentChapter.title
 
@@ -317,8 +342,8 @@ class PlayerViewModel: ViewModelProtocol {
       prevChapterImageName: prevChapterImageName,
       nextChapterImageName: nextChapterImageName,
       chapterTitle: chapterTitle ?? self.chapterBeforeSliderValueChange?.title
-      ?? self.playerManager.currentItem?.title
-      ?? ""
+        ?? self.playerManager.currentItem?.title
+        ?? ""
     )
   }
 
@@ -334,7 +359,8 @@ class PlayerViewModel: ViewModelProtocol {
     var newTimeToDisplay = TimeInterval(value) * (self.playerManager.currentItem?.duration ?? 0)
 
     if self.prefersChapterContext,
-       let currentChapter = self.chapterBeforeSliderValueChange {
+      let currentChapter = self.chapterBeforeSliderValueChange
+    {
       newTimeToDisplay = currentChapter.start + TimeInterval(value) * currentChapter.duration
     }
 
@@ -348,9 +374,9 @@ class PlayerViewModel: ViewModelProtocol {
     // request for review if app is active
     guard UIApplication.shared.applicationState == .active else { return }
 
-#if RELEASE
-    AppDelegate.shared?.requestReview()
-#endif
+    #if RELEASE
+      AppDelegate.shared?.requestReview()
+    #endif
 
     UserDefaults.standard.set(false, forKey: "ask_review")
   }
@@ -417,14 +443,16 @@ class PlayerViewModel: ViewModelProtocol {
 
     actions.append(BPActionItem.cancelAction)
 
-    sendEvent(.sleepTimerAlert(
-      content: BPAlertContent(
-        title: nil,
-        message: getSleepTimerAlertMessage(),
-        style: .actionSheet,
-        actionItems: actions
+    sendEvent(
+      .sleepTimerAlert(
+        content: BPAlertContent(
+          title: nil,
+          message: getSleepTimerAlertMessage(),
+          style: .actionSheet,
+          actionItems: actions
+        )
       )
-    ))
+    )
   }
 
   func getSleepTimerAlertMessage() -> String {
@@ -514,23 +542,38 @@ extension PlayerViewModel {
   func showBookmarkSuccessAlert(vc: UIViewController, bookmark: SimpleBookmark, existed: Bool) {
     let formattedTime = TimeParser.formatTime(bookmark.time)
 
-    let titleKey = existed
-    ? "bookmark_exists_title"
-    : "bookmark_created_title"
+    let titleKey =
+      existed
+      ? "bookmark_exists_title"
+      : "bookmark_created_title"
 
-    let alert = UIAlertController(title: String.localizedStringWithFormat(titleKey.localized, formattedTime),
-                                  message: nil,
-                                  preferredStyle: .alert)
+    let alert = UIAlertController(
+      title: String.localizedStringWithFormat(titleKey.localized, formattedTime),
+      message: nil,
+      preferredStyle: .alert
+    )
 
     if !existed {
-      alert.addAction(UIAlertAction(title: "bookmark_note_action_title".localized, style: .default, handler: { [weak self] _ in
-        self?.showBookmarkNoteAlert(vc: vc, bookmark: bookmark)
-      }))
+      alert.addAction(
+        UIAlertAction(
+          title: "bookmark_note_action_title".localized,
+          style: .default,
+          handler: { [weak self] _ in
+            self?.showBookmarkNoteAlert(vc: vc, bookmark: bookmark)
+          }
+        )
+      )
     }
 
-    alert.addAction(UIAlertAction(title: "bookmarks_see_title".localized, style: .default, handler: { [weak self] _ in
-      self?.showBookmarks()
-    }))
+    alert.addAction(
+      UIAlertAction(
+        title: "bookmarks_see_title".localized,
+        style: .default,
+        handler: { [weak self] _ in
+          self?.showBookmarks()
+        }
+      )
+    )
 
     alert.addAction(UIAlertAction(title: "ok_button".localized, style: .cancel, handler: nil))
 
@@ -538,27 +581,35 @@ extension PlayerViewModel {
   }
 
   func showBookmarkNoteAlert(vc: UIViewController, bookmark: SimpleBookmark) {
-    let alert = UIAlertController(title: "bookmark_note_action_title".localized,
-                                  message: nil,
-                                  preferredStyle: .alert)
+    let alert = UIAlertController(
+      title: "bookmark_note_action_title".localized,
+      message: nil,
+      preferredStyle: .alert
+    )
 
     alert.addTextField(configurationHandler: { textfield in
       textfield.text = ""
     })
 
     alert.addAction(UIAlertAction(title: "cancel_button".localized, style: .cancel, handler: nil))
-    alert.addAction(UIAlertAction(title: "ok_button".localized, style: .default, handler: { [weak self] _ in
-      guard let note = alert.textFields?.first?.text else {
-        return
-      }
+    alert.addAction(
+      UIAlertAction(
+        title: "ok_button".localized,
+        style: .default,
+        handler: { [weak self] _ in
+          guard let note = alert.textFields?.first?.text else {
+            return
+          }
 
-      self?.libraryService.addNote(note, bookmark: bookmark)
-      self?.syncService.scheduleSetBookmark(
-        relativePath: bookmark.relativePath,
-        time: bookmark.time,
-        note: note
+          self?.libraryService.addNote(note, bookmark: bookmark)
+          self?.syncService.scheduleSetBookmark(
+            relativePath: bookmark.relativePath,
+            time: bookmark.time,
+            note: note
+          )
+        }
       )
-    }))
+    )
 
     vc.present(alert, animated: true, completion: nil)
   }

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -1100,13 +1100,22 @@ extension PlayerManager {
     let endOfChapterActive = SleepTimer.shared.state == .endOfChapter
 
     if currentItem.chapters.last == currentItem.currentChapter {
-      self.libraryService.setLibraryLastBook(with: nil)
+      if UserDefaults.standard.bool(
+        forKey: currentItem.filename + Constants.UserDefaults.repeatEnabledSuffix
+      ) {
+        updatePlaybackTime(item: currentItem, time: 0)
+        let firstChapter = currentItem.chapters.first!
+        currentItem.currentChapter = firstChapter
+        loadChapterMetadata(firstChapter, autoplay: !endOfChapterActive)
+      } else {
+        self.libraryService.setLibraryLastBook(with: nil)
 
-      self.markAsCompleted(true)
+        self.markAsCompleted(true)
 
-      self.playNextItem(autoPlayed: true, shouldAutoplay: !endOfChapterActive)
+        self.playNextItem(autoPlayed: true, shouldAutoplay: !endOfChapterActive)
 
-      NotificationCenter.default.post(name: .bookEnd, object: nil)
+        NotificationCenter.default.post(name: .bookEnd, object: nil)
+      }
     } else if currentItem.isBoundBook {
       updatePlaybackTime(item: currentItem, time: currentItem.currentTime)
       /// Load next chapter

--- a/BookPlayer/Services/CarPlayManager.swift
+++ b/BookPlayer/Services/CarPlayManager.swift
@@ -565,6 +565,33 @@ extension CarPlayManager: AlertPresenter {
 
     self.interfaceController?.presentTemplate(alertTemplate, animated: true, completion: nil)
   }
+
+  public func showAlert(_ content: BPAlertContent) {
+    let actions = content.actionItems.map({ item in
+      return CPAlertAction(
+        title: item.title,
+        style: .default,
+        handler: { _ in
+          self.interfaceController?.dismissTemplate(animated: true, completion: nil)
+          item.handler()
+        }
+      )
+    })
+
+    var completeMessage = ""
+
+    if let title = content.title {
+      completeMessage += title
+    }
+
+    if let message = content.message {
+      completeMessage += ": \(message)"
+    }
+
+    let alertTemplate = CPAlertTemplate(titleVariants: [completeMessage], actions: actions)
+
+    self.interfaceController?.presentTemplate(alertTemplate, animated: true, completion: nil)
+  }
 }
 
 extension CarPlayManager: CPTabBarTemplateDelegate {

--- a/BookPlayer/Utils/AlertPresenter.swift
+++ b/BookPlayer/Utils/AlertPresenter.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol AlertPresenter: AnyObject {
   func showAlert(_ title: String?, message: String?, completion: (() -> Void)?)
+  func showAlert(_ content: BPAlertContent)
   func showLoader()
   func stopLoader()
 }
@@ -19,6 +20,8 @@ protocol AlertPresenter: AnyObject {
 /// so we don't need to pass an `AlertPresenter` as a parameter
 class VoidAlertPresenter: AlertPresenter {
   func showAlert(_ title: String?, message: String?, completion: (() -> Void)?) {}
+
+  func showAlert(_ content: BPAlertContent) {}
 
   func showLoader() {}
 

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "ترجيع ${interval}";
 "settings_lock_orientation_title" = "الاتجاه مغلق";
 "more_title" = "أكثر";
+"repeat_turn_on_title" = "قم بتشغيل التكرار لهذا الكتاب";
+"repeat_turn_off_title" = "إيقاف تكرار هذا الكتاب";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Přetočit ${interval}";
 "settings_lock_orientation_title" = "Orientace uzamčena";
 "more_title" = "Více";
+"repeat_turn_on_title" = "Zapněte opakování pro tuto knihu";
+"repeat_turn_off_title" = "Vypnout opakování pro tuto knihu";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Spol ${interval} tilbage";
 "settings_lock_orientation_title" = "Orientering låst";
 "more_title" = "Mere";
+"repeat_turn_on_title" = "Slå Gentag til for denne bog";
+"repeat_turn_off_title" = "Slå Gentag fra for denne bog";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Zurückspulen ${interval}";
 "settings_lock_orientation_title" = "Ausrichtung gesperrt";
 "more_title" = "Mehr";
+"repeat_turn_on_title" = "Aktivieren Sie die Option „Wiederholen“ für dieses Buch";
+"repeat_turn_off_title" = "Deaktivieren Sie „Wiederholen“ für dieses Buch";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -185,7 +185,7 @@
 "storage_duplicate_item_description" = "Το επιλεγμένο αρχείο ήταν διπλότυπο, το υπάρχον αρχείο βρίσκεται στη διεύθυνση: %@";
 "chapters_previous_title" = "Προηγούμενο Κεφάλαιο";
 "chapters_next_title" = "Επόμενο κεφάλαιο";
-"book_time_current_title" = "Τρέχουσα ώρα κράτησης: %@";
+"book_time_current_title" = "Τρέχουσα ώρα βιβλίου: %@";
 "storage_fix_files_description" = "Ο σύνδεσμος μεταξύ των αρχείων και των στοιχείων του ψηφιακού βιβλίου λείπει, εάν δεν μπορεί να βρεθεί το αντίστοιχο στοιχείο για κάθε αρχείο, θα δημιουργηθεί ένα νέο";
 "storage_fix_all_title" = "Διορθώστε όλα";
 "settings_backup_title" = "Αντίγραφα ασφαλείας iCloud";
@@ -318,6 +318,6 @@
 "intent_custom_skiprewind_title" = "Πίσω με μεσοδιάστημα";
 "Rewind ${interval}" = "Επαναφορά ${interval}";
 "settings_lock_orientation_title" = "Ο προσανατολισμός είναι κλειδωμένος";
-"more_title" = "Περισσότερο";
+"more_title" = "Περισσότερα";
 "repeat_turn_on_title" = "Ενεργοποιήστε το Repeat για αυτό το βιβλίο";
 "repeat_turn_off_title" = "Απενεργοποιήστε το Repeat για αυτό το βιβλίο";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Επαναφορά ${interval}";
 "settings_lock_orientation_title" = "Ο προσανατολισμός είναι κλειδωμένος";
 "more_title" = "Περισσότερο";
+"repeat_turn_on_title" = "Ενεργοποιήστε το Repeat για αυτό το βιβλίο";
+"repeat_turn_off_title" = "Απενεργοποιήστε το Repeat για αυτό το βιβλίο";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -319,3 +319,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "Rewind ${interval}" = "Rewind ${interval}";
 "settings_lock_orientation_title" = "Orientation Locked";
 "more_title" = "More";
+"repeat_turn_on_title" = "Turn on Repeat for this book";
+"repeat_turn_off_title" = "Turn off Repeat for this book";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Rebobinar ${interval}";
 "settings_lock_orientation_title" = "Orientación Bloqueada";
 "more_title" = "Más";
+"repeat_turn_on_title" = "Activar repetición para este libro";
+"repeat_turn_off_title" = "Desactivar la repetición para este libro";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Kelaa taaksepäin ${interval}";
 "settings_lock_orientation_title" = "Suunta lukittu";
 "more_title" = "Lisää";
+"repeat_turn_on_title" = "Ota Toista käyttöön tälle kirjalle";
+"repeat_turn_off_title" = "Poista Toista käytöstä tästä kirjasta";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Rembobiner ${interval}";
 "settings_lock_orientation_title" = "Orientation verrouillée";
 "more_title" = "Plus";
+"repeat_turn_on_title" = "Activer la répétition pour ce livre";
+"repeat_turn_off_title" = "Désactiver la répétition pour ce livre";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Visszatekerés ${interval}";
 "settings_lock_orientation_title" = "Tájolás zárolva";
 "more_title" = "Több";
+"repeat_turn_on_title" = "Kapcsolja be az Ismétlés funkciót ennél a könyvnél";
+"repeat_turn_off_title" = "Kapcsolja ki az Ismétlés funkciót ennél a könyvnél";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Riavvolgi ${interval}";
 "settings_lock_orientation_title" = "Orientamento bloccato";
 "more_title" = "Di più";
+"repeat_turn_on_title" = "Attiva Ripeti per questo libro";
+"repeat_turn_off_title" = "Disattiva Ripeti per questo libro";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -319,3 +319,5 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "Rewind ${interval}" = "Spol tilbake ${interval}";
 "settings_lock_orientation_title" = "Orientering låst";
 "more_title" = "Flere";
+"repeat_turn_on_title" = "Slå på Gjenta for denne boken";
+"repeat_turn_off_title" = "Slå av Gjenta for denne boken";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Terugspoelen ${interval}";
 "settings_lock_orientation_title" = "Oriëntatie vergrendeld";
 "more_title" = "Meer";
+"repeat_turn_on_title" = "Schakel Herhalen in voor dit boek";
+"repeat_turn_off_title" = "Herhalen voor dit boek uitschakelen";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Przewiń ${interval}";
 "settings_lock_orientation_title" = "Zablokowana orientacja";
 "more_title" = "Więcej";
+"repeat_turn_on_title" = "Włącz opcję Powtórz dla tej książki";
+"repeat_turn_off_title" = "Wyłącz opcję Powtórz dla tej książki";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Retroceder ${interval}";
 "settings_lock_orientation_title" = "Orientação bloqueada";
 "more_title" = "Mais";
+"repeat_turn_on_title" = "Ativar repetição para este livro";
+"repeat_turn_off_title" = "Desativar Repetir para este livro";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Retroceder ${interval}";
 "settings_lock_orientation_title" = "Orientação bloqueada";
 "more_title" = "Mais";
+"repeat_turn_on_title" = "Ativar repetição para este livro";
+"repeat_turn_off_title" = "Desativar Repetir para este livro";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Derulați înapoi ${interval}";
 "settings_lock_orientation_title" = "Orientare blocată";
 "more_title" = "Mai mult";
+"repeat_turn_on_title" = "Activați Repetare pentru această carte";
+"repeat_turn_off_title" = "Dezactivează Repetarea pentru această carte";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Перемотка назад ${interval}";
 "settings_lock_orientation_title" = "Ориентация заблокирована";
 "more_title" = "Более";
+"repeat_turn_on_title" = "Включить повтор для этой книги";
+"repeat_turn_off_title" = "Отключить повтор для этой книги";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -319,3 +319,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "Rewind ${interval}" = "Pretočiť ${interval}";
 "settings_lock_orientation_title" = "Orientácia uzamknutá";
 "more_title" = "Viac";
+"repeat_turn_on_title" = "Pre túto knihu zapnite možnosť Opakovať";
+"repeat_turn_off_title" = "Vypnúť Opakovať pre túto knihu";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Spola tillbaka ${interval}";
 "settings_lock_orientation_title" = "Orientering låst";
 "more_title" = "Mer";
+"repeat_turn_on_title" = "Aktivera Upprepa för den här boken";
+"repeat_turn_off_title" = "Stäng av Upprepa för den här boken";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "${interval} geri sar";
 "settings_lock_orientation_title" = "Yönlendirme Kilitli";
 "more_title" = "Daha";
+"repeat_turn_on_title" = "Bu kitap için Tekrarı açın";
+"repeat_turn_off_title" = "Bu kitap için Tekrarı kapatın";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "Перемотати ${interval}";
 "settings_lock_orientation_title" = "Орієнтація заблокована";
 "more_title" = "більше";
+"repeat_turn_on_title" = "Увімкніть повтор для цієї книги";
+"repeat_turn_off_title" = "Вимкніть повтор для цієї книги";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -319,3 +319,5 @@
 "Rewind ${interval}" = "后退 ${interval}";
 "settings_lock_orientation_title" = "方向已锁定";
 "more_title" = "更多的";
+"repeat_turn_on_title" = "为这本书开启重复";
+"repeat_turn_off_title" = "关闭此书的重复功能";

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -40,6 +40,7 @@ public enum Constants {
     public static let customSleepTimerDuration = "userSettingsCustomSleepTimerDuration"
     public static let autoTimerEnabled = "userSettingsAutoTimerEnabled"
     public static let lastEnabledTimer = "userSettingsLastEnabledTimer"
+    public static let repeatEnabledSuffix = "_repeatEnabled"
 
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -38,6 +38,10 @@ public final class PlayableItem: NSObject, Identifiable {
     return DataManager.getProcessedFolderURL().appendingPathComponent(self.relativePath)
   }
 
+  public lazy var filename: String = {
+    fileURL.lastPathComponent
+  }()
+
   enum CodingKeys: String, CodingKey {
     case title, author, chapters, currentTime, duration,
       relativePath, parentFolder, percentCompleted, lastPlayDate, isFinished, isBoundBook


### PR DESCRIPTION
## Purpose

- This adds the option to mark books that the user wants to always loop. This is currently accessed via the more options in the player screen 

## Related tasks

#807 

## Things to be aware of / Things to focus on

- There are two more small changes in this PR. The first one just adds the percentage of the book into the book details  view, and the second is an alert to attempt DB recovery on launch