### PR TITLE
Update artwork for the mini-player

### DIFF
--- a/BookPlayer/Library/MiniPlayer/MiniPlayerViewModel.swift
+++ b/BookPlayer/Library/MiniPlayer/MiniPlayerViewModel.swift
@@ -52,6 +52,16 @@ class MiniPlayerViewModel {
         )
       }
       .store(in: &disposeBag)
+
+    ArtworkService.artworkUpdatePublisher.sink { [weak self] relativePath in
+      guard
+        let self,
+        self.currentItemInfo.value?.relativePath == relativePath
+      else { return }
+
+      self.currentItemInfo.send(self.currentItemInfo.value)
+    }
+    .store(in: &disposeBag)
   }
 
   func isPlayingObserver() -> AnyPublisher<Bool, Never> {


### PR DESCRIPTION
## Bugfix

- After updating the artwork on the item details, if it was the currently playing item, the mini player wouldn't update its artwork

## Approach

- Add a passthrough publisher to the `ArtworkService`, and reload the mini player when applicable
