### PR TITLE
Remove usage of settings_siri_title

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Forward";
 "settings_skip_description" = "Adjust the amount skipped when using the buttons in the Player or Control Center.";
 "settings_support_title" = "SUPPORT";
-"settings_siri_title" = "SIRI SHORTCUTS";
+"settings_shortcuts_title" = "SHORTCUTS";
 "settings_support_project_title" = "View project on Github";
 "settings_support_project_description" = "Open new issues for your feature requests and errors";
 "settings_support_email_title" = "Send us an email";

--- a/BookPlayer/Settings/SettingsViewController.swift
+++ b/BookPlayer/Settings/SettingsViewController.swift
@@ -343,7 +343,7 @@ class SettingsViewController: UITableViewController, MVVMControllerProtocol, MFM
         return nil
       }
     case .siri:
-      return "settings_siri_title".localized
+      return "settings_shortcuts_title".localized
     case .backups:
       return "settings_backup_title".localized
     case .jellyfin:

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Endavant";
 "settings_skip_description" = "Ajusteu la quantitat que s'omet quan utilitzeu els botons del reproductor o del centre de control.";
 "settings_support_title" = "SUPORT";
-"settings_siri_title" = "Dreceres SIRI";
+"settings_shortcuts_title" = "DRECERES";
 "settings_support_project_title" = "Veure el projecte a Github";
 "settings_support_project_description" = "Obriu una incidència per a les vostres sol·licituds de noves funcions i errors";
 "settings_support_email_title" = "Envieu-nos un correu electrònic";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Přetočit";
 "settings_skip_description" = "Upravte časový interval, který přeskočíte při přetažení obalu alba nebo pomocí tlačítek v ovládacím centru.";
 "settings_support_title" = "PODPORA";
-"settings_siri_title" = "ZKRATKA SIRI";
+"settings_shortcuts_title" = "ZKRATKY";
 "settings_support_project_title" = "Zobrazit projekt na Githubu";
 "settings_support_project_description" = "Vytvořit hlášení chyb a požadavků na funkce";
 "settings_support_email_title" = "Pošlete nám e-mail";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Spol frem";
 "settings_skip_description" = "Justér mængden der springes over, når du bruger knapperne i afspilleren eller i kontrolcenteret.";
 "settings_support_title" = "SUPPORT";
-"settings_siri_title" = "GENVEJE I SIRI";
+"settings_shortcuts_title" = "GENVEJE";
 "settings_support_project_title" = "Se projektet på GitHub";
 "settings_support_project_description" = "Opret sag for dine funktionsanmodninger og fejl";
 "settings_support_email_title" = "Send os en e-mail";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Vorwärts";
 "settings_skip_description" = "Stelle ein, wie viele Sekunden beim Tippen der Tasten zum Überspringen auf dem Wiedergabebildschirm oder im Kontrollzentrum ausgelassen werden sollen.";
 "settings_support_title" = "Hilfe";
-"settings_siri_title" = "Siri Kurzbefehl";
+"settings_shortcuts_title" = "Verknüpfungen";
 "settings_support_project_title" = "Projekt auf GitHub ansehen";
 "settings_support_project_description" = "Erstelle neue GitHub Issues für Wünsche und Fehler";
 "settings_support_email_title" = "Sende uns eine E-Mail";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Προς τα εμπρός";
 "settings_skip_description" = "Προσαρμόστε το ποσό που παραλείπεται όταν χρησιμοποιείτε τα κουμπιά στο πρόγραμμα αναπαραγωγής ή στο Κέντρο ελέγχου.";
 "settings_support_title" = "ΥΠΟΣΤΗΡΙΞΗ";
-"settings_siri_title" = "ΣΥΝΤΟΜΕΥΣεις ΓΙΑ ΤΗ SIRI";
+"settings_shortcuts_title" = "ΣΥΝΤΟΜΕΥΣΕΙΣ";
 "settings_support_project_title" = "Δείτε το έργο στο Github";
 "settings_support_project_description" = "Ανοίξτε νέα θέματα για τα αιτήματα και τα λάθη σας για δυνατότητες";
 "settings_support_email_title" = "Στείλτε μας ένα email";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Forward";
 "settings_skip_description" = "Adjust the amount skipped when using the buttons in the Player or Control Center.";
 "settings_support_title" = "SUPPORT";
-"settings_siri_title" = "SIRI SHORTCUTS";
+"settings_shortcuts_title" = "SHORTCUTS";
 "settings_support_project_title" = "View project on Github";
 "settings_support_project_description" = "Open new issues for your feature requests and errors";
 "settings_support_email_title" = "Send us an email";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Adelante";
 "settings_skip_description" = "Ajusta el tamaño del intervalo de tiempo omitido con cada salto";
 "settings_support_title" = "SOPORTE";
