### PR TITLE
Prevent deadlock on sync tasks

### DIFF
--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -1790,6 +1790,17 @@ class SyncServiceProtocolMock: SyncServiceProtocol {
         cancelAllJobsCallsCount += 1
         cancelAllJobsClosure?()
     }
+    //MARK: - resetAllJobs
+
+    var resetAllJobsCallsCount = 0
+    var resetAllJobsCalled: Bool {
+        return resetAllJobsCallsCount > 0
+    }
+    var resetAllJobsClosure: (() async -> Void)?
+    func resetAllJobs() async {
+        resetAllJobsCallsCount += 1
+        await resetAllJobsClosure?()
+    }
     //MARK: - cancelDownload
 
     var cancelDownloadOfThrowableError: Error?

--- a/Shared/Services/Sync/SyncJobScheduler.swift
+++ b/Shared/Services/Sync/SyncJobScheduler.swift
@@ -40,6 +40,8 @@ public protocol JobSchedulerProtocol {
   func getAllQueuedJobsWithParams() async -> [SyncTask]
   /// Cancel all stored and ongoing jobs
   func cancelAllJobs()
+  /// Cancel all stored and ongoing jobs and wait for completion
+  func resetAllJobs() async
   /// Check if there's an upload task queued for the item
   func hasUploadTask(for relativePath: String) async -> Bool
 }
@@ -273,6 +275,15 @@ public class SyncJobScheduler: JobSchedulerProtocol, BPLogger {
       await MainActor.run {
         tasksProgress.removeAll()
       }
+    }
+  }
+
+  public func resetAllJobs() async {
+    _ = await initializeStoreTask?.result
+    try? await taskStore.clearAll()
+    operationQueue.cancelAllOperations()
+    await MainActor.run {
+      tasksProgress.removeAll()
     }
   }
 


### PR DESCRIPTION
## Bugfix

- If the initial scheduling fails, there was no way to recover if a job gets queued up (that will always fail)