### PR TITLE
Voiceover: Fix slider interactions on iOS 26

### DIFF
--- a/BookPlayer/Utils/Views/AccessibleSliderView.swift
+++ b/BookPlayer/Utils/Views/AccessibleSliderView.swift
@@ -22,10 +22,12 @@ class AccessibleSliderView: UISlider {
   override func accessibilityDecrement() {
     self.value -= self.intervalValue
     self.accessibilityValue = "\(round(self.value * 100) / 100.0)"
+    sendActions(for: .valueChanged)
   }
 
   override func accessibilityIncrement() {
     self.value += self.intervalValue
     self.accessibilityValue = "\(round(self.value * 100) / 100.0)"
+    sendActions(for: .valueChanged)
   }
 }


### PR DESCRIPTION
## Bugfix

- On iOS 26, when changing a slider value, the publisher is no longer being called automatically