### PR TITLE
Monospaced time fonts for elapsed and remaining time in player view

### DIFF
--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -88,6 +88,9 @@ class PlayerViewController: UIViewController, MVVMControllerProtocol, Storyboard
 
     self.containerItemStackView.setCustomSpacing(26, after: self.artworkControl)
     toggleArtwork(for: traitCollection)
+
+    self.currentTimeLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
+
   }
 
   override func willTransition(
@@ -192,7 +195,15 @@ class PlayerViewController: UIViewController, MVVMControllerProtocol, Storyboard
     if let maxTime = progressObject.maxTime,
       let formattedMaxTime = progressObject.formattedMaxTime
     {
-      self.maxTimeButton.setTitle(formattedMaxTime, for: .normal)
+
+    let title = NSAttributedString(
+         string: formattedMaxTime,
+         attributes: [
+             .font: UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .semibold),
+         ]
+    )
+    self.maxTimeButton.setAttributedTitle(title, for: .normal)
+      
       self.maxTimeButton.accessibilityLabel = String(
         describing: "\(self.viewModel.getMaxTimeVoiceOverPrefix()) \(VoiceOverService.secondsToMinutes(maxTime))"
       )


### PR DESCRIPTION
## Bugfix
Having used the app for a bit I noticed that the elapsed/remaining time labels were varying in width, depending on the string displayed. Other audio applications solve this with monospaced fonts.

## Approach

Overriding the font to be monospace can successfully be done for the `currentTimeLable` within `viewDidLoad`, however that doesn't appear to work for the `maxTimeButton` as every call to `maxTimeButton.setTitle` resets the style.

## Things to be aware of / Things to focus on

Not sure if this is the correct solution, as iOS is something I have limited experience with.

## Screenshots

It's not immediately apparent on the screenshots, but notice how the colon chars line up as the fonts are now monospaced.

<img width="1920" height="1080" alt="monospace" src="https://github.com/user-attachments/assets/098a6792-3a05-44b5-936d-076c46373cdd" />
