### PR TITLE
Fix syncing overwriting local data with stale data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,45 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    # We only use Xcode 16.0
-    - name: Remove unused applications
-      run: |
-        df -hI /dev/disk3s1s1
-        sudo rm -rf /Applications/Xcode_14.3.1.app
-        sudo rm -rf /Applications/Xcode_15.0.1.app
-        sudo rm -rf /Applications/Xcode_15.1.app
-        sudo rm -rf /Applications/Xcode_15.2.app
-        sudo rm -rf /Applications/Xcode_15.3.app
-        sudo rm -rf /Applications/Xcode_16.0.app
-        sudo rm -rf /Applications/Xcode_16.1.app
-        sudo rm -rf /Applications/Xcode_16.2.app
-        sudo rm -rf /Applications/Xcode_16.3.app
-        sudo rm -rf /Applications/Xcode_16.4.app
-        df -hI /dev/disk3s1s1
-    - name: Create Debug.xcconfig
-      run: cp ./BuildConfiguration/Debug.template.xcconfig ./BuildConfiguration/Debug.xcconfig
-    - name: Set Xcode version
-      run: sudo xcode-select -s "/Applications/Xcode_26.0.app"
-    - name: Resolve dependencies
-      run: xcodebuild -resolvePackageDependencies
-    - name: Build and Run tests
-      run: xcodebuild -scheme BookPlayer test -testPlan Unit\ Tests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0'
+      - uses: actions/checkout@v4
+      - name: Select Xcode 26.0
+        run: |
+          ls -1 /Applications | grep -E '^Xcode_26\.' || true
+          sudo xcode-select -s "/Applications/Xcode_26.0.app"
+          xcodebuild -version
+          xcrun simctl list runtimes
+
+      - name: Create Debug.xcconfig
+        run: cp ./BuildConfiguration/Debug.template.xcconfig ./BuildConfiguration/Debug.xcconfig
+
+      - name: Resolve SPM dependencies
+        run: xcodebuild -resolvePackageDependencies
+
+      - name: Reset Simulator
+        run: |
+          xcrun simctl shutdown all || true
+          xcrun simctl erase all || true
+          launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
+          xcrun simctl list devices
+
+      - name: Build for testing
+        run: |
+          xcodebuild \
+            -scheme BookPlayer \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,name=iPhone 17,OS=26.0" \
+            build-for-testing
+
+      - name: Run unit tests (fail fast)
+        timeout-minutes: 12
+        env:
+          NSUnbufferedIO: "YES"
+        run: |
+          xcodebuild \
+            -scheme BookPlayer \
+            -configuration Debug \
+            -testPlan "Unit Tests" \
+            -only-testing:BookPlayerTests \
+            -destination "platform=iOS Simulator,name=iPhone 17,OS=26.0" \
+            -destination-timeout 120 \
+            test-without-building

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -406,7 +406,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
     if let scene = UIApplication.shared.connectedScenes.first(where: {
       $0.activationState == .foregroundActive
     }) as? UIWindowScene {
-      SKStoreReviewController.requestReview(in: scene)
+      AppStore.requestReview(in: scene)
     }
   }
 

--- a/BookPlayer/AppIntents/CustomRewindIntent.swift
+++ b/BookPlayer/AppIntents/CustomRewindIntent.swift
@@ -11,7 +11,7 @@ import BookPlayerKit
 import Foundation
 
 @available(macOS 14.0, watchOS 10.0, tvOS 16.0, *)
-struct CustomRewindIntent: AudioStartingIntent {
+struct CustomRewindIntent: AudioPlaybackIntent {
   static var title: LocalizedStringResource = "intent_custom_skiprewind_title"
 
   @Parameter(

--- a/BookPlayer/AppIntents/CustomSkipForwardIntent.swift
+++ b/BookPlayer/AppIntents/CustomSkipForwardIntent.swift
@@ -11,7 +11,7 @@ import BookPlayerKit
 import Foundation
 
 @available(macOS 14.0, watchOS 10.0, tvOS 16.0, *)
-struct CustomSkipForwardIntent: AudioStartingIntent {
+struct CustomSkipForwardIntent: AudioPlaybackIntent {
   static var title: LocalizedStringResource = "intent_custom_skipforward_title"
 
   @Parameter(

--- a/BookPlayer/AppIntents/LastBookStartPlaybackIntent.swift
+++ b/BookPlayer/AppIntents/LastBookStartPlaybackIntent.swift
@@ -11,7 +11,7 @@ import BookPlayerKit
 import Foundation
 
 @available(macOS 14.0, watchOS 10.0, *)
-struct LastBookStartPlaybackIntent: AudioStartingIntent {
+struct LastBookStartPlaybackIntent: AudioPlaybackIntent {
   static var title: LocalizedStringResource = "intent_lastbook_play_title"
 
   @Dependency

--- a/BookPlayer/AppIntents/PausePlaybackIntent.swift
+++ b/BookPlayer/AppIntents/PausePlaybackIntent.swift
@@ -11,7 +11,7 @@ import BookPlayerKit
 import Foundation
 
 @available(macOS 14.0, watchOS 10.0, *)
-struct PausePlaybackIntent: AudioStartingIntent {
+struct PausePlaybackIntent: AudioPlaybackIntent {
   static var title: LocalizedStringResource = "intent_playback_pause_title"
 
   @Dependency

--- a/BookPlayer/Hardcover/Settings Page/HardcoverSettingsView.swift
+++ b/BookPlayer/Hardcover/Settings Page/HardcoverSettingsView.swift
@@ -33,7 +33,7 @@ struct HardcoverSettingsView: View {
         .onSubmit {
           isTextFieldFocused = false
         }
-        .onChange(of: viewModel.accessToken) { new in
+        .onChange(of: viewModel.accessToken) { _, new in
           isValid = new.isEmpty || !new.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
       } header: {

--- a/BookPlayer/Utils/TextFieldFocused.swift
+++ b/BookPlayer/Utils/TextFieldFocused.swift
@@ -43,11 +43,11 @@ private struct TextFieldFocused<FocusableType: Equatable & Focusable>: ViewModif
 
   func body(content: Content) -> some View {
     content
-      .onChange(of: externalFocused) { newValue in
+      .onChange(of: externalFocused) { _, newValue in
         focused = (newValue.hashValue == selfkey.hashValue)
       }
       .focused($focused)
-      .onChange(of: focused) { isFocused in
+      .onChange(of: focused) { _, isFocused in
         if isFocused {
           externalFocused = selfkey
         }


### PR DESCRIPTION
## Bugfix

- When I removed Realm, and replaced it with SwiftData, the count initialization of the queued tasks was wrong, so the validation to stop the app from fetching data was not working, and it was overwriting things with stale data
- I also fixed some deprecation warnings from the project
