### PR TITLE
z-gesture to back from player working with voice gesture

### DIFF
--- a/BookPlayer/Loading/LoadingViewController.swift
+++ b/BookPlayer/Loading/LoadingViewController.swift
@@ -34,9 +34,4 @@ class LoadingViewController: UIViewController, MVVMControllerProtocol, Storyboar
   func applyTheme(_ theme: SimpleTheme) {
     self.view.backgroundColor = theme.systemBackgroundColor
   }
-  
-  override func accessibilityPerformEscape() -> Bool {
-      viewModel.dismiss()
-      return true
-  }
 }

--- a/BookPlayer/Player/Player Screen/PlayerViewController.swift
+++ b/BookPlayer/Player/Player Screen/PlayerViewController.swift
@@ -239,8 +239,8 @@ class PlayerViewController: UIViewController, MVVMControllerProtocol, Storyboard
 // MARK: - Observers
 extension PlayerViewController {
   override func accessibilityPerformEscape() -> Bool {
-      viewModel.dismiss()
-      return true
+    viewModel.dismiss()
+    return true
   }
   
   func bindProgressObservers() {

--- a/BookPlayer/Utils/MVVMControllerProtocol.swift
+++ b/BookPlayer/Utils/MVVMControllerProtocol.swift
@@ -13,13 +13,6 @@ protocol MVVMControllerProtocol: UIViewController {
   var viewModel: VM! { get set }
 }
 
-extension MVVMControllerProtocol {
-  func accessibilityPerformEscape() -> Bool {
-    self.viewModel.dismiss()
-    return true
-  }
-}
-
 protocol ViewModelProtocol {
   associatedtype C: Coordinator
   var coordinator: C! { get set }


### PR DESCRIPTION
## Bugfix

- Z Gesture to dismiss Player in VoiceOver mode not working

## Approach

- Override method in main class extension

## Things to be aware of / Things to focus on

- Protocol Extensions do not override Objective-C runtime methods defined in ViewController
