### PR TITLE
Load chapters for m4bs inside volumes

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -225,6 +225,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol {
       if let libraryItem = libraryService.getSimpleItem(with: chapter.relativePath) {
         currentItem = try playbackService.getPlayableItem(from: libraryItem)
       }
+    } else if currentItem?.isBoundBook == true, chapter.relativePath.hasSuffix(".m4b") {
+      /// recently synced m4b files do not have their chapters loaded outright
+      await libraryService.loadChaptersIfNeeded(relativePath: chapter.relativePath, asset: asset)
     }
 
     return asset

--- a/BookPlayerWatch/LocalPlayback/Player/PlayerManager.swift
+++ b/BookPlayerWatch/LocalPlayback/Player/PlayerManager.swift
@@ -223,6 +223,9 @@ final class PlayerManager: NSObject, PlayerManagerProtocol, ObservableObject {
           currentItem = try playbackService.getPlayableItem(from: libraryItem)
         }
       }
+    } else if currentItem?.isBoundBook == true, chapter.relativePath.hasSuffix(".m4b") {
+      /// recently synced m4b files do not have their chapters loaded outright
+      await libraryService.loadChaptersIfNeeded(relativePath: chapter.relativePath, asset: asset)
     }
 
     return asset


### PR DESCRIPTION
## Purpose

- M4bs that are used in volumes and synced to other devices are not showing their chapter list

## Approach

- Add check to load chapters for volumes if the currently playing chapter is an m4b file