### PR TITLE
Add new setting to toggle seek on progress bar on lock screen

### DIFF
--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -240,7 +240,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
       return .success
     }
 
-    center.changePlaybackPositionCommand.isEnabled = true
+    setupChangePlaybackPositionCommand()
+  }
+
+  func setupChangePlaybackPositionCommand() {
+    let center = MPRemoteCommandCenter.shared()
+    center.changePlaybackPositionCommand.isEnabled  = UserDefaults.standard.bool(forKey: Constants.UserDefaults.seekProgressBarEnabled)
     center.changePlaybackPositionCommand.addTarget { [weak self] remoteEvent in
       guard
         let playerManager = self?.coreServices?.playerManager,

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -346,3 +346,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "runtime_unknown" = "Unknown duration";
 "subscription_required_title" = "Subscription required";
 "Swipe rows to see download options" = "Swipe rows to see download options";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/Coordinators/PlayerControlsCoordinator.swift
+++ b/BookPlayer/Coordinators/PlayerControlsCoordinator.swift
@@ -27,10 +27,21 @@ class PlayerControlsCoordinator: Coordinator {
       switch routes {
       case .dismiss:
         self.flow.finishPresentation(animated: true)
+      case .more:
+        self.showMoreControls()
       }
     }
     let vc = PlayerControlsViewController.instantiate(from: .Player)
     vc.viewModel = viewModel
     flow.startPresentation(vc, animated: true)
+  }
+
+  func showMoreControls() {
+    let vc = PlayerSettingsViewController.instantiate(from: .Settings)
+    vc.navigationItem.largeTitleDisplayMode = .never
+    let nav = AppNavigationController.instantiate(from: .Main)
+    nav.viewControllers = [vc]
+
+    flow.navigationController.present(nav, animated: true)
   }
 }

--- a/BookPlayer/Player/Base.lproj/Player.storyboard
+++ b/BookPlayer/Player/Base.lproj/Player.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -411,17 +411,17 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BookmarkTableViewCell" id="Te8-vH-xXS" customClass="BookmarkTableViewCell" customModule="BookPlayer" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="414" height="140.5"/>
+                                <rect key="frame" x="0.0" y="50" width="414" height="142.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Te8-vH-xXS" id="A4Z-5c-eS3">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="140.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="142.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Nwf-Dq-SSB">
-                                            <rect key="frame" x="16" y="5" width="382" height="130.5"/>
+                                            <rect key="frame" x="16" y="5" width="382" height="132.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="254" horizontalCompressionResistancePriority="745" text="00:00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jie-XM-DdZ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="61" height="130.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="61" height="132.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="61" id="jXf-E9-2g1"/>
                                                     </constraints>
@@ -430,7 +430,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="246" horizontalCompressionResistancePriority="753" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1vu-0y-Gsj">
-                                                    <rect key="frame" x="69" y="0.0" width="285" height="130.5"/>
+                                                    <rect key="frame" x="69" y="0.0" width="285" height="132.5"/>
                                                     <string key="text">This is a test of a description
 with two lines</string>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -438,10 +438,10 @@ with two lines</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="At3-bV-uru">
-                                                    <rect key="frame" x="362" y="0.0" width="20" height="130.5"/>
+                                                    <rect key="frame" x="362" y="0.0" width="20" height="132.5"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="hl8-aB-hHI">
-                                                            <rect key="frame" x="0.0" y="55.5" width="20" height="20"/>
+                                                            <rect key="frame" x="0.0" y="56.5" width="20" height="20"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="20" id="GgN-Bh-f4r"/>
                                                                 <constraint firstAttribute="height" constant="20" id="w74-rW-tSe"/>
@@ -504,16 +504,16 @@ with two lines</string>
                                 <rect key="frame" x="24" y="63" width="366" height="784"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8i-X3-hlF">
