### PR TITLE
Fix swipe actions for the last played row

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		41F1A204254B09C00043FCF3 /* Themeable in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A203254B09C00043FCF3 /* Themeable */; };
 		41F1A20D254B0A0C0043FCF3 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A20C254B0A0C0043FCF3 /* Sentry */; };
 		41F1A228254B0C6C0043FCF3 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A227254B0C6C0043FCF3 /* ZipArchive */; };
+		4645F9FD2D1E46AC00A04257 /* SwipeInlineTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */; };
 		5126F121258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
 		5126F122258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
 		5126F123258E9F18009965DC /* URL+BookPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5126F120258E9F18009965DC /* URL+BookPlayer.swift */; };
@@ -1127,6 +1128,7 @@
 		41EB071A2752FA6B00EFEE13 /* PlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackService.swift; sourceTree = "<group>"; };
 		41F898AE2402080C00F58B8A /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZipArchive.framework; path = Carthage/Build/iOS/ZipArchive.framework; sourceTree = "<group>"; };
 		41FCA32625E87EC600BFB9E6 /* Audiobook Player 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 4.xcdatamodel"; sourceTree = "<group>"; };
+		4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeInlineTip.swift; sourceTree = "<group>"; };
 		5126F120258E9F18009965DC /* URL+BookPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+BookPlayer.swift"; sourceTree = "<group>"; };
 		5CBB29522163A17F00E3A9FF /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		620C73C7275DA00300D495AA /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ar; path = ar.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -1700,6 +1702,7 @@
 				6334CF1C2CF90AF900F1FA17 /* PlayerMoreListView.swift */,
 				6334CF202CFE330300F1FA17 /* RefreshableListView.swift */,
 				63E7DCBF2D076185005B5E1F /* View+BookPlayer.swift */,
+				4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */,
 				63CD851B2CE2963600EDBEA8 /* Settings */,
 				6399D06E2CEBA1F900A2E278 /* RemoteItemList */,
 				9FA334B427C156DB0064E8EA /* ItemList */,
@@ -3538,6 +3541,7 @@
 				63E7DCC02D076185005B5E1F /* View+BookPlayer.swift in Sources */,
 				6334CF1F2CFAD1B700F1FA17 /* RemoteItemCellViewModel.swift in Sources */,
 				9FA334B927C1B8450064E8EA /* NowPlayingTitleView.swift in Sources */,
+				4645F9FD2D1E46AC00A04257 /* SwipeInlineTip.swift in Sources */,
 				6350E4692CF425500077CDC1 /* WidgetReloadService.swift in Sources */,
 				9FA334B327C156CB0064E8EA /* NowPlayingView.swift in Sources */,
 				9FA334C527C285650064E8EA /* ChapterListView.swift in Sources */,

--- a/BookPlayer/Player/BPPlayerError.swift
+++ b/BookPlayer/Player/BPPlayerError.swift
@@ -9,5 +9,14 @@
 import Foundation
 
 enum BPPlayerError: Error {
-  case fileMissing
+  case fileMissing(relativePath: String)
+}
+
+extension BPPlayerError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .fileMissing(let relativePath):
+      return "file_missing_description".localized + "\n\(relativePath)"
+    }
+  }
 }

