### PR TITLE
Add logic to show any pending import flow

### DIFF
--- a/BookPlayer/Coordinators/FolderListCoordinator.swift
+++ b/BookPlayer/Coordinators/FolderListCoordinator.swift
@@ -72,8 +72,10 @@ class FolderListCoordinator: ItemListCoordinator {
         self.showItemSelectionScreen(availableItems: availableItems, selectionHandler: selectionHandler)
       case .showMiniPlayer(let flag):
         self.showMiniPlayer(flag: flag)
-      case .listDidAppear:
-        self.syncList()
+      case .listDidAppear(let isFirstTime):
+        if isFirstTime {
+          self.syncList()
+        }
       case .showQueuedTasks:
         self.showQueuedTasks()
       }

--- a/BookPlayer/Import/ImportManager.swift
+++ b/BookPlayer/Import/ImportManager.swift
@@ -37,6 +37,10 @@ final class ImportManager {
     self.files.value.insert(fileUrl)
   }
 
+  public func hasPendingFiles() -> Bool {
+    return !self.files.value.isEmpty
+  }
+
   public func observeFiles() -> AnyPublisher<[URL], Never> {
     return self.files
       .map({ Array($0) })

--- a/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewController.swift
@@ -124,9 +124,10 @@ class ItemListViewController: UIViewController, MVVMControllerProtocol, Storyboa
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
+    viewModel.viewDidAppear(isFirstTime: didAppearForFirstTime)
+
     if didAppearForFirstTime {
       didAppearForFirstTime = false
-      viewModel.viewDidAppear()
       if navigationController?.viewControllers.count == 1 {
         navigationController!.interactivePopGestureRecognizer!.delegate = self
       }

--- a/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList Screen/ItemListViewModel.swift
@@ -27,7 +27,7 @@ class ItemListViewModel: ViewModelProtocol {
       selectionHandler: (SimpleLibraryItem) -> Void
     )
     case showMiniPlayer(flag: Bool)
-    case listDidAppear
+    case listDidAppear(isFirstTime: Bool)
     case showQueuedTasks
   }
 
@@ -121,9 +121,10 @@ class ItemListViewModel: ViewModelProtocol {
     bindDownloadObservers()
   }
 
-  /// Notify that the UI is presented and ready
-  func viewDidAppear() {
-    onTransition?(.listDidAppear)
+  /// Notify that the UI is presented and ready on the first time
+  /// Subsequent triggers is in service of the import flow
+  func viewDidAppear(isFirstTime: Bool) {
+    onTransition?(.listDidAppear(isFirstTime: isFirstTime))
   }
 
   func bindBookObservers() {


### PR DESCRIPTION
## Purpose

- As we're not showing the import flow over presented screens (like the player), I've added some failsafes to trigger the flow if necessary when the library screen is shown, or when the app comes back to the foreground

## Screenshots


https://github.com/user-attachments/assets/3538903e-b9c6-4099-bdea-ff3bea214b4f