-                                        <rect key="frame" x="0.0" y="0.0" width="366" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="366" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set Playback speed" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n9d-nZ-fG0">
-                                                <rect key="frame" x="0.0" y="0.0" width="135" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="135" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="2.95x" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bNA-0S-HSw">
-                                                <rect key="frame" x="135" y="0.0" width="231" height="20.5"/>
+                                                <rect key="frame" x="135" y="0.0" width="231" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -521,10 +521,10 @@ with two lines</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="820-mH-tvu">
-                                        <rect key="frame" x="0.0" y="35.5" width="366" height="30"/>
+                                        <rect key="frame" x="0.0" y="33" width="366" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.5" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RSw-zr-d6a">
-                                                <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="T9U-JO-YlL"/>
                                                 </constraints>
@@ -533,10 +533,10 @@ with two lines</string>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="9G4-Hw-bkq" customClass="AccessibleSliderView" customModule="BookPlayer" customModuleProvider="target">
-                                                <rect key="frame" x="28" y="0.0" width="310" height="31"/>
+                                                <rect key="frame" x="28" y="0.0" width="310" height="19"/>
                                             </slider>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4.0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hht-Bn-wcE">
-                                                <rect key="frame" x="336" y="0.0" width="30" height="30"/>
+                                                <rect key="frame" x="336" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="WgD-5e-9VX"/>
                                                 </constraints>
@@ -547,7 +547,7 @@ with two lines</string>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5eS-yd-wtY">
-                                        <rect key="frame" x="0.0" y="80.5" width="366" height="32"/>
+                                        <rect key="frame" x="0.0" y="66" width="366" height="32"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EJm-SF-lge">
                                                 <rect key="frame" x="0.0" y="0.0" width="366" height="32"/>
@@ -618,20 +618,20 @@ with two lines</string>
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r7W-Dz-9we">
-                                        <rect key="frame" x="0.0" y="127.5" width="366" height="0.5"/>
+                                        <rect key="frame" x="0.0" y="113" width="366" height="0.5"/>
                                         <color key="backgroundColor" systemColor="secondaryLabelColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="0.5" id="saN-UB-vlS"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Boost Volume" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1e9-ga-tQH">
-                                        <rect key="frame" x="0.0" y="143" width="366" height="18"/>
+                                        <rect key="frame" x="0.0" y="128.5" width="366" height="18"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="754" translatesAutoresizingMaskIntoConstraints="NO" id="iN5-ES-d7T">
-                                        <rect key="frame" x="0.0" y="176" width="366" height="31.5"/>
+                                        <rect key="frame" x="0.0" y="161.5" width="366" height="31.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="755" verticalCompressionResistancePriority="754" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9d8-f2-tOD">
                                                 <rect key="frame" x="0.0" y="0.0" width="317" height="31.5"/>
@@ -655,8 +655,16 @@ Use with caution and care for your hearing.</string>
                                             <constraint firstAttribute="trailing" secondItem="vOX-QN-FKF" secondAttribute="trailing" id="P8B-oP-xFK"/>
                                         </constraints>
                                     </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="04U-zw-Hrv">
+                                        <rect key="frame" x="0.0" y="208" width="366" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="More"/>
+                                        <connections>
+                                            <action selector="handleMoreAction:" destination="KEV-vU-Q0I" eventType="touchUpInside" id="0nu-hH-8Lq"/>
+                                        </connections>
+                                    </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oMT-YJ-ekq">
-                                        <rect key="frame" x="0.0" y="222.5" width="366" height="561.5"/>
+                                        <rect key="frame" x="0.0" y="257.5" width="366" height="526.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                 </subviews>
@@ -689,6 +697,7 @@ Use with caution and care for your hearing.</string>
                         <outlet property="decrementSpeedButton" destination="hCV-r7-j9u" id="KK1-tD-Sle"/>
                         <outlet property="incrementSpeedButton" destination="huR-Zt-fkc" id="3Y1-vN-CcO"/>
                         <outlet property="mainContainterStackView" destination="GG9-6P-sif" id="ppg-W8-AGk"/>
+                        <outlet property="moreButton" destination="04U-zw-Hrv" id="7dt-0a-YGH"/>
                         <outlet property="playbackContainerStackView" destination="820-mH-tvu" id="FWV-2I-4CH"/>
                         <outlet property="playbackLabel" destination="n9d-nZ-fG0" id="i8c-rw-EOe"/>
                         <outlet property="separatorView" destination="r7W-Dz-9we" id="31u-ab-PcD"/>

