### PR TITLE
Fix theming for when using Always use dark variation

### DIFF
--- a/BookPlayer/Coordinators/MainCoordinator.swift
+++ b/BookPlayer/Coordinators/MainCoordinator.swift
@@ -108,6 +108,17 @@ class MainCoordinator: NSObject {
     )
     vc.modalPresentationStyle = .fullScreen
     vc.modalTransitionStyle = .crossDissolve
+    
+    // Set window interface style BEFORE presenting the view controller
+    // This ensures SwiftUI views are initialized with the correct colorScheme
+    if let window = navigationController.view.window ?? AppDelegate.shared?.activeSceneDelegate?.window {
+      if UserDefaults.standard.bool(forKey: Constants.UserDefaults.systemThemeVariantEnabled) {
+        window.overrideUserInterfaceStyle = .unspecified
+      } else {
+        window.overrideUserInterfaceStyle = ThemeManager.shared.useDarkVariant ? .dark : .light
+      }
+    }
+    
     navigationController.present(vc, animated: false)
     mainController = vc
 

--- a/BookPlayer/Loading/LoadingViewController.swift
+++ b/BookPlayer/Loading/LoadingViewController.swift
@@ -13,7 +13,11 @@ import UIKit
 class LoadingViewController: UIViewController, MVVMControllerProtocol, Storyboarded, Themeable {
   var viewModel: LoadingViewModel!
   override func viewDidLoad() {
+    super.viewDidLoad()
     self.navigationController?.isNavigationBarHidden = true
+    
+    // Subscribe to theme changes to ensure proper initial rendering
+    setUpTheming()
   }
 
   override func viewWillAppear(_ animated: Bool) {

--- a/BookPlayer/Settings/Themes/ThemeManager.swift
+++ b/BookPlayer/Settings/Themes/ThemeManager.swift
@@ -94,15 +94,17 @@ final class ThemeManager: ThemeProvider {
   }
 
   private func setNewTheme(_ newTheme: SimpleTheme) {
+    // Always create theme with current useDarkVariant flag
+    let newTheme = SimpleTheme(with: newTheme, useDarkVariant: self.useDarkVariant)
+    
     guard
       let sceneDelegate = AppDelegate.shared?.activeSceneDelegate,
       let window = sceneDelegate.window
     else {
+      // No window yet, just set the value without animation
       self.theme.value = newTheme
       return
     }
-
-    let newTheme = SimpleTheme(with: newTheme, useDarkVariant: self.useDarkVariant)
 
     // Moved from scene delegate
     UINavigationBar.appearance().titleTextAttributes = [

--- a/BookPlayer/Utils/ThemeViewModel.swift
+++ b/BookPlayer/Utils/ThemeViewModel.swift
@@ -16,7 +16,8 @@ class ThemeViewModel: ObservableObject, Themeable {
   @Published var defaultArtwork: Image?
 
   init() {
-    theme = SimpleTheme.getDefaultTheme(useDarkVariant: UIScreen.main.traitCollection.userInterfaceStyle == .dark)
+    // Initialize with current theme from ThemeManager for consistency
+    theme = ThemeManager.shared.currentTheme
     setUpTheming()
   }
 


### PR DESCRIPTION
## Bugfix

- When having the phone in light mode, and the app marked to always use dark mode, when launching the app, there are multiple elements that aren't displaying in dark mode

## Related tasks

#1404 