### PR TITLE
Add Jellyfin folder downloads with UI improvements and localization

### DIFF
--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -151,8 +151,10 @@
 "import_preparing_title" = "Preparing to import files";
 "library_add_title" = "Add your first book";
 "invalid_url_title" = "Invalid URL: %@";
-"downloading_file_title" = "Downloading file";
 "progress_title" = "Progress";
+"download_folder_confirmation_title" = "Download Folder";
+"download_folder_confirmation_message" = "Download all %d files from this folder?";
+"download_folder_confirm_button" = "Download";
 "settings_siri_sleeptimer_title" = "Sleep Timer";
 "active_title" = "On";
 "voiceover_currently_playing_title" = "Currently playing %@ by %@";
@@ -342,6 +344,7 @@ We're working hard on providing a seamless experience, if possible, please conta
 "jellyfin_error_unexpected_response" = "Unexpected server response";
 "jellyfin_error_unexpected_response_with_code" = "Unexpected server response (Code: %d - %@)";
 "jellyfin_error_unauthorized" = "Sign In failed. Check your username and password.";
+"jellyfin_selection_count" = "%d of %d Items";
 "file_size_unknown" = "Unknown size";
 "runtime_unknown" = "Unknown duration";
 "subscription_required_title" = "Subscription required";

--- a/BookPlayer/Import/ImportViewController.swift
+++ b/BookPlayer/Import/ImportViewController.swift
@@ -34,7 +34,7 @@ final class ImportViewController: UIViewController, Storyboarded {
 
   private func bindFilesObserver() {
     self.viewModel.$files.sink { [weak self] files in
-      self?.files = files
+      self?.files = files.sorted()
       self?.tableView.reloadData()
 
       self?.navigationItem.rightBarButtonItem?.isEnabled = files.count > 0
@@ -68,16 +68,16 @@ extension ImportViewController: UITableViewDataSource {
     // swiftlint:enable force_cast
     let fileItem = self.files[indexPath.row]
 
-    let imageName = fileItem.fileUrl.isDirectoryFolder ? "folder" : "waveform"
+    let imageName = fileItem.fileURL.isDirectoryFolder ? "folder" : "waveform"
     cell.iconImageView.image = UIImage(systemName: imageName)
-    cell.filenameLabel.text = fileItem.getFileName()
+    cell.filenameLabel.text = fileItem.name
     cell.countLabel.text = fileItem.subItems > 0
     ? String.localizedStringWithFormat("files_title".localized, fileItem.subItems)
     : ""
 
     cell.onDeleteTap = { [weak self] in
       do {
-        try self?.viewModel.deleteItem(fileItem.fileUrl)
+        try self?.viewModel.deleteItem(fileItem.fileURL)
       } catch {
         self?.showAlert("error_title".localized, message: error.localizedDescription)
       }

--- a/BookPlayer/Import/ImportViewModel.swift
+++ b/BookPlayer/Import/ImportViewModel.swift
@@ -38,7 +38,7 @@ final class ImportViewModel: NSObject, ObservableObject {
 
       self.cleanupWatchters()
       // make a copy of the files
-      self.observedFiles = files.map { ImportFileItem(fileUrl: $0) }
+      self.observedFiles = files.map { ImportFileItem(fileURL: $0) }
       self.subscribeNewFolders()
       self.refreshData()
     }.store(in: &disposeBag)
@@ -51,14 +51,18 @@ final class ImportViewModel: NSObject, ObservableObject {
 
   private func subscribeNewFolders() {
     for item in self.observedFiles {
-      guard item.fileUrl.isDirectoryFolder else { continue }
-
-      let enumerator = FileManager.default.enumerator(at: item.fileUrl,
-                                                      includingPropertiesForKeys: [.isDirectoryKey],
-                                                      options: [.skipsHiddenFiles], errorHandler: { (url, error) -> Bool in
-        print("directoryEnumerator error at \(url): ", error)
-        return true
-      })!
+      guard
+        item.fileURL.isDirectoryFolder,
+        let enumerator = FileManager.default.enumerator(
+          at: item.fileURL,
+          includingPropertiesForKeys: [.isDirectoryKey],
+          options: [.skipsHiddenFiles],
+          errorHandler: { (url, error) -> Bool in
+            print("directoryEnumerator error at \(url): ", error)
+            return true
+          }
+        )
+      else { continue }
 
       for case let fileURL as URL in enumerator {
         if !fileURL.isDirectoryFolder {
@@ -85,7 +89,7 @@ final class ImportViewModel: NSObject, ObservableObject {
 
   public func getTotalItems() -> Int {
     return self.files.reduce(0) { result, item in
-      return item.fileUrl.isDirectoryFolder
+      return item.fileURL.isDirectoryFolder
       ? result + item.subItems
       : result + 1
     }

--- a/BookPlayer/Import/Models/ImportFileItem.swift
+++ b/BookPlayer/Import/Models/ImportFileItem.swift
@@ -8,19 +8,28 @@
 
 import Foundation
 
-public class ImportFileItem: NSCopying {
-  public var fileUrl: URL
+public class ImportFileItem: NSCopying, Comparable {
+  public var fileURL: URL
+  public var name: String
   public var subItems = 0
 
-  public init(fileUrl: URL) {
-    self.fileUrl = fileUrl
+  public init(fileURL: URL) {
+    self.fileURL = fileURL
+    self.name = fileURL.lastPathComponent
   }
 
   public func copy(with zone: NSZone? = nil) -> Any {
-    return ImportFileItem(fileUrl: self.fileUrl)
+    ImportFileItem(fileURL: fileURL)
   }
+}
 
-  public func getFileName() -> String {
-    return self.fileUrl.lastPathComponent
+// MARK: - Comparable
+extension ImportFileItem {
+  public static func < (lhs: ImportFileItem, rhs: ImportFileItem) -> Bool {
+    lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+  }
+  
+  public static func == (lhs: ImportFileItem, rhs: ImportFileItem) -> Bool {
+    lhs.fileURL == rhs.fileURL
   }
 }

--- a/BookPlayer/Import/Models/ImportOperation.swift
+++ b/BookPlayer/Import/Models/ImportOperation.swift
@@ -199,7 +199,26 @@ public class ImportOperation: Operation {
   }
 
   public override func main() {
+    self.detectFolderOrganization()
     self.processFile(from: self.files)
+  }
+
+  private func detectFolderOrganization() {
+    guard files.count > 1 else { return }
+
+    let documentsURL = DataManager.getDocumentsFolderURL()
+    var parentFolders = Set<String>()
+
+    for file in files {
+        let parentURL = file.deletingLastPathComponent()
+
+        guard parentURL != documentsURL else { continue }
+
+        parentFolders.insert(parentURL.lastPathComponent)
+    }
+
+    guard parentFolders.count == 1, let folderName = parentFolders.first else { return }
+    suggestedFolderName = folderName
   }
 
   func processFile(from files: [URL]) {

--- a/BookPlayer/Jellyfin/JellyfinRootView.swift
+++ b/BookPlayer/Jellyfin/JellyfinRootView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 @MainActor
 final class BPNavigation: ObservableObject {
+  var dismiss: DismissAction?
+
   @Published var path = NavigationPath()
 
   nonisolated init() {}
@@ -75,6 +77,9 @@ struct JellyfinRootView: View {
             }
           }
         }
+    }
+    .onAppear {
+        navigation.dismiss = dismiss
     }
   }
 }

--- a/BookPlayer/Jellyfin/Library Screen/GridLayout/JellyfinLibraryGridView.swift
+++ b/BookPlayer/Jellyfin/Library Screen/GridLayout/JellyfinLibraryGridView.swift
@@ -81,6 +81,7 @@ final class MockJellyfinLibraryViewModel: JellyfinLibraryViewModelProtocol, Obse
   var editMode: EditMode = .inactive
   var selectedItems: Set<JellyfinLibraryItem.ID> = []
   var downloadRemaining: Int = 0
+  var showingDownloadConfirmation: Bool = false
 
   init(data: JellyfinLibraryLevelData) {
     self.data = data
@@ -96,6 +97,8 @@ final class MockJellyfinLibraryViewModel: JellyfinLibraryViewModelProtocol, Obse
   func onSelectTapped(for item: JellyfinLibraryItem) {}
   func onSelectAllTapped() {}
   func onDownloadTapped() {}
+  func onDownloadFolderTapped() {}
+  func confirmDownloadFolder() {}
 }
 
 #Preview("top level") {

--- a/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
+++ b/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
@@ -37,6 +37,17 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
     .onDisappear { viewModel.cancelFetchItems() }
     .errorAlert(error: $viewModel.error)
     .environment(\.editMode, $viewModel.editMode)
+    .confirmationDialog(
+      "download_folder_confirmation_title".localized,
+      isPresented: $viewModel.showingDownloadConfirmation
+    ) {
+      Button("download_folder_confirm_button".localized) {
+        viewModel.confirmDownloadFolder()
+      }
+      Button("cancel_button".localized, role: .cancel) { }
+    } message: {
+      Text(String.localizedStringWithFormat("download_folder_confirmation_message".localized, viewModel.totalItems))
+    }
     .toolbar {
       ToolbarItem(placement: .principal) {
         navigationTitle
@@ -60,11 +71,14 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
   var toolbarTrailing: some View {
     if !viewModel.editMode.isEditing {
       Menu {
-        if #available(iOS 17.0, *) {
-          Section {
+        Section {
+          if #available(iOS 17.0, *) {
             Button(action: viewModel.onEditToggleSelectTapped) {
               Label("Select".localized, systemImage: "checkmark.circle")
             }
+          }
+          Button(action: viewModel.onDownloadFolderTapped) {
+            Label("Download".localized, systemImage: "arrow.down.to.line")
           }
         }
 

--- a/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
+++ b/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
@@ -16,7 +16,7 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
 
   var navigationTitle: Text {
     if viewModel.editMode.isEditing, !viewModel.selectedItems.isEmpty {
-      return Text("\(viewModel.selectedItems.count) of \(viewModel.totalItems) Items")
+      return Text(String(format: "jellyfin_selection_count".localized, viewModel.selectedItems.count, viewModel.totalItems))
     } else {
       return Text(viewModel.navigationTitle)
     }
@@ -74,11 +74,11 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
         Section {
           if #available(iOS 17.0, *) {
             Button(action: viewModel.onEditToggleSelectTapped) {
-              Label("Select".localized, systemImage: "checkmark.circle")
+              Label("select_title".localized, systemImage: "checkmark.circle")
             }
           }
           Button(action: viewModel.onDownloadFolderTapped) {
-            Label("Download".localized, systemImage: "arrow.down.to.line")
+            Label("download_title".localized, systemImage: "arrow.down.to.line")
           }
         }
 
@@ -88,7 +88,7 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
       }
     } else {
       Button(action: viewModel.onEditToggleSelectTapped) {
-        Text("Done".localized).bold()
+        Text("done_title".localized).bold()
       }
     }
   }

--- a/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
+++ b/BookPlayer/Jellyfin/Library Screen/JellyfinLibraryView.swift
@@ -54,16 +54,6 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
         }
       }
     }
-    .overlay {
-      if viewModel.downloadRemaining > 0 {
-        LoadingHUD(
-          remaining: viewModel.downloadRemaining,
-          total: viewModel.selectedItems.count
-        )
-        .transition(.opacity)
-      }
-    }
-    .animation(.easeInOut(duration: 0.3), value: viewModel.downloadRemaining != 0)
   }
 
   @ViewBuilder
@@ -117,66 +107,5 @@ struct JellyfinLibraryView<Model: JellyfinLibraryViewModelProtocol>: View {
       Image(systemName: "arrow.down.to.line")
     }
     .disabled(viewModel.selectedItems.isEmpty)
-  }
-}
-
-extension JellyfinLibraryView {
-  struct LoadingHUD: View {
-    let remaining: Int
-    let total: Int
-
-    private var downloaded: Int { total - remaining }
-
-    private var progress: Double {
-      guard total > 0 else { return 0 }
-      return Double(downloaded) / Double(total)
-    }
-
-    var body: some View {
-      ZStack {
-        Color.black.opacity(0.4)
-          .ignoresSafeArea()
-          .onTapGesture {}
-
-        VStack(spacing: 24) {
-          ZStack {
-            Circle()
-              .stroke(Color.white.opacity(0.3), lineWidth: 6)
-              .frame(width: 80, height: 80)
-
-            Circle()
-              .trim(from: 0, to: progress)
-              .stroke(Color.white, lineWidth: 6)
-              .frame(width: 80, height: 80)
-              .rotationEffect(Angle(degrees: -90))
-              .animation(.easeInOut(duration: 0.5), value: progress)
-
-            Text("\(downloaded)")
-              .foregroundColor(.white)
-              .font(.title2)
-              .fontWeight(.semibold)
-          }
-
-          VStack(spacing: 8) {
-            HStack {
-              ProgressView()
-                .progressViewStyle(CircularProgressViewStyle(tint: .white))
-
-              Text("Downloading...".localized)
-                .foregroundColor(.white)
-                .font(.headline)
-            }
-
-            Text("\(downloaded) of \(total) items".localized)
-              .foregroundColor(.white.opacity(0.8))
-              .font(.subheadline)
-          }
-        }
-        .padding(32)
-        .background(Color.black.opacity(0.85))
-        .cornerRadius(16)
-        .shadow(radius: 10)
-      }
-    }
   }
 }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -201,8 +201,8 @@ class ItemListViewController: UIViewController, MVVMControllerProtocol, Storyboa
               let progress = userInfo["progress"] as? String else {
           return
         }
-
-        self.showLoadView(true, title: "downloading_file_title".localized, subtitle: "\("progress_title".localized) \(progress)%")
+        let title = String.localizedStringWithFormat("downloading_file_title".localized, 1)
+        self.showLoadView(true, title: title, subtitle: "\("progress_title".localized) \(progress)%")
       }
       .store(in: &disposeBag)
 
@@ -664,7 +664,7 @@ extension ItemListViewController {
   }
 
   func showLoadView(_ show: Bool, title: String? = nil, subtitle: String? = nil) {
-    guard self.isViewLoaded && self.view.window != nil else {
+    guard self.isViewLoaded else {
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
         self?.showLoadView(show, title: title, subtitle: subtitle)
       }

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "التحضير لاستيراد الملفات";
 "library_add_title" = "أضف كتابك الأول";
 "invalid_url_title" = "URL غير صالح: %@";
-"downloading_file_title" = "تحميل الملف";
 "progress_title" = "التقدم";
 "settings_siri_sleeptimer_title" = "مؤقت النوم";
 "active_title" = "تشغيل";
@@ -343,6 +342,7 @@
 "jellyfin_error_unexpected_response" = "استجابة غير متوقعة من الخادم";
 "jellyfin_error_unexpected_response_with_code" = "استجابة غير متوقعة من الخادم (الرمز: %d - %@ )";
 "jellyfin_error_unauthorized" = "فشل تسجيل الدخول. تحقق من اسم المستخدم وكلمة المرور.";
+"jellyfin_selection_count" = "%d من %d عناصر";
 "file_size_unknown" = "حجم غير معروف";
 "runtime_unknown" = "مدة غير معروفة";
 "Swipe rows to see download options" = "اسحب لرؤية خيارات التنزيل";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "تمكين البحث في شاشة القفل";
 "donate_title" = "تبرع";
 "bookmark_automatic_sleep_title" = "آخر موضع تم فيه عند تشغيل مؤقت السكون";
+"download_folder_confirmation_title" = "تحميل المجلد";
+"download_folder_confirmation_message" = "تحميل جميع الملفات %d من هذا المجلد؟";
+"download_folder_confirm_button" = "تحميل";

--- a/BookPlayer/ar.lproj/Localizable.stringsdict
+++ b/BookPlayer/ar.lproj/Localizable.stringsdict
@@ -98,5 +98,29 @@
         <string>تتم معالجة %d ملف</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>zero</key>
+        <string>تنزيل ملفات</string>
+        <key>one</key>
+        <string>تنزيل ملف واحد</string>
+        <key>two</key>
+        <string>تنزيل ملفين</string>
+        <key>few</key>
+        <string>تنزيل %d ملفات</string>
+        <key>many</key>
+        <string>تنزيل %d ملفًا</string>
+        <key>other</key>
+        <string>تنزيل %d ملف</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Preparant la importació de fitxers";
 "library_add_title" = "Afegeix el teu primer llibre";
 "invalid_url_title" = "URL no vàlida: %@";
-"downloading_file_title" = "S'està baixant el fitxer";
 "progress_title" = "Progrés";
 "settings_siri_sleeptimer_title" = "Temporitzador de suspensió";
 "active_title" = "Activat";
@@ -343,6 +342,7 @@ Estem treballant dur per oferir una experiència perfecta; si és possible, pose
 "jellyfin_error_unexpected_response" = "Resposta del servidor inesperada";
 "jellyfin_error_unexpected_response_with_code" = "Resposta del servidor inesperada (Codi: %d - %@)";
 "jellyfin_error_unauthorized" = "No s'ha pogut iniciar la sessió. Comproveu el vostre nom d'usuari i contrasenya.";
+"jellyfin_selection_count" = "%d de %d Elements";
 "file_size_unknown" = "Mida desconeguda";
 "runtime_unknown" = "Durada desconeguda";
 "Swipe rows to see download options" = "Feu lliscar les files per veure les opcions de baixada";
@@ -350,3 +350,6 @@ Estem treballant dur per oferir una experiència perfecta; si és possible, pose
 "settings_seekprogressbar_description" = "Activa la cerca a la pantalla de bloqueig";
 "donate_title" = "Donar";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Baixar carpeta";
+"download_folder_confirmation_message" = "Baixar tots els %d fitxers d'aquesta carpeta?";
+"download_folder_confirm_button" = "Baixar";

--- a/BookPlayer/ca.lproj/Localizable.stringsdict
+++ b/BookPlayer/ca.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Processant %d fitxers</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Descarregant 1 fitxer</string>
+        <key>other</key>
+        <string>Descarregant %d fitxers</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Příprava importu souborů";
 "library_add_title" = "Přidejte vaši první knihu";
 "invalid_url_title" = "Neplatná adresa URL: %@";
-"downloading_file_title" = "Stahování souboru";
 "progress_title" = "Pokrok";
 "settings_siri_sleeptimer_title" = "Časovač";
 "active_title" = "Aktivní";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Neočekávaná odpověď serveru";
 "jellyfin_error_unexpected_response_with_code" = "Neočekávaná odpověď serveru (kód: %d – %@ )";
 "jellyfin_error_unauthorized" = "Přihlášení se nezdařilo. Zkontrolujte své uživatelské jméno a heslo.";
+"jellyfin_selection_count" = "%d z %d Poživek";
 "file_size_unknown" = "Neznámá velikost";
 "runtime_unknown" = "Neznámá doba trvání";
 "subscription_required_title" = "Je vyžadováno předplatné";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Darovat";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Stáhnout složku";
+"download_folder_confirmation_message" = "Stáhnout všechny %d soubory z této složky?";
+"download_folder_confirm_button" = "Stáhnout";

--- a/BookPlayer/cs.lproj/Localizable.stringsdict
+++ b/BookPlayer/cs.lproj/Localizable.stringsdict
@@ -82,5 +82,25 @@
         <string>Zpracování %d souborů</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Stahování 1 souboru</string>
+        <key>few</key>
+        <string>Stahování %d souborů</string>
+        <key>many</key>
+        <string>Stahování %d souborů</string>
+        <key>other</key>
+        <string>Stahování %d souborů</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Forbereder import af filer";
 "library_add_title" = "Tilføj din første bog";
 "invalid_url_title" = "Ugyldig URL: %@";
-"downloading_file_title" = "Henter fil";
 "progress_title" = "Fremskridt";
 "settings_siri_sleeptimer_title" = "Sleeptimer";
 "active_title" = "Aktiv";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Uventet serversvar";
 "jellyfin_error_unexpected_response_with_code" = "Uventet serversvar (Kode: %d - %@ )";
 "jellyfin_error_unauthorized" = "Log ind mislykkedes. Tjek dit brugernavn og adgangskode.";
+"jellyfin_selection_count" = "%d af %d Elementer";
 "file_size_unknown" = "Ukendt størrelse";
 "runtime_unknown" = "Ukendt varighed";
 "subscription_required_title" = "Kræver abonnement";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Doner";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Download mappe";
+"download_folder_confirmation_message" = "Download alle %d filer fra denne mappe?";
+"download_folder_confirm_button" = "Download";

--- a/BookPlayer/da.lproj/Localizable.stringsdict
+++ b/BookPlayer/da.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Behandler %d filer</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Henter 1 fil</string>
+        <key>other</key>
+        <string>Henter %d filer</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Import wird vorbereitet";
 "library_add_title" = "Füge dein erstes Buch hinzu";
 "invalid_url_title" = "Ungültige URL: %@";
-"downloading_file_title" = "Datei wird heruntergeladen";
 "progress_title" = "Fortschritt";
 "settings_siri_sleeptimer_title" = "Einschlaf-Timer";
 "active_title" = "Aktiv";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Unerwartete Serverantwort";
 "jellyfin_error_unexpected_response_with_code" = "Unerwartete Serverantwort (Code: %d - %@ )";
 "jellyfin_error_unauthorized" = "Anmeldung fehlgeschlagen. Überprüfen Sie Ihren Benutzernamen und Ihr Passwort.";
+"jellyfin_selection_count" = "%d von %d Elementen";
 "file_size_unknown" = "Unbekannte Größe";
 "runtime_unknown" = "Unbekannte Dauer";
 "subscription_required_title" = "Abonnement erforderlich";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Spenden";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Ordner herunterladen";
+"download_folder_confirmation_message" = "Alle %d Dateien aus diesem Ordner herunterladen?";
+"download_folder_confirm_button" = "Herunterladen";

--- a/BookPlayer/de.lproj/Localizable.stringsdict
+++ b/BookPlayer/de.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>%d Dateien werden verarbeitet</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>1 Datei wird heruntergeladen</string>
+        <key>other</key>
+        <string>%d Dateien werden heruntergeladen</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Προετοιμασία για εισαγωγή αρχείων";
 "library_add_title" = "Προσθέστε το πρώτο σας βιβλίο";
 "invalid_url_title" = "Μη έγκυρη διεύθυνση URL: %@";
-"downloading_file_title" = "Λήψη αρχείου";
 "progress_title" = "Πρόοδος";
 "settings_siri_sleeptimer_title" = "Χρονοδιακόπτης ύπνου";
 "active_title" = "Επί";
@@ -343,6 +342,7 @@
 "jellyfin_error_unexpected_response" = "Απροσδόκητη απόκριση διακομιστή";
 "jellyfin_error_unexpected_response_with_code" = "Μη αναμενόμενη απόκριση διακομιστή (Κωδικός: %d - %@ )";
 "jellyfin_error_unauthorized" = "Η σύνδεση απέτυχε. Ελέγξτε το όνομα χρήστη και τον κωδικό πρόσβασής σας.";
+"jellyfin_selection_count" = "%d από %d Στοιχεία";
 "file_size_unknown" = "Άγνωστο μέγεθος";
 "runtime_unknown" = "Άγνωστη διάρκεια";
 "Swipe rows to see download options" = "Σύρετε σειρές για να δείτε τις επιλογές λήψης";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Ενεργοποιήστε την αναζήτηση στην οθόνη κλειδώματος";
 "donate_title" = "Προσφέρω";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Κατέβασμα φακέλου";
+"download_folder_confirmation_message" = "Κατέβασμα όλων των %d αρχείων από αυτόν τον φάκελο;";
+"download_folder_confirm_button" = "Κατέβασμα";

--- a/BookPlayer/el.lproj/Localizable.stringsdict
+++ b/BookPlayer/el.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Επεξεργασία %d αρχείων</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Λήψη 1 αρχείου</string>
+        <key>other</key>
+        <string>Λήψη %d αρχείων</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Preparing to import files";
 "library_add_title" = "Add your first book";
 "invalid_url_title" = "Invalid URL: %@";
-"downloading_file_title" = "Downloading file";
 "progress_title" = "Progress";
 "settings_siri_sleeptimer_title" = "Sleep Timer";
 "active_title" = "On";
@@ -342,6 +341,7 @@ We're working hard on providing a seamless experience, if possible, please conta
 "jellyfin_error_unexpected_response" = "Unexpected server response";
 "jellyfin_error_unexpected_response_with_code" = "Unexpected server response (Code: %d - %@)";
 "jellyfin_error_unauthorized" = "Sign In failed. Check your username and password.";
+"jellyfin_selection_count" = "%d of %d Items";
 "file_size_unknown" = "Unknown size";
 "runtime_unknown" = "Unknown duration";
 "subscription_required_title" = "Subscription required";
@@ -350,3 +350,6 @@ We're working hard on providing a seamless experience, if possible, please conta
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Donate";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Download Folder";
+"download_folder_confirmation_message" = "Download all %d files from this folder?";
+"download_folder_confirm_button" = "Download";

--- a/BookPlayer/en.lproj/Localizable.stringsdict
+++ b/BookPlayer/en.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Processing %d files</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Downloading 1 file</string>
+        <key>other</key>
+        <string>Downloading %d files</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Preparando la importación de archivos";
 "library_add_title" = "Agrega tu primer libro";
 "invalid_url_title" = "URL no válida: %@";
-"downloading_file_title" = "Descargando archivo";
 "progress_title" = "Progreso";
 "settings_siri_sleeptimer_title" = "Temporizador de suspensión";
 "active_title" = "Activo";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Respuesta inesperada del servidor";
 "jellyfin_error_unexpected_response_with_code" = "Respuesta inesperada del servidor (Código: %d - %@ )";
 "jellyfin_error_unauthorized" = "Error al iniciar sesión. Verifique su nombre de usuario y contraseña.";
+"jellyfin_selection_count" = "%d de %d Elementos";
 "file_size_unknown" = "Tamaño desconocido";
 "runtime_unknown" = "Duración desconocida";
 "subscription_required_title" = "Se requiere suscripción";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Donar";
 "bookmark_automatic_sleep_title" = "Última posición antes de que inicie el temporizador de suspensión";
+"download_folder_confirmation_title" = "Descargar carpeta";
+"download_folder_confirmation_message" = "¿Descargar todos los %d archivos de esta carpeta?";
+"download_folder_confirm_button" = "Descargar";

--- a/BookPlayer/es.lproj/Localizable.stringsdict
+++ b/BookPlayer/es.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Procesando %d archivos</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Descargando 1 archivo</string>
+        <key>other</key>
+        <string>Descargando %d archivos</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Valmistellaan tiedostojen tuontia";
 "library_add_title" = "Lisää ensimmäinen kirjasi";
 "invalid_url_title" = "Virheellinen URL-osoite: %@";
-"downloading_file_title" = "Ladataan tiedostoa";
 "progress_title" = "Edistyminen";
 "settings_siri_sleeptimer_title" = "Uniajastin";
 "active_title" = "Päällä";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Odottamaton palvelimen vastaus";
 "jellyfin_error_unexpected_response_with_code" = "Odottamaton palvelimen vastaus (Koodi: %d - %@ )";
 "jellyfin_error_unauthorized" = "Kirjautuminen epäonnistui. Tarkista käyttäjätunnuksesi ja salasanasi.";
+"jellyfin_selection_count" = "%d / %d Kohdetta";
 "file_size_unknown" = "Tuntematon koko";
 "runtime_unknown" = "Tuntematon kesto";
 "subscription_required_title" = "Tilaus vaaditaan";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Lahjoittaa";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Lataa kansio";
+"download_folder_confirmation_message" = "Ladataanko kaikki %d tiedostoa tästä kansiosta?";
+"download_folder_confirm_button" = "Lataa";

--- a/BookPlayer/fi.lproj/Localizable.stringsdict
+++ b/BookPlayer/fi.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Työstetään %d tiedostoa</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Ladataan 1 tiedostoa</string>
+        <key>other</key>
+        <string>Ladataan %d tiedostoa</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Préparation à l'importation de fichiers";
 "library_add_title" = "Ajoutez votre premier livre";
 "invalid_url_title" = "URL non valide : %@";
-"downloading_file_title" = "Téléchargement du fichier";
 "progress_title" = "Avancement";
 "settings_siri_sleeptimer_title" = "Mise en veille";
 "active_title" = "Actif";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Réponse inattendue du serveur";
 "jellyfin_error_unexpected_response_with_code" = "Réponse inattendue du serveur (Code : %d - %@ )";
 "jellyfin_error_unauthorized" = "La connexion a échoué. Vérifiez votre nom d'utilisateur et votre mot de passe.";
+"jellyfin_selection_count" = "%d sur %d Éléments";
 "file_size_unknown" = "Taille inconnue";
 "runtime_unknown" = "Durée inconnue";
 "subscription_required_title" = "Abonnement requis";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Faire un don";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Télécharger le dossier";
+"download_folder_confirmation_message" = "Télécharger tous les %d fichiers de ce dossier ?"; 
+"download_folder_confirm_button" = "Télécharger";

--- a/BookPlayer/fr.lproj/Localizable.stringsdict
+++ b/BookPlayer/fr.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Traitement de %d fichiers</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Téléchargement de 1 fichier</string>
+        <key>other</key>
+        <string>Téléchargement de %d fichiers</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Fájlok importálásának előkészítése";
 "library_add_title" = "Az első könyv hozzáadása";
 "invalid_url_title" = "Érvénytelen URL: %@";
-"downloading_file_title" = "Fájl letöltése";
 "progress_title" = "Folyamat";
 "settings_siri_sleeptimer_title" = "Alvó állapot időzítése";
 "active_title" = "Be";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Váratlan szerver válasz";
 "jellyfin_error_unexpected_response_with_code" = "Váratlan szerverválasz (Kód: %d - %@ )";
 "jellyfin_error_unauthorized" = "Sikertelen bejelentkezés. Ellenőrizze felhasználónevét és jelszavát.";
+"jellyfin_selection_count" = "%d / %d Elem";
 "file_size_unknown" = "Ismeretlen méret";
 "runtime_unknown" = "Ismeretlen időtartam";
 "subscription_required_title" = "Előfizetés szükséges";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Adományoz";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Mappa letöltése";
+"download_folder_confirmation_message" = "Letölti az összes %d fájlt ebből a mappából?";
+"download_folder_confirm_button" = "Letöltés";

--- a/BookPlayer/hu.lproj/Localizable.stringsdict
+++ b/BookPlayer/hu.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>%d fájl feldolgozása</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>1 fájl letöltése</string>
+        <key>other</key>
+        <string>%d fájl letöltése</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Preparazione per l'importazione dei file";
 "library_add_title" = "Aggiungi il tuo primo libro";
 "invalid_url_title" = "URL invalido: %@";
-"downloading_file_title" = "File in scaricamento";
 "progress_title" = "Progresso";
 "settings_siri_sleeptimer_title" = "Timer Spegnimento";
 "active_title" = "Attivo";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Risposta imprevista del server";
 "jellyfin_error_unexpected_response_with_code" = "Risposta imprevista del server (codice: %d - %@ )";
 "jellyfin_error_unauthorized" = "Accesso non riuscito. Controlla il tuo nome utente e la tua password.";
+"jellyfin_selection_count" = "%d di %d Elementi";
 "file_size_unknown" = "Dimensioni sconosciute";
 "runtime_unknown" = "Durata sconosciuta";
 "subscription_required_title" = "Abbonamento richiesto";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Donare";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Scarica cartella";
+"download_folder_confirmation_message" = "Scaricare tutti i %d file da questa cartella?";
+"download_folder_confirm_button" = "Scarica";

--- a/BookPlayer/it.lproj/Localizable.stringsdict
+++ b/BookPlayer/it.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Processando %d file</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Scaricando 1 file</string>
+        <key>other</key>
+        <string>Scaricando %d file</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "ファイルの読み込みの準備中";
 "library_add_title" = "最初のブックを追加";
 "invalid_url_title" = "無効なURL: %@";
-"downloading_file_title" = "ダウンロード中のファイル";
 "progress_title" = "進捗状況";
 "settings_siri_sleeptimer_title" = "スリープタイマー";
 "active_title" = "オン";
@@ -343,6 +342,7 @@
 "jellyfin_error_unexpected_response" = "サーバからの予期しない応答";
 "jellyfin_error_unexpected_response_with_code" = "サーバからの予期しない応答（コード: %d - %@）";
 "jellyfin_error_unauthorized" = "サインインできませんでした。ユーザ名とパスワードを確認してください。";
+"jellyfin_selection_count" = "%d / %d アイテム";
 "file_size_unknown" = "不明なサイズ";
 "runtime_unknown" = "不明な再生時間";
 "Swipe rows to see download options" = "スワイプしてダウンロードオプションを表示";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "ロック画面でシークを有効にします。";
 "donate_title" = "寄付";
 "bookmark_automatic_sleep_title" = "スリープタイマーがオンになった最後の位置";
+"download_folder_confirmation_title" = "フォルダをダウンロード";
+"download_folder_confirmation_message" = "このフォルダからすべての %d ファイルをダウンロードしますか？";
+"download_folder_confirm_button" = "ダウンロード";

--- a/BookPlayer/ja.lproj/Localizable.stringsdict
+++ b/BookPlayer/ja.lproj/Localizable.stringsdict
@@ -58,5 +58,19 @@
         <string>%d個のファイルの読み込み処理中</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>other</key>
+        <string>%d個のファイルをダウンロード中</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Forbereder import av filer";
 "library_add_title" = "Legg til din første bok";
 "invalid_url_title" = "Ugyldig URL: %@";
-"downloading_file_title" = "Laster ned fil";
 "progress_title" = "Fremdrift";
 "settings_siri_sleeptimer_title" = "Søvntimer";
 "active_title" = "På";
@@ -342,6 +341,7 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "jellyfin_error_unexpected_response" = "Uventet serverrespons";
 "jellyfin_error_unexpected_response_with_code" = "Uventet serverrespons (kode: %d - %@ )";
 "jellyfin_error_unauthorized" = "Pålogging mislyktes. Sjekk brukernavnet og passordet ditt.";
+"jellyfin_selection_count" = "%d av %d Elementer";
 "file_size_unknown" = "Ukjent størrelse";
 "runtime_unknown" = "Ukjent varighet";
 "subscription_required_title" = "Abonnement kreves";
@@ -350,3 +350,6 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Donere";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Last ned mappe";
+"download_folder_confirmation_message" = "Last ned alle %d filer fra denne mappen?";
+"download_folder_confirm_button" = "Last ned";

--- a/BookPlayer/nb.lproj/Localizable.stringsdict
+++ b/BookPlayer/nb.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Behandler %d filer</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Laster ned 1 fil</string>
+        <key>other</key>
+        <string>Laster ned %d filer</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Bestanden importeren voorbereiden";
 "library_add_title" = "Voeg je eerste boek toe";
 "invalid_url_title" = "Ongeldige URL: %@";
-"downloading_file_title" = "Bestand aan het downloaden";
 "progress_title" = "Voortgang";
 "settings_siri_sleeptimer_title" = "Slaaptimer";
 "active_title" = "Op";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Onverwachte serverreactie";
 "jellyfin_error_unexpected_response_with_code" = "Onverwachte serverrespons (Code: %d - %@ )";
 "jellyfin_error_unauthorized" = "Aanmelden mislukt. Controleer uw gebruikersnaam en wachtwoord.";
+"jellyfin_selection_count" = "%d van %d Items";
 "file_size_unknown" = "Onbekende grootte";
 "runtime_unknown" = "Onbekende duur";
 "subscription_required_title" = "Abonnement vereist";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Doneren";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Map downloaden";
+"download_folder_confirmation_message" = "Alle %d bestanden uit deze map downloaden?";
+"download_folder_confirm_button" = "Downloaden";

--- a/BookPlayer/nl.lproj/Localizable.stringsdict
+++ b/BookPlayer/nl.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Verwerken van %d bestanden</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Downloaden van 1 bestand</string>
+        <key>other</key>
+        <string>Downloaden van %d bestanden</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Przygotowanie do importu plików";
 "library_add_title" = "Dodaj swoją pierwszą książkę";
 "invalid_url_title" = "Nieprawidłowy adres URL: %@";
-"downloading_file_title" = "Pobieranie pliku";
 "progress_title" = "Postęp";
 "settings_siri_sleeptimer_title" = "Wyłącznik czasowy";
 "active_title" = "Włącz";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Nieoczekiwana odpowiedź serwera";
 "jellyfin_error_unexpected_response_with_code" = "Nieoczekiwana odpowiedź serwera (Kod: %d - %@ )";
 "jellyfin_error_unauthorized" = "Logowanie nie powiodło się. Sprawdź swoją nazwę użytkownika i hasło.";
+"jellyfin_selection_count" = "%d z %d Elementów";
 "file_size_unknown" = "Nieznany rozmiar";
 "runtime_unknown" = "Nieznany czas trwania";
 "subscription_required_title" = "Wymagana subskrypcja";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Podarować";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Pobierz folder";
+"download_folder_confirmation_message" = "Pobrać wszystkie %d pliki z tego folderu?";
+"download_folder_confirm_button" = "Pobierz";

--- a/BookPlayer/pl.lproj/Localizable.stringsdict
+++ b/BookPlayer/pl.lproj/Localizable.stringsdict
@@ -82,5 +82,25 @@
         <string>pliki</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Pobieranie 1 pliku</string>
+        <key>few</key>
+        <string>Pobieranie %d plików</string>
+        <key>many</key>
+        <string>Pobieranie %d plików</string>
+        <key>other</key>
+        <string>Pobieranie %d plików</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Preparando para importar arquivos";
 "library_add_title" = "Adicione o seu primeiro livro";
 "invalid_url_title" = "URL inválida: %@";
-"downloading_file_title" = "Baixando arquivo";
 "progress_title" = "Progresso";
 "settings_siri_sleeptimer_title" = "Temporizador de Sono";
 "active_title" = "On";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Resposta inesperada do servidor";
 "jellyfin_error_unexpected_response_with_code" = "Resposta inesperada do servidor (Código: %d - %@ )";
 "jellyfin_error_unauthorized" = "Falha ao entrar. Verifique seu nome de usuário e senha.";
+"jellyfin_selection_count" = "%d de %d Itens";
 "file_size_unknown" = "Tamanho desconhecido";
 "runtime_unknown" = "Duração desconhecida";
 "subscription_required_title" = "Assinatura necessária";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Doar";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Baixar pasta";
+"download_folder_confirmation_message" = "Baixar todos os %d arquivos desta pasta?";
+"download_folder_confirm_button" = "Baixar";

--- a/BookPlayer/pt-BR.lproj/Localizable.stringsdict
+++ b/BookPlayer/pt-BR.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Processando %d arquivos</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Baixando 1 arquivo</string>
+        <key>other</key>
+        <string>Baixando %d arquivos</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Importação de ficheiros em preparação";
 "library_add_title" = "Adicionar o seu primeiro livro";
 "invalid_url_title" = "URL inválido: %@";
-"downloading_file_title" = "Descarregando ficheiro";
 "progress_title" = "Progresso";
 "settings_siri_sleeptimer_title" = "Temporizador";
 "active_title" = "Ligado";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Resposta inesperada do servidor";
 "jellyfin_error_unexpected_response_with_code" = "Resposta inesperada do servidor (Código: %d - %@ )";
 "jellyfin_error_unauthorized" = "Falha ao entrar. Verifique seu nome de usuário e senha.";
+"jellyfin_selection_count" = "%d de %d Itens";
 "file_size_unknown" = "Tamanho desconhecido";
 "runtime_unknown" = "Duração desconhecida";
 "subscription_required_title" = "Assinatura necessária";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Doar";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Transferir pasta";
+"download_folder_confirmation_message" = "Transferir todos os %d ficheiros desta pasta?";
+"download_folder_confirm_button" = "Transferir";

--- a/BookPlayer/pt-PT.lproj/Localizable.stringsdict
+++ b/BookPlayer/pt-PT.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Processando %d ficheiros</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>A descarregar 1 ficheiro</string>
+        <key>other</key>
+        <string>A descarregar %d ficheiros</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Pregătire pentru importarea fișierelor";
 "library_add_title" = "Adaugați prima carte";
 "invalid_url_title" = "URL invalid: %@";
-"downloading_file_title" = "Descărcarea fișierului.";
 "progress_title" = "Derulare";
 "settings_siri_sleeptimer_title" = "Temporizator somn";
 "active_title" = "Pornit";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Răspuns neașteptat al serverului";
 "jellyfin_error_unexpected_response_with_code" = "Răspuns neașteptat al serverului (Cod: %d - %@ )";
 "jellyfin_error_unauthorized" = "Conectarea a eșuat. Verificați-vă numele de utilizator și parola.";
+"jellyfin_selection_count" = "%d din %d Elemente";
 "file_size_unknown" = "Dimensiune necunoscută";
 "runtime_unknown" = "Durată necunoscută";
 "subscription_required_title" = "Este necesar un abonament";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Dona";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Descarcă dosarul";
+"download_folder_confirmation_message" = "Descarcă toate cele %d fișiere din acest dosar?";
+"download_folder_confirm_button" = "Descarcă";

--- a/BookPlayer/ro.lproj/Localizable.stringsdict
+++ b/BookPlayer/ro.lproj/Localizable.stringsdict
@@ -74,5 +74,23 @@
         <string></string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Se descarcă 1 fișier</string>
+        <key>few</key>
+        <string>Se descarcă %d fișiere</string>
+        <key>other</key>
+        <string>Se descarcă %d fișiere</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Подготовка к импорту файлов";
 "library_add_title" = "Добавьте вашу первую книгу";
 "invalid_url_title" = "Неверный URL: %@";
-"downloading_file_title" = "Скачивание файла";
 "progress_title" = "Прогресс";
 "settings_siri_sleeptimer_title" = "Таймер сна";
 "active_title" = "Включен";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Неожиданный ответ сервера";
 "jellyfin_error_unexpected_response_with_code" = "Неожиданный ответ сервера (Код: %d - %@)";
 "jellyfin_error_unauthorized" = "Ошибка входа. Проверьте имя пользователя и пароль.";
+"jellyfin_selection_count" = "%d из %d Элементов";
 "file_size_unknown" = "Неизвестный размер";
 "runtime_unknown" = "Неизвестная продолжительность";
 "subscription_required_title" = "Требуется подписка";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Включить возможность перемотки на экране блокировки";
 "donate_title" = "Пожертвовать";
 "bookmark_automatic_sleep_title" = "Последняя позиция, когда был включен таймер сна";
+"download_folder_confirmation_title" = "Скачать папку";
+"download_folder_confirmation_message" = "Скачать все %d файлов из этой папки?";
+"download_folder_confirm_button" = "Скачать";

--- a/BookPlayer/ru.lproj/Localizable.stringsdict
+++ b/BookPlayer/ru.lproj/Localizable.stringsdict
@@ -82,5 +82,25 @@
         <string>Обработка %d файлов</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Загрузка 1 файла</string>
+        <key>few</key>
+        <string>Загрузка %d файлов</string>
+        <key>many</key>
+        <string>Загрузка %d файлов</string>
+        <key>other</key>
+        <string>Загрузка %d файлов</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Príprava importu súborov";
 "library_add_title" = "Pridajte vašu prvú knihu";
 "invalid_url_title" = "Neplatná adresa URL: %@";
-"downloading_file_title" = "Sťahovanie súboru";
 "progress_title" = "Priebeh";
 "settings_siri_sleeptimer_title" = "Časovač spánku";
 "active_title" = "Zap.";
@@ -343,6 +342,7 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "jellyfin_error_unexpected_response" = "Neočakávaná odpoveď servera";
 "jellyfin_error_unexpected_response_with_code" = "Neočakávaná odpoveď servera (kód: %d – %@)";
 "jellyfin_error_unauthorized" = "Prihlásenie zlyhalo. Skontrolujte svoje používateľské meno a heslo.";
+"jellyfin_selection_count" = "%d z %d Položiek";
 "file_size_unknown" = "Neznáma veľkosť";
 "runtime_unknown" = "Neznáme trvanie";
 "Swipe rows to see download options" = "Potiahnutím riadkov zobrazíte možnosti sťahovania";
@@ -350,3 +350,6 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "settings_seekprogressbar_description" = "Povolenie vyhľadávania pri zamknutej obrazovke";
 "donate_title" = "Darovať";
 "bookmark_automatic_sleep_title" = "Posledná pozícia, keď bol časovač spánku zapnutý";
+"download_folder_confirmation_title" = "Stiahnuť priečinok";
+"download_folder_confirmation_message" = "Stiahnuť všetkých %d súbory z tohto priečinku?";
+"download_folder_confirm_button" = "Stiahnuť";

--- a/BookPlayer/sk-SK.lproj/Localizable.stringsdict
+++ b/BookPlayer/sk-SK.lproj/Localizable.stringsdict
@@ -82,5 +82,25 @@
         <string>Spracovávanie %d súborov</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Sťahovanie 1 súboru</string>
+        <key>few</key>
+        <string>Sťahovanie %d súborov</string>
+        <key>many</key>
+        <string>Sťahovanie %d súborov</string>
+        <key>other</key>
+        <string>Sťahovanie %d súborov</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Förbereder import av filer";
 "library_add_title" = "Lägg till din första bok";
 "invalid_url_title" = "Ogiltig URL: %@";
-"downloading_file_title" = "Hämtar fil";
 "progress_title" = "Framsteg";
 "settings_siri_sleeptimer_title" = "Timer";
 "active_title" = "Aktiva";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Oväntat serversvar";
 "jellyfin_error_unexpected_response_with_code" = "Oväntat serversvar (kod: %d - %@ )";
 "jellyfin_error_unauthorized" = "Inloggning misslyckades. Kontrollera ditt användarnamn och lösenord.";
+"jellyfin_selection_count" = "%d av %d Objekt";
 "file_size_unknown" = "Okänd storlek";
 "runtime_unknown" = "Okänd varaktighet";
 "subscription_required_title" = "Prenumeration krävs";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Donera";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Ladda ner mapp";
+"download_folder_confirmation_message" = "Ladda ner alla %d filer från denna mapp?";
+"download_folder_confirm_button" = "Ladda ner";

--- a/BookPlayer/sv.lproj/Localizable.stringsdict
+++ b/BookPlayer/sv.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>Bearbetar %d filer</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Laddar ner 1 fil</string>
+        <key>other</key>
+        <string>Laddar ner %d filer</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Dosyaları içeri aktarmaya hazırlanılıyor";
 "library_add_title" = "İlk kitabınızı ekleyin";
 "invalid_url_title" = "Geçersiz URL: %@";
-"downloading_file_title" = "Dosya indiriliyor";
 "progress_title" = "İlerleme";
 "settings_siri_sleeptimer_title" = "Uyku Zamanlayıcısı";
 "active_title" = "Aktif Kitap";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Beklenmeyen sunucu yanıtı";
 "jellyfin_error_unexpected_response_with_code" = "Beklenmeyen sunucu yanıtı (Kod: %d - %@ )";
 "jellyfin_error_unauthorized" = "Giriş başarısız. Kullanıcı adınızı ve şifrenizi kontrol edin.";
+"jellyfin_selection_count" = "%d / %d Öğe";
 "file_size_unknown" = "Bilinmeyen boyut";
 "runtime_unknown" = "Bilinmeyen süre";
 "subscription_required_title" = "Abonelik gerekli";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Bağış yapmak";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Klasörü indir";
+"download_folder_confirmation_message" = "Bu klasördeki tüm %d dosya indirilsin mi?";
+"download_folder_confirm_button" = "İndir";

--- a/BookPlayer/tr.lproj/Localizable.stringsdict
+++ b/BookPlayer/tr.lproj/Localizable.stringsdict
@@ -66,5 +66,21 @@
         <string>%d Dosya işleniyor.</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>1 dosya indiriliyor</string>
+        <key>other</key>
+        <string>%d dosya indiriliyor</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "Підготовка до імпорту файлів";
 "library_add_title" = "Додайте свою першу книгу";
 "invalid_url_title" = "Невірне посилання: %@";
-"downloading_file_title" = "Завантаження файлу";
 "progress_title" = "Прогрес";
 "settings_siri_sleeptimer_title" = "Таймер сну";
 "active_title" = "Активний";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "Неочікувана відповідь сервера";
 "jellyfin_error_unexpected_response_with_code" = "Неочікувана відповідь сервера (Код: %d - %@ )";
 "jellyfin_error_unauthorized" = "Помилка входу. Перевірте своє ім'я користувача та пароль.";
+"jellyfin_selection_count" = "%d з %d Елементів";
 "file_size_unknown" = "Невідомий розмір";
 "runtime_unknown" = "Невідома тривалість";
 "subscription_required_title" = "Потрібна підписка";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "Пожертвуйте";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "Завантажити папку";
+"download_folder_confirmation_message" = "Завантажити всі %d файлів з цієї папки?";
+"download_folder_confirm_button" = "Завантажити";

--- a/BookPlayer/uk.lproj/Localizable.stringsdict
+++ b/BookPlayer/uk.lproj/Localizable.stringsdict
@@ -82,5 +82,25 @@
         <string>Обробка %d файлів</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Завантаження 1 файлу</string>
+        <key>few</key>
+        <string>Завантаження %d файлів</string>
+        <key>many</key>
+        <string>Завантаження %d файлів</string>
+        <key>other</key>
+        <string>Завантаження %d файлів</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -151,7 +151,6 @@
 "import_preparing_title" = "准备导入文件";
 "library_add_title" = "添加第一本书";
 "invalid_url_title" = "无效的网址： %@";
-"downloading_file_title" = "下载文件";
 "progress_title" = "进展";
 "settings_siri_sleeptimer_title" = "睡眠定时";
 "active_title" = "活性";
@@ -342,6 +341,7 @@
 "jellyfin_error_unexpected_response" = "意外的服务器响应";
 "jellyfin_error_unexpected_response_with_code" = "意外的服务器响应（代码： %d - %@ ）";
 "jellyfin_error_unauthorized" = "登录失败。请检查您的用户名和密码。";
+"jellyfin_selection_count" = "%d / %d 项";
 "file_size_unknown" = "未知尺寸";
 "runtime_unknown" = "持续时间未知";
 "subscription_required_title" = "需要订阅";
@@ -350,3 +350,6 @@
 "settings_seekprogressbar_description" = "Enable seeking on the lock screen";
 "donate_title" = "捐";
 "bookmark_automatic_sleep_title" = "Last position when the sleep timer was turned on";
+"download_folder_confirmation_title" = "下载文件夹";
+"download_folder_confirmation_message" = "下载此文件夹中的所有 %d 个文件？";
+"download_folder_confirm_button" = "下载";

--- a/BookPlayer/zh-Hans.lproj/Localizable.stringsdict
+++ b/BookPlayer/zh-Hans.lproj/Localizable.stringsdict
@@ -58,5 +58,19 @@
         <string>正在处理%d文件</string>
       </dict>
     </dict>
+    <key>downloading_file_title</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@format@</string>
+      <key>format</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>other</key>
+        <string>正在下载 %d 个文件</string>
+      </dict>
+    </dict>
   </dict>
 </plist>

--- a/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
+++ b/BookPlayerTests/Coordinators/ItemListCoordinatorTests.swift
@@ -51,10 +51,6 @@ class LibraryListCoordinatorTests: XCTestCase {
     self.libraryListCoordinator.start()
   }
 
-  func testInitialState() {
-    XCTAssert(self.libraryListCoordinator.shouldShowImportScreen())
-  }
-
   func testDocumentPickerDelegate() {
     XCTAssertNotNil(self.libraryListCoordinator.documentPickerDelegate)
   }

--- a/Shared/Network/NetworkClient.swift
+++ b/Shared/Network/NetworkClient.swift
@@ -34,12 +34,6 @@ public protocol NetworkClientProtocol {
     session: URLSession
   ) async -> URLSessionTask
 
-  /// Download a file handled by a delegate and an internal URLSession
-  func download(
-    url: URL,
-    delegate: BPTaskDownloadDelegate
-  )
-
   /// Managed download by an existing URLSession
   func download(
     url: URL,
@@ -88,23 +82,6 @@ public class NetworkClient: NetworkClientProtocol, BPLogger {
     let request = try buildURLRequest(path: path, method: method, parameters: parameters)
 
     return try await executeRequest(request, method: method, parameters: parameters)
-  }
-
-  public func download(
-    url: URL,
-    delegate: BPTaskDownloadDelegate
-  ) {
-    let bundleIdentifier: String = Bundle.main.configurationValue(for: .bundleIdentifier)
-
-    let session = URLSession(
-      configuration: URLSessionConfiguration.background(
-        withIdentifier: "\(bundleIdentifier).background.import"
-      ),
-      delegate: delegate,
-      delegateQueue: OperationQueue()
-    )
-    let task = session.downloadTask(with: url)
-    task.resume()
   }
 
   public func download(


### PR DESCRIPTION
## Purpose

This PR enhances the Jellyfin integration with several key improvements focused on folder downloads, UI/UX enhancements, and localization support. The changes include adding support for full folder downloads, improving the import process with better sorting, and refactoring the download progress handling for multi-file operations.

Key improvements:
- **Full folder download support** - Users can now download entire folders from Jellyfin servers
- **Enhanced import UI** - Import view now sorts items for better user experience  
- **Improved download handling** - `SingleFileDownloadService` now processes one file at a time to prevent resource conflicts
- **Complete localization** - Added missing localization strings for the Jellyfin flow across all supported languages

## Screenshots
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-01 at 23 16 07](https://github.com/user-attachments/assets/36f8fe1f-caa9-47dd-8e42-387ef410bad2)