--- a/BookPlayer/Player/Controls Screen/PlayerControlsViewController.swift
+++ b/BookPlayer/Player/Controls Screen/PlayerControlsViewController.swift
@@ -32,6 +32,8 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
   @IBOutlet weak var boostSwitchControl: UISwitch!
   @IBOutlet weak var moreButton: UIButton!
 
+  private var boostVolumeObserver: NSKeyValueObservation?
+
   private var disposeBag = Set<AnyCancellable>()
 
   override func viewDidLoad() {
@@ -118,6 +120,14 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
         self?.viewModel.handleBoostVolumeToggle(flag: switchControl.isOn)
       }
       .store(in: &disposeBag)
+
+    boostVolumeObserver = UserDefaults.standard.observe(
+      \.userSettingsBoostVolume,
+       options: [.new]
+    ) { [weak self] _, change in
+      guard let newValue = change.newValue else { return }
+      self?.boostSwitchControl.setOn(newValue, animated: false)
+    }
   }
 
   func bindSpeedObservers() {

--- a/BookPlayer/Player/Controls Screen/PlayerControlsViewController.swift
+++ b/BookPlayer/Player/Controls Screen/PlayerControlsViewController.swift
@@ -30,6 +30,7 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
   @IBOutlet weak var boostLabel: UILabel!
   @IBOutlet weak var boostWarningLabel: UILabel!
   @IBOutlet weak var boostSwitchControl: UISwitch!
+  @IBOutlet weak var moreButton: UIButton!
 
   private var disposeBag = Set<AnyCancellable>()
 
@@ -49,6 +50,7 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
     self.playbackLabel.text = "player_speed_title".localized
     self.boostLabel.text = "settings_boostvolume_title".localized
     self.boostWarningLabel.text = "settings_boostvolume_description".localized
+    self.moreButton.setTitle("more_title".localized, for: .normal)
 
     self.speedFirstQuickActionButton.layer.masksToBounds = true
     self.speedFirstQuickActionButton.layer.cornerRadius = 5
@@ -91,14 +93,20 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
 
   func setupAccessibility() {
     self.boostLabel.accessibilityHint = "settings_boostvolume_description".localized
+    self.decrementSpeedButton.accessibilityLabel = "➖"
     self.currentSpeedSlider.accessibilityValue = "\(self.viewModel.getCurrentSpeed())"
+    self.incrementSpeedButton.accessibilityLabel = "➕"
     self.boostWarningLabel.isAccessibilityElement = false
     self.currentSpeedLabel.isAccessibilityElement = false
 
     self.mainContainterStackView.accessibilityElements = [
+      self.playbackLabel!,
+      self.decrementSpeedButton!,
       self.currentSpeedSlider!,
+      self.incrementSpeedButton!,
       self.boostLabel!,
-      self.boostSwitchControl!
+      self.boostSwitchControl!,
+      self.moreButton!
     ]
   }
 
@@ -168,12 +176,17 @@ class PlayerControlsViewController: UIViewController, Storyboarded {
   }
 
   private func setSliderSpeed(_ value: Float) {
+    self.currentSpeedSlider.accessibilityValue = "\(value)"
     self.currentSpeedSlider.value = value
     self.viewModel.handleSpeedChange(newValue: value)
   }
 
   @IBAction func done(_ sender: UIBarButtonItem?) {
     self.viewModel.dismiss()
+  }
+
+  @IBAction func handleMoreAction(_ sender: UIButton) {
+    viewModel.showMoreControls()
   }
 }
 
@@ -202,6 +215,8 @@ extension PlayerControlsViewController: Themeable {
       self.decrementSpeedButton.tintColor = theme.linkColor
       self.incrementSpeedButton.tintColor = theme.linkColor
     }
+
+    self.moreButton.tintColor = theme.linkColor
 
     self.overrideUserInterfaceStyle = theme.useDarkVariant
     ? UIUserInterfaceStyle.dark

