### PR TITLE
Add anonymous id to pre-populated info for email support

### DIFF
--- a/BookPlayer/Settings/SettingsViewModel.swift
+++ b/BookPlayer/Settings/SettingsViewModel.swift
@@ -88,8 +88,16 @@ class SettingsViewModel: ViewModelProtocol {
     self.account = self.accountService.getAccount()
   }
 
+  func hasActiveSubscription() -> Bool {
+    return accountService.hasSyncEnabled()
+  }
+
   func hasMadeDonation() -> Bool {
     return accountService.hasPlusAccess()
+  }
+
+  func getAnonymousId() -> String {
+    return accountService.getAnonymousId() ?? ""
   }
 
   /// Handle registering the value in `UserDefaults`


### PR DESCRIPTION
## Purpose

- Add anonymous id so it's easier to give support to users when they reach out

