### PR TITLE
Fix formatting for bookmarks when exporting

### DIFF
--- a/BookPlayer/Services/BookmarksActivityItemProvider.swift
+++ b/BookPlayer/Services/BookmarksActivityItemProvider.swift
@@ -46,7 +46,10 @@ final class BookmarksActivityItemProvider: UIActivityItemProvider {
     for bookmark in bookmarks {
       guard let chapter = currentItem.getChapter(at: bookmark.time) else { continue }
       let chapterTime = currentItem.getChapterTime(in: chapter, for: bookmark.time)
-      let formattedTime = TimeParser.formatTime(chapterTime)
+      let formattedTime = TimeParser.formatTime(
+        chapterTime,
+        units: [.hour, .minute, .second]
+      )
 
       var chapterTitle = String.localizedStringWithFormat("chapter_number_title".localized, chapter.index)
       /// Add title if it's different from the numeric title (do not consider volumes as titles would be numeric)

--- a/Shared/CommandParser.swift
+++ b/Shared/CommandParser.swift
@@ -246,17 +246,24 @@ public class TimeParser {
 
   // utility function to transform seconds to format MM:SS or HH:MM:SS
   public class func formatTime(_ time: TimeInterval) -> String {
+    return Self.formatTime(
+      time,
+      units: abs(time) < 3600
+        ? [.minute, .second]
+        : [.hour, .minute, .second]
+    )
+  }
+
+  public class func formatTime(
+    _ time: TimeInterval,
+    units: NSCalendar.Unit
+  ) -> String {
     let durationFormatter = DateComponentsFormatter()
 
     durationFormatter.unitsStyle = .positional
     durationFormatter.zeroFormattingBehavior = .pad
     durationFormatter.collapsesLargestUnit = false
-
-    if abs(time) < 3600 {
-      durationFormatter.allowedUnits = [.minute, .second]
-    } else {
-      durationFormatter.allowedUnits = [.hour, .minute, .second]
-    }
+    durationFormatter.allowedUnits = units
 
     return durationFormatter.string(from: time)!
   }


### PR DESCRIPTION
## Bugfix

- Bookmarks was using the same formatting time code as the rest of the app, so whenever the bookmark was at a point less than an hour into the book, it would get exported as MM:SS instead of HH:MM:SS, which can create confusion