### PR TITLE
Fixing multi-select mark as unfinished visual feedback

### DIFF
--- a/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerWidgetsPhone.xcscheme
+++ b/BookPlayer.xcodeproj/xcshareddata/xcschemes/BookPlayerWidgetsPhone.xcscheme
@@ -90,6 +90,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/BookPlayer/Library/ItemList/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList/ItemListViewModel.swift
@@ -315,14 +315,8 @@ extension ItemListViewModel {
   }
 
   func handleMarkAsFinished(flag: Bool) {
-    if flag {
-      selectedItems.forEach {
-        libraryService.markAsFinished(flag: flag, relativePath: $0.relativePath)
-      }
-    } else {
-      selectedItems.forEach {
-        libraryService.jumpToStart(relativePath: $0.relativePath)
-      }
+    selectedItems.forEach {
+      libraryService.markAsFinished(flag: flag, relativePath: $0.relativePath)
     }
 
     if let parentFolder = libraryNode.folderRelativePath {

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -1983,7 +1983,9 @@ extension LibraryService {
       book.currentTime.rounded(.up) == book.duration.rounded(.up)
     {
       book.currentTime = 0.0
+      book.percentCompleted = 0.0
       metadataUpdates[#keyPath(LibraryItem.currentTime)] = Double(0)
+      metadataUpdates[#keyPath(LibraryItem.percentCompleted)] = Double(0)
     }
 
     metadataPassthroughPublisher.send(metadataUpdates)


### PR DESCRIPTION
## Bugfix

- When selecting books that where finished to mark them as unfinished, the visual feedback was missing, items where not being updated visually

## Approach

- Book View should update progress based on the incoming database observer update

## Things to be aware of / Things to focus on

- Marking a book as unfinished will reset the progress back to 0