### PR TITLE
Add double tap gesture to now playing controls

### DIFF
--- a/BookPlayerWatch/NowPlaying/Views/NowPlayingMediaControlsView.swift
+++ b/BookPlayerWatch/NowPlaying/Views/NowPlayingMediaControlsView.swift
@@ -40,6 +40,7 @@ struct NowPlayingMediaControlsView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .frame(width: geometry.size.width * 0.28)
+        .applyPrimaryHandGesture()
         Spacer()
         Button {
           contextManager.handleSkip(.forward)


### PR DESCRIPTION
## Summary
- Adds double tap (primary hand gesture) support for play/pause in the Watch app's Now Playing view
- This enables the watchOS 11+ double tap gesture to toggle playback when using the watch as a companion/remote control for the iPhone

## Approach
Applied the existing `applyPrimaryHandGesture()` modifier to the play/pause button in `NowPlayingMediaControlsView.swift`. This modifier was already being used in `PlayerControlsView.swift` for local playback mode, so this change extends the same functionality to companion mode.

The implementation gracefully degrades on watchOS versions below 11.0.

## Things to watch out for
- Requires watchOS 11.0+ for the gesture to work
- No behaviour change on older watchOS versions