--- a/BookPlayer/Player/PlayerLoaderService.swift
+++ b/BookPlayer/Player/PlayerLoaderService.swift
@@ -42,7 +42,7 @@ final class PlayerLoaderService: @unchecked Sendable {
     if syncService.isActive == false,
       !FileManager.default.fileExists(atPath: fileURL.path)
     {
-      throw BPPlayerError.fileMissing
+      throw BPPlayerError.fileMissing(relativePath: relativePath)
     }
 
     // Only load if loaded book is a different one

--- a/BookPlayerWatch/Base.lproj/Localizable.strings
+++ b/BookPlayerWatch/Base.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Log out";
 "benefits_watchapp_description" = "Stream or download your books and listen on the go without your phone.";
 "subscription_required_title" = "Subscription required";
+"Swipe rows to see download options" = "Swipe rows to see download options";

--- a/BookPlayerWatch/ExtensionDelegate.swift
+++ b/BookPlayerWatch/ExtensionDelegate.swift
@@ -9,6 +9,7 @@
 import BookPlayerWatchKit
 import RevenueCat
 import SwiftUI
+import TipKit
 import WatchKit
 import MediaPlayer
 
@@ -25,6 +26,13 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate, ObservableObject {
     setupRevenueCat()
     setupCoreServices()
     setupMPRemoteCommands()
+    setupTips()
+  }
+  
+  func setupTips() {
+    if #available(watchOS 10.0, *) {
+      try? Tips.configure()
+    }
   }
 
   func setupRevenueCat() {

--- a/BookPlayerWatch/RemoteItemList/RemoteItemListCellView.swift
+++ b/BookPlayerWatch/RemoteItemList/RemoteItemListCellView.swift
@@ -12,15 +12,17 @@ import SwiftUI
 struct RemoteItemListCellView: View {
   @ObservedObject var model: RemoteItemCellViewModel
   @State private var error: Error?
+  var onTap: () -> Void
 
   let numberFormatter: NumberFormatter
 
-  init(model: RemoteItemCellViewModel) {
+  init(model: RemoteItemCellViewModel, onTap: @escaping () -> Void) {
     self.model = model
     let formatter = NumberFormatter()
     formatter.numberStyle = .percent
     formatter.maximumFractionDigits = 2
     self.numberFormatter = formatter
+    self.onTap = onTap
   }
 
   var percentCompleted: String {
@@ -38,47 +40,49 @@ struct RemoteItemListCellView: View {
   }
 
   var body: some View {
-    HStack {
-      VStack(alignment: .leading) {
-        Text(model.item.title)
-          .lineLimit(2)
-        Text(model.item.details)
-          .font(.footnote)
-          .foregroundColor(Color.secondary)
-          .lineLimit(1)
-        switch model.downloadState {
-        case .downloading(let progress):
-          HStack {
-            if #available(watchOS 10.0, *) {
-              Image(systemName: "icloud.and.arrow.down.fill")
-                .font(.caption2)
-                .symbolEffect(.pulse)
-            } else {
-              Image(systemName: "icloud.and.arrow.down.fill")
-                .font(.caption2)
+    Button(action: onTap) {
+      HStack {
+        VStack(alignment: .leading) {
+          Text(model.item.title)
+            .lineLimit(2)
+          Text(model.item.details)
+            .font(.footnote)
+            .foregroundColor(Color.secondary)
+            .lineLimit(1)
+          switch model.downloadState {
+          case .downloading(let progress):
+            HStack {
+              if #available(watchOS 10.0, *) {
+                Image(systemName: "icloud.and.arrow.down.fill")
+                  .font(.caption2)
+                  .symbolEffect(.pulse)
+              } else {
+                Image(systemName: "icloud.and.arrow.down.fill")
+                  .font(.caption2)
+              }
+              LinearProgressView(value: progress, fillColor: .white)
+                .frame(maxWidth: 70, maxHeight: 10)
+              Text(formattedProgress(progress))
+                .font(.footnote)
             }
-            LinearProgressView(value: progress, fillColor: .white)
-              .frame(maxWidth: 70, maxHeight: 10)
-            Text(formattedProgress(progress))
+          case .downloaded:
+            Text(Image(systemName: "applewatch"))
+              .font(.caption2)
+              + Text(" - \(percentCompleted)\(model.item.durationFormatted)")
               .font(.footnote)
+              .foregroundColor(Color.secondary)
+          case .notDownloaded:
+            Text(Image(systemName: "icloud.fill"))
+              .font(.caption2)
+              + Text(" - \(percentCompleted)\(model.item.durationFormatted)")
+              .font(.footnote)
+              .foregroundColor(Color.secondary)
           }
-        case .downloaded:
-          Text(Image(systemName: "applewatch"))
-            .font(.caption2)
-            + Text(" - \(percentCompleted)\(model.item.durationFormatted)")
-            .font(.footnote)
-            .foregroundColor(Color.secondary)
-        case .notDownloaded:
-          Text(Image(systemName: "icloud.fill"))
-            .font(.caption2)
-            + Text(" - \(percentCompleted)\(model.item.durationFormatted)")
-            .font(.footnote)
-            .foregroundColor(Color.secondary)
         }
-      }
-      Spacer()
-      if model.item.type == .folder {
-        Image(systemName: "chevron.forward")
+        Spacer()
+        if model.item.type == .folder {
+          Image(systemName: "chevron.forward")
+        }
       }
     }
     .errorAlert(error: $error)

--- a/BookPlayerWatch/RemoteItemList/RemoteItemListView.swift
+++ b/BookPlayerWatch/RemoteItemList/RemoteItemListView.swift
@@ -126,14 +126,11 @@ struct RemoteItemListView: View {
       if folderRelativePath == nil {
         Section {
           if let lastPlayedItem {
-            Button {
+            RemoteItemListCellView(model: .init(item: lastPlayedItem, coreServices: coreServices)) {
               Task {
                 do {
                   isLoading = true
-                  try await coreServices.playerLoaderService.loadPlayer(
-                    lastPlayedItem.relativePath,
-                    autoplay: true
-                  )
+                  try await coreServices.playerLoaderService.loadPlayer(lastPlayedItem.relativePath, autoplay: true)
                   showPlayer = true
                   isLoading = false
                 } catch {
@@ -141,8 +138,6 @@ struct RemoteItemListView: View {
                   self.error = error
                 }
               }
-            } label: {
-              RemoteItemListCellView(model: .init(item: lastPlayedItem, coreServices: coreServices))
             }
             .applyPrimaryHandGesture()
           }
@@ -161,24 +156,24 @@ struct RemoteItemListView: View {
                 folderRelativePath: item.relativePath
               )
             } label: {
-              RemoteItemListCellView(model: .init(item: item, coreServices: coreServices))
+              RemoteItemListCellView(model: .init(item: item, coreServices: coreServices)) {}
+                .allowsHitTesting(false)
                 .foregroundColor(getForegroundColor(for: item))
             }
           } else {
-            RemoteItemListCellView(model: .init(item: item, coreServices: coreServices))
-              .onTapGesture {
-                Task {
-                  do {
-                    isLoading = true
-                    try await coreServices.playerLoaderService.loadPlayer(item.relativePath, autoplay: true)
-                    showPlayer = true
-                    isLoading = false
-                  } catch {
-                    isLoading = false
-                    self.error = error
-                  }
+            RemoteItemListCellView(model: .init(item: item, coreServices: coreServices)) {
+              Task {
+                do {
+                  isLoading = true
+                  try await coreServices.playerLoaderService.loadPlayer(item.relativePath, autoplay: true)
+                  showPlayer = true
+                  isLoading = false
+                } catch {
+                  isLoading = false
+                  self.error = error
                 }
               }
+            }
           }
         }
       } header: {

--- a/BookPlayerWatch/RemoteItemList/RemoteItemListView.swift
+++ b/BookPlayerWatch/RemoteItemList/RemoteItemListView.swift
@@ -8,6 +8,7 @@
 
 import BookPlayerWatchKit
 import SwiftUI
+import TipKit
 
 struct RemoteItemListView: View {
   @Environment(\.scenePhase) var scenePhase
@@ -148,6 +149,14 @@ struct RemoteItemListView: View {
       }
 
       Section {
+        if #available(watchOS 10.0, *),
+          folderRelativePath == nil,
+           !items.isEmpty
+        {
+          TipView(SwipeInlineTip())
+            .listRowBackground(Color.clear)
+        }
+
         ForEach(items) { item in
           if item.type == .folder {
             NavigationLink {

--- a/BookPlayerWatch/SwipeInlineTip.swift
+++ b/BookPlayerWatch/SwipeInlineTip.swift
@@ -1,0 +1,17 @@
+//
+//  SwipeInlineTip.swift
+//  BookPlayerWatch
+//
+//  Created by Gianni Carlo on 12/26/24.
+//  Copyright © 2024 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+import TipKit
+
+@available(watchOS 10.0, *)
+struct SwipeInlineTip: Tip {
+  var title: Text {
+    Text("Swipe rows to see download options")
+  }
+}

--- a/BookPlayerWatch/ar.lproj/Localizable.strings
+++ b/BookPlayerWatch/ar.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "تسجيل خروج";
 "benefits_watchapp_description" = "قم ببث كتبك أو تنزيلها واستمع إليها أثناء التنقل دون الحاجة إلى هاتفك.";
 "subscription_required_title" = "الاشتراك مطلوب";
+"Swipe rows to see download options" = "مرر الصفوف لرؤية خيارات التنزيل";

--- a/BookPlayerWatch/cs.lproj/Localizable.strings
+++ b/BookPlayerWatch/cs.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Odhlásit se";
 "benefits_watchapp_description" = "Streamujte nebo stahujte své knihy a poslouchejte je na cestách bez telefonu.";
 "subscription_required_title" = "Je vyžadováno předplatné";
+"Swipe rows to see download options" = "Přejetím po řádcích zobrazíte možnosti stahování";

--- a/BookPlayerWatch/da.lproj/Localizable.strings
+++ b/BookPlayerWatch/da.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Log ud";
 "benefits_watchapp_description" = "Stream eller download dine bøger, og lyt på farten uden din telefon.";
 "subscription_required_title" = "Kræver abonnement";
+"Swipe rows to see download options" = "Stryg rækkerne for at se downloadmuligheder";

--- a/BookPlayerWatch/de.lproj/Localizable.strings
+++ b/BookPlayerWatch/de.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Ausloggen";
 "benefits_watchapp_description" = "Streamen oder laden Sie Ihre Bücher herunter und hören Sie sie unterwegs ohne Ihr Telefon.";
 "subscription_required_title" = "Abonnement erforderlich";
+"Swipe rows to see download options" = "Wischen Sie durch die Zeilen, um die Download-Optionen anzuzeigen";

--- a/BookPlayerWatch/el.lproj/Localizable.strings
+++ b/BookPlayerWatch/el.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Αποσύνδεση";
 "benefits_watchapp_description" = "Μεταδώστε ροή ή κατεβάστε τα βιβλία σας και ακούστε τα εν κινήσει χωρίς το τηλέφωνό σας.";
 "subscription_required_title" = "Απαιτείται συνδρομή";
+"Swipe rows to see download options" = "Σύρετε σειρές για να δείτε τις επιλογές λήψης";

--- a/BookPlayerWatch/en.lproj/Localizable.strings
+++ b/BookPlayerWatch/en.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Log out";
 "benefits_watchapp_description" = "Stream or download your books and listen on the go without your phone.";
 "subscription_required_title" = "Subscription required";
+"Swipe rows to see download options" = "";

--- a/BookPlayerWatch/es.lproj/Localizable.strings
+++ b/BookPlayerWatch/es.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Cerrar sesión";
 "benefits_watchapp_description" = "Transmite o descarga tus libros y escúchalos mientras viajas sin tu teléfono.";
 "subscription_required_title" = "Se requiere suscripción";
+"Swipe rows to see download options" = "Desliza las filas para ver las opciones de descarga";

--- a/BookPlayerWatch/fi.lproj/Localizable.strings
+++ b/BookPlayerWatch/fi.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Kirjautua ulos";
 "benefits_watchapp_description" = "Suoratoista tai lataa kirjojasi ja kuuntele tien päällä ilman puhelinta.";
 "subscription_required_title" = "Tilaus vaaditaan";
+"Swipe rows to see download options" = "Pyyhkäise rivejä nähdäksesi latausvaihtoehdot";

--- a/BookPlayerWatch/fr.lproj/Localizable.strings
+++ b/BookPlayerWatch/fr.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Se déconnecter";
 "benefits_watchapp_description" = "Diffusez ou téléchargez vos livres et écoutez-les en déplacement sans votre téléphone.";
 "subscription_required_title" = "Abonnement requis";
+"Swipe rows to see download options" = "Faites glisser les lignes pour voir les options de téléchargement";

--- a/BookPlayerWatch/hu.lproj/Localizable.strings
+++ b/BookPlayerWatch/hu.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Kijelentkezés";
 "benefits_watchapp_description" = "Streamelje vagy töltse le könyveit, és telefonja nélkül hallgassa útközben.";
 "subscription_required_title" = "Előfizetés szükséges";
+"Swipe rows to see download options" = "Csúsztassa el a sorokat a letöltési lehetőségek megtekintéséhez";

--- a/BookPlayerWatch/it.lproj/Localizable.strings
+++ b/BookPlayerWatch/it.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Disconnettersi";
 "benefits_watchapp_description" = "Ascolta in streaming o scarica i tuoi libri e ascoltali ovunque tu sia, senza usare il telefono.";
 "subscription_required_title" = "Abbonamento richiesto";
+"Swipe rows to see download options" = "Scorri le righe per vedere le opzioni di download";

--- a/BookPlayerWatch/ja.lproj/Localizable.strings
+++ b/BookPlayerWatch/ja.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Log out";
 "benefits_watchapp_description" = "Stream or download your books and listen on the go without your phone.";
 "subscription_required_title" = "Subscription required";
+"Swipe rows to see download options" = "Swipe rows to see download options";

--- a/BookPlayerWatch/nb.lproj/Localizable.strings
+++ b/BookPlayerWatch/nb.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Logg ut";
 "benefits_watchapp_description" = "Stream eller last ned bøkene dine og lytt mens du er på farten uten telefonen.";
 "subscription_required_title" = "Abonnement kreves";
+"Swipe rows to see download options" = "Sveip rader for å se nedlastingsalternativer";

--- a/BookPlayerWatch/nl.lproj/Localizable.strings
+++ b/BookPlayerWatch/nl.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Uitloggen";
 "benefits_watchapp_description" = "Stream of download uw boeken en luister er onderweg naar, zonder uw telefoon.";
 "subscription_required_title" = "Abonnement vereist";
+"Swipe rows to see download options" = "Veeg over de rijen om de downloadopties te zien";

--- a/BookPlayerWatch/pl.lproj/Localizable.strings
+++ b/BookPlayerWatch/pl.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Wyloguj";
 "benefits_watchapp_description" = "Przesyłaj strumieniowo lub pobieraj książki i słuchaj ich w podróży, bez użycia telefonu.";
 "subscription_required_title" = "Wymagana subskrypcja";
+"Swipe rows to see download options" = "Przesuń wiersze, aby zobaczyć opcje pobierania";

--- a/BookPlayerWatch/pt-BR.lproj/Localizable.strings
+++ b/BookPlayerWatch/pt-BR.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Sair";
 "benefits_watchapp_description" = "Transmita ou baixe seus livros e ouça em qualquer lugar, sem precisar do seu celular.";
 "subscription_required_title" = "Assinatura necessária";
+"Swipe rows to see download options" = "Deslize as linhas para ver as opções de download";

--- a/BookPlayerWatch/pt-PT.lproj/Localizable.strings
+++ b/BookPlayerWatch/pt-PT.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Sair";
 "benefits_watchapp_description" = "Transmita ou baixe seus livros e ouça em qualquer lugar, sem precisar do seu celular.";
 "subscription_required_title" = "Assinatura necessária";
+"Swipe rows to see download options" = "Deslize as linhas para ver as opções de download";

--- a/BookPlayerWatch/ro.lproj/Localizable.strings
+++ b/BookPlayerWatch/ro.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Deconectați-vă";
 "benefits_watchapp_description" = "Transmiteți în flux sau descărcați cărțile și ascultați din mers fără telefon.";
 "subscription_required_title" = "Este necesar un abonament";
+"Swipe rows to see download options" = "Glisați rândurile pentru a vedea opțiunile de descărcare";

--- a/BookPlayerWatch/ru.lproj/Localizable.strings
+++ b/BookPlayerWatch/ru.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Выйти";
 "benefits_watchapp_description" = "Слушайте книги онлайн или скачивайте их, где бы вы ни находились, без телефона.";
 "subscription_required_title" = "Требуется подписка";
+"Swipe rows to see download options" = "Проведите пальцем по строкам, чтобы увидеть варианты загрузки";

--- a/BookPlayerWatch/sk-SK.lproj/Localizable.strings
+++ b/BookPlayerWatch/sk-SK.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Odhlásiť sa";
 "benefits_watchapp_description" = "Streamujte alebo sťahujte svoje knihy a počúvajte na cestách bez telefónu.";
 "subscription_required_title" = "Vyžaduje sa predplatné";
+"Swipe rows to see download options" = "Potiahnutím riadkov zobrazíte možnosti sťahovania";

--- a/BookPlayerWatch/sv.lproj/Localizable.strings
+++ b/BookPlayerWatch/sv.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Logga ut";
 "benefits_watchapp_description" = "Streama eller ladda ner dina böcker och lyssna på språng utan din telefon.";
 "subscription_required_title" = "Prenumeration krävs";
+"Swipe rows to see download options" = "Svep rader för att se nedladdningsalternativ";

--- a/BookPlayerWatch/tr.lproj/Localizable.strings
+++ b/BookPlayerWatch/tr.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Çıkış Yap";
 "benefits_watchapp_description" = "Kitaplarınızı yayınlayın veya indirin ve telefonunuz olmadan hareket halindeyken dinleyin.";
 "subscription_required_title" = "Abonelik gerekli";
+"Swipe rows to see download options" = "İndirme seçeneklerini görmek için satırları kaydırın";

--- a/BookPlayerWatch/uk.lproj/Localizable.strings
+++ b/BookPlayerWatch/uk.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "Вийти";
 "benefits_watchapp_description" = "Транслюйте або завантажуйте свої книги та слухайте їх у дорозі без телефону.";
 "subscription_required_title" = "Потрібна підписка";
+"Swipe rows to see download options" = "Гортайте рядки, щоб переглянути параметри завантаження";

--- a/BookPlayerWatch/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayerWatch/zh-Hans.lproj/Localizable.strings
@@ -26,3 +26,4 @@
 "logout_title" = "登出";
 "benefits_watchapp_description" = "流式传输或下载您的书籍并随时随地收听，无需使用手机。";
 "subscription_required_title" = "需要订阅";
+"Swipe rows to see download options" = "滑动行查看下载选项";


### PR DESCRIPTION
## Bugfix

- The last played row on the Watch app is not allowing swiping left to see the download options

## Approach

- Rework `RemoteItemListCellView` to have a `Button` as the root view, and inject the action

## Things to be aware of / Things to focus on

- I'm also including a `TipView` that is available for WatchOS 10+ users, so a tooltip shows up, explaining that rows can be swiped for additional functionality

--- EDIT

I'm including the fixes to the last played item's synced time here as well
