### PR TITLE
Mac bottom padding

### DIFF
--- a/BookPlayer/Utils/Extensions/View+BookPlayer.swift
+++ b/BookPlayer/Utils/Extensions/View+BookPlayer.swift
@@ -145,7 +145,7 @@ struct MiniPlayerSafeAreaInsetModifier: ViewModifier {
   @Environment(\.playerState) var playerState
   @Environment(\.miniPlayerBottomInset) private var miniPlayerBottomInset
   @StateObject private var keyboardObserver = KeyboardObserver()
-  
+
   private var spacerHeight: CGFloat {
     // When keyboard is visible, let iOS handle the safe area adjustment
     guard !keyboardObserver.isKeyboardVisible else { return 0 }
@@ -194,22 +194,22 @@ extension View {
 }
 
 private struct MiniPlayerBottomInsetKey: EnvironmentKey {
-    static let defaultValue: CGFloat = 80
+  static let defaultValue: CGFloat = 80
 }
 
 extension EnvironmentValues {
-    var miniPlayerBottomInset: CGFloat {
-        get { self[MiniPlayerBottomInsetKey.self] }
-        set { self[MiniPlayerBottomInsetKey.self] = newValue }
-    }
+  var miniPlayerBottomInset: CGFloat {
+    get { self[MiniPlayerBottomInsetKey.self] }
+    set { self[MiniPlayerBottomInsetKey.self] = newValue }
+  }
 }
 
 // MARK: - Toolbar utils
 struct MiniPlayerSizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
+  static var defaultValue: CGSize = .zero
+  static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+    value = nextValue()
+  }
 }
 
 struct MiniPlayerModifier<Regular: View, Accessory: View>: ViewModifier {
@@ -225,42 +225,42 @@ struct MiniPlayerModifier<Regular: View, Accessory: View>: ViewModifier {
   
   @ViewBuilder
   private func iOSBody(_ content: Content) -> some View {
-      if #available(iOS 26.1, *) {
-        defaultBody(content)
-      } else if #available(iOS 26.0, *) {
-          content
-              .tabBarMinimizeBehavior(.onScrollDown)
-              .tabViewBottomAccessory(content: accessory)
-      } else {
-        defaultBody(content)
-      }
+    if #available(iOS 26.1, *) {
+      defaultBody(content)
+    } else if #available(iOS 26.0, *) {
+      content
+        .tabBarMinimizeBehavior(.onScrollDown)
+        .tabViewBottomAccessory(content: accessory)
+    } else {
+      defaultBody(content)
+    }
   }
   
   @ViewBuilder
   private func defaultBody(_ content: Content) -> some View {
-      content
-        .overlay(alignment: .bottom) {
-          regular()
-              .fixedSize(horizontal: false, vertical: true)
-                .overlay(
-                    GeometryReader { geo in
-                        Color.clear.preference(
-                            key: MiniPlayerSizePreferenceKey.self,
-                            value: geo.size
-                        )
-                    }
-                )
-        }
-        .onPreferenceChange(MiniPlayerSizePreferenceKey.self) {
-          let miniPlayerHeight = $0.height
-          let topPadding: CGFloat = 20
-          let reduceSize = hSize == .compact ? 44.0 : 0
-          let reduceTopPadding = miniPlayerHeight > reduceSize ? reduceSize : 0
-          miniPlayerBottomInset = miniPlayerHeight + topPadding - reduceTopPadding
-        }
-        .environment(\.miniPlayerBottomInset, miniPlayerBottomInset)
+    content
+      .overlay(alignment: .bottom) {
+        regular()
+          .fixedSize(horizontal: false, vertical: true)
+          .overlay(
+            GeometryReader { geo in
+              Color.clear.preference(
+                key: MiniPlayerSizePreferenceKey.self,
+                value: geo.size
+              )
+            }
+          )
+      }
+      .onPreferenceChange(MiniPlayerSizePreferenceKey.self) {
+        let miniPlayerHeight = $0.height
+        let topPadding: CGFloat = 20
+        let reduceSize = hSize == .compact ? 44.0 : 0
+        let reduceTopPadding = miniPlayerHeight > reduceSize ? reduceSize : 0
+        miniPlayerBottomInset = miniPlayerHeight + topPadding - reduceTopPadding
+      }
+      .environment(\.miniPlayerBottomInset, miniPlayerBottomInset)
   }
-
+  
 }
 extension View {
   func miniPlayer<Regular: View, Accessory: View>(


### PR DESCRIPTION
## Bugfix

- Add a bottom inset to the contents displayed on the tab so the mini player does not block any component behind it
- Bug known for iPad and MacOS versions of the app

## Related tasks

- Links to related tasks being addressed in this PR

## Approach

- Calculate the height of the space the mini player occupies and use its value to add an inset to the tabs

## Things to be aware of / Things to focus on

- This changes are applied to any device, not just iPad and MacOS

## Screenshots

<img width="343" height="503" alt="Screenshot 2026-02-04 at 5 32 22 PM" src="https://github.com/user-attachments/assets/f416e5b6-eb63-4f4d-8f4a-06103a9c5401" />