-"settings_siri_title" = "ATAJO DE SIRI";
+"settings_shortcuts_title" = "ATAJOS";
 "settings_support_project_title" = "Ver proyecto en Github";
 "settings_support_project_description" = "Abre nuevos tickets para informarnos de errores y peticiones";
 "settings_support_email_title" = "Envíanos un correo";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Eteenpäin";
 "settings_skip_description" = "Säädä skippauksen kokoa nappeja paineltaessa joko soittimessa tai Ohjauskeskuksessa.";
 "settings_support_title" = "TUKI";
-"settings_siri_title" = "SIRI-PIKAKOMENTO";
+"settings_shortcuts_title" = "PIKANÄPPÄIMET";
 "settings_support_project_title" = "Katso projekti Githubissa";
 "settings_support_project_description" = "Avaa uusia issueita ominaisuuspyynnöillesi ja virheille";
 "settings_support_email_title" = "Lähetä meille sähköpostia";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Avancer";
 "settings_skip_description" = "Ajuste le temps sauté lorsque sont utilisés les boutons dans le Lecteur ou le Centre de contrôle.";
 "settings_support_title" = "SUPPORT";
-"settings_siri_title" = "RACCOURCI SIRI";
+"settings_shortcuts_title" = "RACCOURCIS";
 "settings_support_project_title" = "Voir le projet sur Github";
 "settings_support_project_description" = "Ouvrez des tickets pour vos demandes de fonctionnalité et erreurs";
 "settings_support_email_title" = "Envoyez-nous un courrier électronique";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Előretekerés";
 "settings_skip_description" = "A Lejátszó vagy a Vezérlőközpont gombok használatával előidézhető ugrások időtartamának beállítása.";
 "settings_support_title" = "TÁMOGATÁS";
-"settings_siri_title" = "SIRI PARANCSOK";
+"settings_shortcuts_title" = "PARANCSOK";
 "settings_support_project_title" = "Projekt megtekintése a Githubon";
 "settings_support_project_description" = "Új kéréseket nyithat funkcióigényekkel és felfedezett hibákkal kapcsolatban";
 "settings_support_email_title" = "Küldjön nekünk egy e-mailt";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Avanti";
 "settings_skip_description" = "Regola l'importo saltato quando usi i pulsanti nel Lettore o nel Centro di Controllo.";
 "settings_support_title" = "SUPPORTO";
-"settings_siri_title" = "SCORCIATOIA SIRI";
+"settings_shortcuts_title" = "SCORCIATOIE";
 "settings_support_project_title" = "Visualizza il progetto su Github";
 "settings_support_project_description" = "Apri una nuova issue per richiedere funzionalità o segnalare errori";
 "settings_support_email_title" = "Inviaci una e-mail";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Spol fremover";
 "settings_skip_description" = "Juster hvor mye som hoppes over når du bruker knappene i spilleren eller kontrollsenteret.";
 "settings_support_title" = "STØTTE";
-"settings_siri_title" = "SIRI SNARVEIER";
+"settings_shortcuts_title" = "SNARVEIER";
 "settings_support_project_title" = "Se prosjektet på Github";
 "settings_support_project_description" = "Åpne ny ticket å foreslå nye funksjoner eller rapportere feil";
 "settings_support_email_title" = "Send oss en e-post";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Naar voren";
 "settings_skip_description" = "Pas het bedrag aan dat wordt overgeslagen bij het gebruik van de knoppen in de speler of het controlecentrum.";
 "settings_support_title" = "STEUN";
-"settings_siri_title" = "SIRI Snelkoppelingen";
+"settings_shortcuts_title" = "SNELKOPPELINGEN";
 "settings_support_project_title" = "Bekijk project op Github";
 "settings_support_project_description" = "Open nieuwe problemen voor uw functieverzoeken en fouten";
 "settings_support_email_title" = "Stuur ons een e-mail";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Do przodu";
 "settings_skip_description" = "Dostosuj ilość pomijaną podczas używania przycisków w odtwarzaczu lub centrum sterowania.";
 "settings_support_title" = "WSPARCIE";
-"settings_siri_title" = "SKRÓTY SIRI";
+"settings_shortcuts_title" = "SKRÓTY";
 "settings_support_project_title" = "Zobacz projekt na Github'ie";
 "settings_support_project_description" = "Otwórz nowe zgłoszenia dotyczące żądań nowych funkcji i błędów";
 "settings_support_email_title" = "Wyślij nam wiadomość e-mail";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Avançar";
 "settings_skip_description" = "Ajuste a quantidade saltada ao usar os botões no Player ou no Centro de Controle.";
 "settings_support_title" = "SUPORTE";
