### PR TITLE
Fix last played widgets not showing due to artwork size

### DIFF
--- a/BookPlayerWidgets/Phone/LastPlayed/LastPlayedView.swift
+++ b/BookPlayerWidgets/Phone/LastPlayed/LastPlayedView.swift
@@ -16,13 +16,10 @@ struct LastPlayedView: View {
 
   func getArtworkView(for relativePath: String) -> some View {
     ZStack {
-      var uiImage =
-        UIImage(
-          contentsOfFile:
-            ArtworkService.getCachedImageURL(for: relativePath).path
-        )
-        ?? ArtworkService.generateDefaultArtwork(from: model.theme.linkColor)
-      if let uiImage {
+      if let uiImage = WidgetUtils.getArtworkImage(
+        for: relativePath,
+        theme: model.theme
+      ) {
         Image(
           uiImage: uiImage
         )

--- a/BookPlayerWidgets/Phone/RecentBooks/RecentBooksWidgetView.swift
+++ b/BookPlayerWidgets/Phone/RecentBooks/RecentBooksWidgetView.swift
@@ -8,6 +8,7 @@
 
 import BookPlayerKit
 import SwiftUI
+import UIKit
 import WidgetKit
 
 struct BookView: View {
@@ -25,20 +26,23 @@ struct BookView: View {
 
     return VStack(spacing: 5) {
       ZStack {
-        var uiImage =
+        let uiImage =
           UIImage(contentsOfFile: cachedImageURL.path)
           ?? ArtworkService.generateDefaultArtwork(from: theme.linkColor)
 
-        if let uiImage {
+        if let uiImage,
+          WidgetUtils.isValidSize(image: uiImage)
+        {
           Image(uiImage: uiImage)
             .resizable()
             .frame(minWidth: 60, maxWidth: 60, minHeight: 60, maxHeight: 60)
             .aspectRatio(1.0, contentMode: .fit)
             .cornerRadius(8.0)
         } else {
-          Rectangle()
+          Image(systemName: "photo.badge.exclamationmark.fill")
             .frame(width: 60, height: 60)
-            .foregroundColor(Color.gray.opacity(0.2))
+            .background(Color.gray.opacity(0.2))
+            .foregroundColor(Color.white)
             .cornerRadius(8.0)
         }
 


### PR DESCRIPTION
## Bugfix

- If the artwork is too big, the widget extension fails with the following message: `Widget archival failed due to image being too large [11] - (1536, 2039), totalArea: 3131904 > max[2121055.200000].`

## Related tasks

#1230 

## Approach

- It's not clear if the max size varies by device type, but to be safe, we target a lower total area, and transform the uiimage data to a lower resolution image

## Things to be aware of / Things to focus on

- This can only be done for the last played widget, as the recent books widget crashes if there's more than one artwork to process in this same manner