--- a/BookPlayer/Player/Controls Screen/PlayerControlsViewModel.swift
+++ b/BookPlayer/Player/Controls Screen/PlayerControlsViewModel.swift
@@ -12,6 +12,7 @@ import Foundation
 
 class PlayerControlsViewModel {
   enum Routes {
+    case more
     case dismiss
   }
 
@@ -64,5 +65,9 @@ class PlayerControlsViewModel {
 
   func dismiss() {
     onTransition?(.dismiss)
+  }
+
+  func showMoreControls() {
+    onTransition?(.more)
   }
 }

--- a/BookPlayer/Player/Player Screen/PlayerViewModel.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewModel.swift
@@ -219,6 +219,13 @@ class PlayerViewModel: ViewModelProtocol {
     )
   }
 
+  func reloadSharedFlags() {
+    /// Flags are not a getter to avoid reading too often from defaults, as progress objects can be
+    /// triggered multiple times in a second
+    self.prefersChapterContext = sharedDefaults.bool(forKey: Constants.UserDefaults.chapterContextEnabled)
+    self.prefersRemainingTime = sharedDefaults.bool(forKey: Constants.UserDefaults.remainingTimeEnabled)
+  }
+
   func processToggleMaxTime() -> ProgressObject {
     self.prefersRemainingTime = !self.prefersRemainingTime
     sharedDefaults.set(self.prefersRemainingTime, forKey: Constants.UserDefaults.remainingTimeEnabled)

--- a/BookPlayer/Player/Player Screen/Views/PlayerJumpIcon.swift
+++ b/BookPlayer/Player/Player Screen/Views/PlayerJumpIcon.swift
@@ -96,6 +96,8 @@ extension PlayerJumpIcon: Themeable {
 }
 
 class PlayerJumpIconForward: PlayerJumpIcon {
+  private var intervalObserver: NSKeyValueObservation?
+
   override var backgroundImage: UIImage {
     get {
       return #imageLiteral(resourceName: "playerIconForward")
@@ -110,10 +112,25 @@ class PlayerJumpIconForward: PlayerJumpIcon {
 
     self.title = "+\(Int(PlayerManager.forwardInterval.rounded())) "
     self.actionButton.accessibilityLabel = VoiceOverService.fastForwardText()
+
+    self.bindObserver()
+  }
+
+  func bindObserver() {
+    intervalObserver = UserDefaults.standard.observe(
+      \.userSettingsForwardInterval,
+       options: [.new]
+    ) { [weak self] _, change in
+      guard let newValue = change.newValue else { return }
+      self?.title = "+\(Int(newValue.rounded())) "
+      self?.actionButton.accessibilityLabel = VoiceOverService.fastForwardText()
+    }
   }
 }
 
 class PlayerJumpIconRewind: PlayerJumpIcon {
+  private var intervalObserver: NSKeyValueObservation?
+
   override var backgroundImage: UIImage {
     get {
       return #imageLiteral(resourceName: "playerIconRewind")
@@ -128,5 +145,18 @@ class PlayerJumpIconRewind: PlayerJumpIcon {
 
     self.title = "−\(Int(PlayerManager.rewindInterval.rounded())) "
     self.actionButton.accessibilityLabel = VoiceOverService.rewindText()
+
+    self.bindObserver()
+  }
+
+  func bindObserver() {
+    intervalObserver = UserDefaults.standard.observe(
+      \.userSettingsRewindInterval,
+       options: [.new]
+    ) { [weak self] _, change in
+      guard let newValue = change.newValue else { return }
+      self?.title = "-\(Int(newValue.rounded())) "
+      self?.actionButton.accessibilityLabel = VoiceOverService.rewindText()
+    }
   }
 }

--- a/BookPlayer/Settings/Base.lproj/Settings.storyboard
+++ b/BookPlayer/Settings/Base.lproj/Settings.storyboard
@@ -310,7 +310,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sleep Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BsZ-qn-RYs" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Sleep Timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BsZ-qn-RYs" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -334,13 +334,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ssf-Q5-vn2">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ssf-Q5-vn2">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="9Gr-mL-Nfy"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Include book files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rRx-5f-ZeW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Include book files" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="rRx-5f-ZeW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -370,11 +370,11 @@
                                         <rect key="frame" x="0.0" y="1058" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ycN-2h-zKH" id="45f-nU-QEL">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage Connection" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tqa-gc-GDP" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Manage Connection" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tqa-gc-GDP" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="8" y="0.0" width="340.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -398,13 +398,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fvX-JA-Us2">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fvX-JA-Us2">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="vCo-kk-ggY"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable crash reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="BI5-jj-QYz" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Disable crash reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="BI5-jj-QYz" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -433,13 +433,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SyN-Fu-K5b">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SyN-Fu-K5b">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="7V8-9T-0Tl"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable SKAN attribution" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="DOq-C5-tRv" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Disable SKAN attribution" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="DOq-C5-tRv" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -473,7 +473,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Tip Jar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MVf-CT-ocr" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -496,7 +496,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Send us an email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nCM-M8-bSw" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="9" width="129" height="20.5"/>
+                                                    <rect key="frame" x="8" y="9" width="129" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -506,7 +506,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="support@bookplayer.app" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6ow-P5-iYK">
-                                                    <rect key="frame" x="16" y="29.5" width="121" height="12"/>
+                                                    <rect key="frame" x="8" y="29.5" width="121" height="12"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="10"/>
                                                     <nil key="textColor"/>
@@ -527,7 +527,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Share debug information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7ap-vd-Uq1" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -550,7 +550,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="View project on Github" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tUC-Ss-lea" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                                    <rect key="frame" x="8" y="0.0" width="359" height="50"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -573,11 +573,11 @@
                                         <rect key="frame" x="0.0" y="1589.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="03X-zP-RZe" id="IIp-cC-U1k">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Credits and Licenses" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="f5k-Kh-fBQ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="340.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2217,10 +2217,49 @@ Use with caution and care for your hearing.</string>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection footerTitle="Enable seeking on the lock screen" id="iDD-aB-AJl">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="FwU-jz-K8l" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="607.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FwU-jz-K8l" id="pDE-fu-X2U">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J90-Fp-Uvn">
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="49" id="2Hf-KH-hJM"/>
+                                                    </constraints>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Progress Bar Seeking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HMN-gr-oaZ" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                    <rect key="frame" x="16" y="11.5" width="286" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="localizedKey" value="settings_seekprogressbar_title"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="HMN-gr-oaZ" firstAttribute="leading" secondItem="pDE-fu-X2U" secondAttribute="leading" constant="16" id="2Xk-fA-byh"/>
+                                                <constraint firstAttribute="trailing" secondItem="J90-Fp-Uvn" secondAttribute="trailing" constant="16" id="6a4-P8-PVh"/>
+                                                <constraint firstItem="HMN-gr-oaZ" firstAttribute="centerY" secondItem="pDE-fu-X2U" secondAttribute="centerY" id="MaD-IT-1Wb"/>
+                                                <constraint firstItem="J90-Fp-Uvn" firstAttribute="leading" secondItem="HMN-gr-oaZ" secondAttribute="trailing" constant="8" id="Wbx-vD-H1D"/>
+                                                <constraint firstItem="J90-Fp-Uvn" firstAttribute="centerY" secondItem="pDE-fu-X2U" secondAttribute="centerY" id="a1O-ac-7Qd"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="customLabel" destination="HMN-gr-oaZ" id="PvL-wt-V9U"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection footerTitle="Adjust what the list button in the player screen opens" id="04N-lB-8ix">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Ydn-hQ-kXZ" detailTextLabel="Jbk-jB-Hyp" imageView="wIP-hW-J0B" style="IBUITableViewCellStyleValue1" id="oMW-vV-SO2" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="607.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="699.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oMW-vV-SO2" id="8zv-VN-kiu">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="44"/>
@@ -2256,7 +2295,7 @@ Use with caution and care for your hearing.</string>
                                 <string key="footerTitle">Toggle between displaying the remaining time, total duration and progress of either the chapter or the book in the player screen</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="BJG-C7-5Vg" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="727" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="819" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BJG-C7-5Vg" id="dpV-7M-H3x">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -2291,19 +2330,19 @@ Use with caution and care for your hearing.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="vru-07-FFi" customClass="StaticCellView" customModule="BookPlayer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="771" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="863" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vru-07-FFi" id="V6Q-pu-WgH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jzV-Oj-QRt">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jzV-Oj-QRt">
                                                     <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="dX3-2o-B6Y"/>
                                                     </constraints>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Use Chapter Context" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jWe-Ru-KOW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use Chapter Context" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jWe-Ru-KOW" customClass="LocalizableLabel" customModule="BookPlayer" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="11.5" width="286" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2344,6 +2383,7 @@ Use with caution and care for your hearing.</string>
                         <outlet property="playerListPreferenceLabel" destination="Jbk-jB-Hyp" id="v79-dv-pvm"/>
                         <outlet property="remainingTimeSwitch" destination="81u-k2-GAa" id="t2S-gl-IgH"/>
                         <outlet property="rewindIntervalLabel" destination="1x1-g6-7Vg" id="AQa-qN-8HA"/>
+                        <outlet property="seekProgressBarSwitch" destination="J90-Fp-Uvn" id="dRK-8e-UAt"/>
                         <outlet property="smartRewindSwitch" destination="k1y-6J-4zm" id="zkj-QL-uhv"/>
                     </connections>
                 </tableViewController>

--- a/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
+++ b/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewController.swift
@@ -10,12 +10,14 @@ import BookPlayerKit
 import Combine
 import Themeable
 import UIKit
+import MediaPlayer
 
 class PlayerSettingsViewController: UITableViewController, Storyboarded {
   @IBOutlet weak var autoSleepTimerSwitch: UISwitch!
   @IBOutlet weak var smartRewindSwitch: UISwitch!
   @IBOutlet weak var boostVolumeSwitch: UISwitch!
   @IBOutlet weak var globalSpeedSwitch: UISwitch!
+  @IBOutlet weak var seekProgressBarSwitch: UISwitch!
   @IBOutlet weak var rewindIntervalLabel: UILabel!
   @IBOutlet weak var forwardIntervalLabel: UILabel!
   @IBOutlet weak var playerListPreferenceLabel: UILabel!
@@ -28,7 +30,7 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
 
   enum SettingsSection: Int {
     case intervals = 0
-    case rewind, sleepTimer, volume, speed, playerList, progressLabels
+    case rewind, sleepTimer, volume, speed, seek, playerList, progressLabels
   }
 
   let playerListPreferencePath = IndexPath(row: 0, section: SettingsSection.playerList.rawValue)
@@ -49,6 +51,7 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
     autoSleepTimerSwitch.addTarget(self, action: #selector(autoSleepTimerToggleDidChange), for: .valueChanged)
     boostVolumeSwitch.addTarget(self, action: #selector(boostVolumeToggleDidChange), for: .valueChanged)
     globalSpeedSwitch.addTarget(self, action: #selector(globalSpeedToggleDidChange), for: .valueChanged)
+    seekProgressBarSwitch.addTarget(self, action: #selector(seekProgressBarToggleDidChange), for: .valueChanged)
 
     // Set initial switch positions
     smartRewindSwitch.setOn(
@@ -65,6 +68,10 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
     )
     globalSpeedSwitch.setOn(
       UserDefaults.standard.bool(forKey: Constants.UserDefaults.globalSpeedEnabled),
+      animated: false
+    )
+    seekProgressBarSwitch.setOn(
+      UserDefaults.standard.bool(forKey: Constants.UserDefaults.seekProgressBarEnabled),
       animated: false
     )
     chapterTimeSwitch.setOn(
@@ -204,6 +211,8 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
       return "settings_boostvolume_description".localized
     case .speed:
       return "settings_globalspeed_description".localized
+    case .seek:
+      return "settings_seekprogressbar_description".localized
     case .progressLabels:
       return "settings_progresslabels_description".localized
     case .playerList:
@@ -229,6 +238,11 @@ class PlayerSettingsViewController: UITableViewController, Storyboarded {
 
   @objc func globalSpeedToggleDidChange() {
     UserDefaults.standard.set(self.globalSpeedSwitch.isOn, forKey: Constants.UserDefaults.globalSpeedEnabled)
+  }
+
+  @objc func seekProgressBarToggleDidChange() {
+    UserDefaults.standard.set(self.seekProgressBarSwitch.isOn, forKey: Constants.UserDefaults.seekProgressBarEnabled)
+    MPRemoteCommandCenter.shared().changePlaybackPositionCommand.isEnabled = seekProgressBarSwitch.isOn
   }
 }
 

--- a/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewModel.swift
+++ b/BookPlayer/Settings/Player Settings Screen/PlayerSettingsViewModel.swift
@@ -43,9 +43,11 @@ final class PlayerSettingsViewModel {
 
   func handlePrefersChapterContext(_ flag: Bool) {
     UserDefaults.sharedDefaults.set(flag, forKey: Constants.UserDefaults.chapterContextEnabled)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.updateProgress)
   }
 
   func handlePrefersRemainingTime(_ flag: Bool) {
     UserDefaults.sharedDefaults.set(flag, forKey: Constants.UserDefaults.remainingTimeEnabled)
+    UserDefaults.standard.set(true, forKey: Constants.UserDefaults.updateProgress)
   }
 }

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "مدة غير معروفة";
 "subscription_required_title" = "الاشتراك مطلوب";
 "Swipe rows to see download options" = "مرر الصفوف لرؤية خيارات التنزيل";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Neznámá doba trvání";
 "subscription_required_title" = "Je vyžadováno předplatné";
 "Swipe rows to see download options" = "Přejetím po řádcích zobrazíte možnosti stahování";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Ukendt varighed";
 "subscription_required_title" = "Kræver abonnement";
 "Swipe rows to see download options" = "Stryg rækkerne for at se downloadmuligheder";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Unbekannte Dauer";
 "subscription_required_title" = "Abonnement erforderlich";
 "Swipe rows to see download options" = "Wischen Sie durch die Zeilen, um die Download-Optionen anzuzeigen";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Άγνωστη διάρκεια";
 "subscription_required_title" = "Απαιτείται συνδρομή";
 "Swipe rows to see download options" = "Σύρετε σειρές για να δείτε τις επιλογές λήψης";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -346,3 +346,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "runtime_unknown" = "Unknown duration";
 "subscription_required_title" = "Subscription required";
 "Swipe rows to see download options" = "Swipe rows to see download options";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Duración desconocida";
 "subscription_required_title" = "Se requiere suscripción";
 "Swipe rows to see download options" = "Desliza las filas para ver las opciones de descarga";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Tuntematon kesto";
 "subscription_required_title" = "Tilaus vaaditaan";
 "Swipe rows to see download options" = "Pyyhkäise rivejä nähdäksesi latausvaihtoehdot";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Durée inconnue";
 "subscription_required_title" = "Abonnement requis";
 "Swipe rows to see download options" = "Faites glisser les lignes pour voir les options de téléchargement";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Ismeretlen időtartam";
 "subscription_required_title" = "Előfizetés szükséges";
 "Swipe rows to see download options" = "Csúsztassa el a sorokat a letöltési lehetőségek megtekintéséhez";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Durata sconosciuta";
 "subscription_required_title" = "Abbonamento richiesto";
 "Swipe rows to see download options" = "Scorri le righe per vedere le opzioni di download";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -346,3 +346,5 @@ We're working hard on providing a seamless experience, if possible, please conta
 "runtime_unknown" = "Unknown duration";
 "subscription_required_title" = "Subscription required";
 "Swipe rows to see download options" = "Swipe rows to see download options";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -346,3 +346,5 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "runtime_unknown" = "Ukjent varighet";
 "subscription_required_title" = "Abonnement kreves";
 "Swipe rows to see download options" = "Sveip rader for å se nedlastingsalternativer";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Onbekende duur";
 "subscription_required_title" = "Abonnement vereist";
 "Swipe rows to see download options" = "Veeg over de rijen om de downloadopties te zien";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Nieznany czas trwania";
 "subscription_required_title" = "Wymagana subskrypcja";
 "Swipe rows to see download options" = "Przesuń wiersze, aby zobaczyć opcje pobierania";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Duração desconhecida";
 "subscription_required_title" = "Assinatura necessária";
 "Swipe rows to see download options" = "Deslize as linhas para ver as opções de download";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Duração desconhecida";
 "subscription_required_title" = "Assinatura necessária";
 "Swipe rows to see download options" = "Deslize as linhas para ver as opções de download";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Durată necunoscută";
 "subscription_required_title" = "Este necesar un abonament";
 "Swipe rows to see download options" = "Glisați rândurile pentru a vedea opțiunile de descărcare";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Неизвестная продолжительность";
 "subscription_required_title" = "Требуется подписка";
 "Swipe rows to see download options" = "Проведите пальцем по строкам, чтобы увидеть варианты загрузки";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -346,3 +346,5 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "runtime_unknown" = "Neznáme trvanie";
 "subscription_required_title" = "Vyžaduje sa predplatné";
 "Swipe rows to see download options" = "Potiahnutím riadkov zobrazíte možnosti sťahovania";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Okänd varaktighet";
 "subscription_required_title" = "Prenumeration krävs";
 "Swipe rows to see download options" = "Svep rader för att se nedladdningsalternativ";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Bilinmeyen süre";
 "subscription_required_title" = "Abonelik gerekli";
 "Swipe rows to see download options" = "İndirme seçeneklerini görmek için satırları kaydırın";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "Невідома тривалість";
 "subscription_required_title" = "Потрібна підписка";
 "Swipe rows to see download options" = "Гортайте рядки, щоб переглянути параметри завантаження";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -346,3 +346,5 @@
 "runtime_unknown" = "持续时间未知";
 "subscription_required_title" = "需要订阅";
 "Swipe rows to see download options" = "滑动行查看下载选项";
+"settings_seekprogressbar_title" = "Progress Bar Seeking";
+"settings_seekprogressbar_description" = "Enable seeking on the lock screen";

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -26,6 +26,7 @@ public enum Constants {
     public static let smartRewindEnabled = "userSettingsSmartRewind"
     public static let boostVolumeEnabled = "userSettingsBoostVolume"
     public static let globalSpeedEnabled = "userSettingsGlobalSpeed"
+    public static let seekProgressBarEnabled = "userSettingsSeekProgressBar"
     public static let autoplayEnabled = "userSettingsAutoplay"
     public static let autoplayRestartEnabled = "userSettingsAutoplayRestart"
     public static let allowCellularData = "userSettingsAllowCellularData"

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -46,6 +46,8 @@ public enum Constants {
     public static let rewindInterval = "userSettingsRewindInterval"
     public static let forwardInterval = "userSettingsForwardInterval"
 
+    public static let updateProgress = "userSettingsUpdateProgress"
+
     /// Key to store an array of identifiers that need their progress recalculated
     public static let staleProgressIdentifiers = "staleProgressIdentifiers"
 

--- a/Shared/Extensions/UserDefaults+BookPlayer.swift
+++ b/Shared/Extensions/UserDefaults+BookPlayer.swift
@@ -22,4 +22,8 @@ public extension UserDefaults {
   @objc dynamic var userSettingsAllowCellularData: Bool {
     return bool(forKey: Constants.UserDefaults.allowCellularData)
   }
+
+  @objc dynamic var userSettingsBoostVolume: Bool {
+    return bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
+  }
 }

--- a/Shared/Extensions/UserDefaults+BookPlayer.swift
+++ b/Shared/Extensions/UserDefaults+BookPlayer.swift
@@ -26,4 +26,16 @@ public extension UserDefaults {
   @objc dynamic var userSettingsBoostVolume: Bool {
     return bool(forKey: Constants.UserDefaults.boostVolumeEnabled)
   }
+
+  @objc dynamic var userSettingsUpdateProgress: Bool {
+    return bool(forKey: Constants.UserDefaults.updateProgress)
+  }
+
+  @objc dynamic var userSettingsRewindInterval: TimeInterval {
+    return double(forKey: Constants.UserDefaults.rewindInterval)
+  }
+
+  @objc dynamic var userSettingsForwardInterval: TimeInterval {
+    return double(forKey: Constants.UserDefaults.forwardInterval)
+  }
 }


### PR DESCRIPTION
## Purpose

- Add new setting inside the settings-player-controls screen to enable / disable scrubbing on the progress bar on the lock screen (or in the control center)

## Things to be aware of / Things to focus on

- There's now a 'More' button inside the mini controls screen that opens from the player screen, to open the settings player controls
- Also some VoiceOver updates for the mini controls screen, so the + and - icons are accessible