-"settings_siri_title" = "ATALHO SIRI";
+"settings_shortcuts_title" = "ATALHOS";
 "settings_support_project_title" = "Veja o projeto no Github";
 "settings_support_project_description" = "Abra novos problemas para os seus pedidos de funcionalidades e erros";
 "settings_support_email_title" = "Envie-nos um e-mail";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Avançar";
 "settings_skip_description" = "Ajustar a quantidade saltada ao utilizar os botões no Player ou no Centro de Controle.";
 "settings_support_title" = "AJUDA";
-"settings_siri_title" = "ATALHOS SIRI";
+"settings_shortcuts_title" = "ATALHOS";
 "settings_support_project_title" = "Ver o projecto no Github";
 "settings_support_project_description" = "Abrir novos problemas para os seus pedidos de funcionalidades e erros";
 "settings_support_email_title" = "Enviar-nos um e-mail";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Înainte";
 "settings_skip_description" = "Ajustați valoarea ignorată atunci când utilizați butoanele din Player sau Centrul de Control.";
 "settings_support_title" = "SUPORT";
-"settings_siri_title" = "COMANDA RAPIDĂ SIRI";
+"settings_shortcuts_title" = "SCURTĂTURI";
 "settings_support_project_title" = "Vizualizați proiectul pe Github";
 "settings_support_project_description" = "Deschideți noi probleme pentru solicitările și erorile dvs. de funcții";
 "settings_support_email_title" = "Trimite-ne un e-mail";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Вперёд";
 "settings_skip_description" = "Настройте шаг перемотки при использовании кнопок в плеере или Центре управления.";
 "settings_support_title" = "ПОДДЕРЖКА";
-"settings_siri_title" = "БЫСТРАЯ КОМАНДА SIRI";
+"settings_shortcuts_title" = "ЯРЛЫКИ";
 "settings_support_project_title" = "Посмотреть проект на Github";
 "settings_support_project_description" = "Создайте новые записи с Вашими пожеланиями и замеченными ошибками";
 "settings_support_email_title" = "Отправить нам письмо";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Dopredu";
 "settings_skip_description" = "Úprava časového intervalu preskočenia pri použití tlačidiel v Prehrávači alebo Ovládacom centre.";
 "settings_support_title" = "PODPORA";
-"settings_siri_title" = "SKRATKY SIRI";
+"settings_shortcuts_title" = "SKRATKY";
 "settings_support_project_title" = "Zobraziť projekt na Githube";
 "settings_support_project_description" = "Vytvorí nové hlásenie chyby alebo požiadavky na funkcie";
 "settings_support_email_title" = "Pošlite nám e-mail";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Framåt";
 "settings_skip_description" = "Justera tiden som hoppas över när du drar albumbilden eller använder knapparna i kontrollpanelen.";
 "settings_support_title" = "HJÄLP";
-"settings_siri_title" = "SIRI GENVÄG";
+"settings_shortcuts_title" = "GENVÄGAR";
 "settings_support_project_title" = "Visa projektet på GitHub";
 "settings_support_project_description" = "Registrera önskemål eller felrapport";
 "settings_support_email_title" = "Skicka e-post";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "İleri Sarma";
 "settings_skip_description" = "Oynatıcı veya Kontrol Merkezi'ndeki düğmeleri kullanırken atlanan miktarı ayarlayın.";
 "settings_support_title" = "DESTEK";
-"settings_siri_title" = "SIRI KISAYOLU";
+"settings_shortcuts_title" = "KISAYOLLAR";
 "settings_support_project_title" = "Projeyi Github'da görüntüle";
 "settings_support_project_description" = "Özellik istekleriniz ve hatalar için yeni sorun açın";
 "settings_support_email_title" = "Bize bir e-posta gönder";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "Вперед";
 "settings_skip_description" = "Налаштування перемотування для кнопок плеєра або центру керування.";
 "settings_support_title" = "Підтримка";
-"settings_siri_title" = "Команди SIRI";
+"settings_shortcuts_title" = "Ярлики";
 "settings_support_project_title" = "Переглянути проєкт на GitHub";
 "settings_support_project_description" = "Створити новий запит на новий функціонал або повідомити про помилку";
 "settings_support_email_title" = "Напишіть нам";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "settings_skip_forward_title" = "快进";
 "settings_skip_description" = "在播放器或控制中间调整略过的时长。";
 "settings_support_title" = "支持";
-"settings_siri_title" = "SIRI 快捷方式";
+"settings_shortcuts_title" = "快捷方式";
 "settings_support_project_title" = "在 Github 上查看项目";
 "settings_support_project_description" = "针对您的功能请求和错误与我们联系";
 "settings_support_email_title" = "向我们发送电子邮件";


### PR DESCRIPTION
## Purpose

The current shortcuts are not really the original Siri shortcuts, so it's no longer necessary to mention Siri in the title