### PR TITLE
Improve smart rewind behavior

### DIFF
--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -829,17 +829,34 @@ extension PlayerManager {
       let timePassedLimited = min(max(timePassed, 0), Constants.SmartRewind.threshold)
 
       let delta = timePassedLimited / Constants.SmartRewind.threshold
+      let baseRewindTime = ease(delta) * getMaxInterval()
 
-      // Using a cubic curve to soften the rewind effect for lower values and strengthen it for higher
-      let rewindTime = pow(delta, 3) * PlayerManager.rewindInterval
+      // Always rewind by at least minRewind...
+      let rewindTimeMin = max(baseRewindTime, Constants.SmartRewind.minRewind)
 
-      // Don't rewind past the beginning of the chapter
+      // ...but don't rewind past the beginning of the chapter, or more than the amount of time passed
       let timeInChapter = item.currentTime - item.currentChapter.start
-      let rewindTimeLimited = min(rewindTime, timeInChapter)
+      let rewindTimeLimited = min(rewindTimeMin, timeInChapter, timePassed)
 
       let newPlayerTime = max(CMTimeGetSeconds(self.audioPlayer.currentTime()) - rewindTimeLimited, 0)
 
       self.audioPlayer.seek(to: CMTime(seconds: newPlayerTime, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+    }
+
+    func getMaxInterval() -> TimeInterval {
+      let userSetInterval = UserDefaults.standard.double(forKey: Constants.UserDefaults.smartRewindMaxInterval)
+      // The interval may be 0 if the setting has never been changed
+      return if userSetInterval > 0 {
+        userSetInterval
+      } else {
+        30.0
+      }
+    }
+
+    // Quartic ease out, where 0 ≤ delta ≤ 1
+    // Increases quickly at first, then levels off closer to 1
+    func ease(_ delta: Double) -> Double {
+      return 1 - pow(1 - delta, 4)
     }
   }
 

--- a/BookPlayer/Settings/Sections/PlayerControls/SmartRewindSectionView.swift
+++ b/BookPlayer/Settings/Sections/PlayerControls/SmartRewindSectionView.swift
@@ -11,14 +11,42 @@ import SwiftUI
 
 struct SmartRewindSectionView: View {
   @AppStorage(Constants.UserDefaults.smartRewindEnabled) var smartRewindEnabled: Bool = true
+  @AppStorage(Constants.UserDefaults.smartRewindMaxInterval) var smartRewindMaxInterval: TimeInterval = 30
 
   @EnvironmentObject var theme: ThemeViewModel
+
+  private let intervals: [TimeInterval] = [
+    2.0,
+    5.0,
+    10.0,
+    15.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    90.0,
+    120.0,
+    180.0,
+    240.0,
+    300.0,
+  ]
 
   var body: some View {
     Section {
       Toggle("settings_smartrewind_title", isOn: $smartRewindEnabled)
+      if smartRewindEnabled {
+        Picker("settings_smartrewind_max_interval_title", selection: $smartRewindMaxInterval) {
+          ForEach(intervals, id: \.self) { interval in
+            Text(
+              TimeParser.formatDuration(interval)
+            ).tag(interval)
+              .foregroundStyle(theme.linkColor)
+          }
+        }
+        .pickerStyle(.menu)
+      }
     } footer: {
-      Text("settings_smartrewind_description")
+      Text(String(format: "settings_smartrewind_description".localized, TimeParser.formatDuration(smartRewindMaxInterval)))
         .foregroundStyle(theme.secondaryColor)
     }
   }

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -4,7 +4,8 @@
 "settings_autoplay_title" = "AutoPlay Library";
 "settings_autoplay_description" = "After finishing an audiobook, playback will resume with all items in the library, including items in folders.";
 "settings_smartrewind_title" = "Smart Rewind";
-"settings_smartrewind_description" = "Automatically skip backwards once after being paused for 10 minutes.";
+"settings_smartrewind_description" = "Automatically skip backwards when resuming playback. Skips back further the longer playback has been paused, up to a maximum of %@.";
+"settings_smartrewind_max_interval_title" = "Smart Rewind Limit";
 "settings_boostvolume_title" = "Boost Volume";
 "settings_boostvolume_description" = "Doubles the volume.\nUse with caution and care for your hearing.";
 "settings_globalspeed_title" = "Global Speed Control";

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -24,6 +24,7 @@ public enum Constants {
     public static let chapterContextEnabled = "userSettingsChapterContext"
     public static let remainingTimeEnabled = "userSettingsRemainingTime"
     public static let smartRewindEnabled = "userSettingsSmartRewind"
+    public static let smartRewindMaxInterval = "userSettingsSmartRewindMaxInterval"
     public static let boostVolumeEnabled = "userSettingsBoostVolume"
     public static let globalSpeedEnabled = "userSettingsGlobalSpeed"
     public static let seekProgressBarEnabled = "userSettingsSeekProgressBar"
@@ -83,7 +84,8 @@ public enum Constants {
   }
 
   public enum SmartRewind {
-    public static let threshold: TimeInterval = 599.0 // 599 = 10 mins
+    public static let threshold: TimeInterval = 60 * 60 // 60 minutes
+    public static let minRewind: TimeInterval = 2
   }
 
   public enum Volume {


### PR DESCRIPTION
## Purpose

This PR contains contains a few fixes:

**Don't smart rewind past beginning of chapter**
Currently, smart rewind will always put you back 30 seconds, even if you are very close to the start of a chapter. This is probably not the behavior that most users would expect or desire. So instead we can limit rewinding so that we never cross backwards over a chapter boundary. Users have requested this fixed in #1182.

**Add smart rewind interval setting**
This adds a new setting that allows users to specify the maximum amount of time they want the smart rewind feature to skip backwards by. The setting is only shown when smart rewind is enabled. Requested in #624 and #976.

**Improve rewind interval calculation**
This adds a minimum rewind interval of 2 seconds, so that when smart rewind is enabled, playback will always rewind by at least 2 seconds. The only exceptions are if we have been paused for less than 2 seconds or if we are less than 2 seconds from the start of the chapter. In these cases we will skip backwards by either the amount of time paused, or to the beginning of the chapter, whichever is closest. This is also requested in #717 and https://github.com/TortugaPower/BookPlayer/issues/976#issuecomment-1756982635.

This changes the easing function to be ease-out instead of ease-in. Instead of an easing function that starts slowly, then quickly increases towards the end I think the opposite is more natural. The amount we forget over time quickly increases at first, then slows down as time goes on. So I think the easing function should follow this. Also IMHO quartic feels like a little bit better of a fit than cubic here.

Finally, this changes smart rewind threshold up from 10 to 60 minutes. This seems like a big change, but with the change of the easing function it's less extreme—being paused for just 10 mins still gets you 50% of the rewind time, 26 mins get you 90%. IMO 10 minutes was a bit too short of a threshold, as personally I would want to skip back further after e.g. 45 minutes of pause time than after 10. See attached graphs to get a feel for how this looks in practice.

| Before | After |
|--------|--------|
| <img width="800" height="800" alt="desmos-graph(1)" src="https://github.com/user-attachments/assets/d192bb72-f0ce-4e1a-8e3c-af2d2f8a9c87" />  | <img width="800" height="800" alt="desmos-graph" src="https://github.com/user-attachments/assets/027dc380-b125-4d82-98af-c1f53dafec8f" />  |
|  | NB: This is with the rewind limit set to 30s (0.5 min); that value is now configurable. The notch at the beginning is the 2 second minimum. |

## Things to be aware of / Things to focus on

- I've tested in the simulator and everything seems to work as expected
- I'm not sure how to handle updating the translation strings, as I've changed `settings_smartrewind_description` string but only in English for now.

Updated settings screen:
<img height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-19 at 11 19 37" src="https://github.com/user-attachments/assets/32b24155-e47f-4c39-9ec1-ea043d0bf711" />