### PR TITLE
Fix sorting in AudiobookShelf

### DIFF
--- a/BookPlayer/AudiobookShelf/Library Screen/AudiobookShelfLibraryViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Library Screen/AudiobookShelfLibraryViewModel.swift
@@ -180,10 +180,12 @@ final class AudiobookShelfLibraryViewModel: AudiobookShelfLibraryViewModelProtoc
       defer { self.fetchTask = nil }
 
       do {
+        var desc: Bool?
         let sortByParam: String
         switch sortBy {
         case .recent:
           sortByParam = "addedAt"
+          desc = true
         case .title:
           sortByParam = "media.metadata.title"
         }
@@ -192,7 +194,8 @@ final class AudiobookShelfLibraryViewModel: AudiobookShelfLibraryViewModelProtoc
           in: libraryID,
           limit: Self.itemBatchSize,
           page: nextPage,
-          sortBy: sortByParam
+          sortBy: sortByParam,
+          desc: desc
         )
 
         self.nextPage += 1

--- a/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
+++ b/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
@@ -157,30 +157,39 @@ class AudiobookShelfConnectionService: BPLogger {
     in libraryId: String,
     limit: Int? = nil,
     page: Int? = nil,
-    sortBy: String? = "media.metadata.title"
+    sortBy: String? = "media.metadata.title",
+    desc: Bool? = nil
   ) async throws -> (items: [AudiobookShelfLibraryItem], total: Int) {
     guard let connection else {
       throw URLError(.userAuthenticationRequired)
     }
 
-    var urlComponents = URLComponents(
-      url: connection.url
-        .appendingPathComponent("api")
-        .appendingPathComponent("libraries")
-        .appendingPathComponent(libraryId)
-        .appendingPathComponent("items"),
-      resolvingAgainstBaseURL: false
-    )!
+    guard
+      var urlComponents = URLComponents(
+        url: connection.url
+          .appendingPathComponent("api")
+          .appendingPathComponent("libraries")
+          .appendingPathComponent(libraryId)
+          .appendingPathComponent("items"),
+        resolvingAgainstBaseURL: false
+      )
+    else {
+      throw URLError(.badURL)
+    }
 
     var queryItems: [URLQueryItem] = []
-    if let limit = limit {
+
+    if let limit {
       queryItems.append(URLQueryItem(name: "limit", value: "\(limit)"))
     }
-    if let page = page {
+    if let page {
       queryItems.append(URLQueryItem(name: "page", value: "\(page)"))
     }
-    if let sortBy = sortBy {
+    if let sortBy {
       queryItems.append(URLQueryItem(name: "sort", value: sortBy))
+      if let desc {
+        queryItems.append(URLQueryItem(name: "desc", value: desc ? "1" : "0"))
+      }
     }
 
     if !queryItems.isEmpty {


### PR DESCRIPTION
## Bugfix

- We're missing the `desc` parameter when sorting, so right now it's sorting by the oldest one first