### PR TITLE
VoiceOver: Fix interaction with slider inside the player screen

### DIFF
--- a/BookPlayer/Player/Player Screen/Views/ProgressSlider.swift
+++ b/BookPlayer/Player/Player Screen/Views/ProgressSlider.swift
@@ -102,4 +102,14 @@ class ProgressSlider: UISlider {
     self.value = value
     self.setNeedsDisplay()
   }
+
+  override func accessibilityDecrement() {
+    super.accessibilityDecrement()
+    sendActions(for: .touchUpOutside)
+  }
+
+  override func accessibilityIncrement() {
+    super.accessibilityIncrement()
+    sendActions(for: .touchUpOutside)
+  }
 }


### PR DESCRIPTION
## Bugfix

Users in iOS 26 were not able to update the slider percentage in the player screen using VoiceOver