### PR TITLE
Fix VoiceOver performance lag with large libraries

### DIFF
--- a/BookPlayer/Library/ItemList/ItemListView.swift
+++ b/BookPlayer/Library/ItemList/ItemListView.swift
@@ -757,11 +757,7 @@ extension ItemListView {
   private func customBookRotor(with scrollView: ScrollViewProxy) -> some AccessibilityRotorContent {
     ForEach(model.filteredResults, id: \.id) { item in
       if item.type != .folder {
-        AccessibilityRotorEntry(
-          VoiceOverService.getAccessibilityLabel(for: item),
-          item.id,
-          in: customRotorNamespace
-        ) {
+        AccessibilityRotorEntry(item.title, item.id, in: customRotorNamespace) {
           scrollView.scrollTo(item.id)
         }
       }
@@ -772,11 +768,7 @@ extension ItemListView {
   private func customFolderRotor(with scrollView: ScrollViewProxy) -> some AccessibilityRotorContent {
     ForEach(model.filteredResults, id: \.id) { item in
       if item.type == .folder {
-        AccessibilityRotorEntry(
-          VoiceOverService.getAccessibilityLabel(for: item),
-          item.id,
-          in: customRotorNamespace
-        ) {
+        AccessibilityRotorEntry(item.title, item.id, in: customRotorNamespace) {
           scrollView.scrollTo(item.id)
         }
       }

--- a/BookPlayer/Library/ItemList/Views/DynamicAccessibilityLabel.swift
+++ b/BookPlayer/Library/ItemList/Views/DynamicAccessibilityLabel.swift
@@ -38,9 +38,11 @@ struct DynamicAccessibilityLabelModifier: ViewModifier {
       .onDisappear {
         cancellable?.cancel()
       }
-      .onChange(of: playerManager.currentItem?.relativePath) { _, _ in
-        // Re-setup observer when the playing item changes
-        setupObserver()
+      .onChange(of: playerManager.currentItem?.relativePath) { _, newPath in
+        // Only re-setup if this item is now playing, or was playing (has active subscription)
+        if newPath == item.relativePath || cancellable != nil {
+          setupObserver()
+        }
       }
   }
   

--- a/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
+++ b/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
@@ -39,6 +39,7 @@ struct ItemProgressView: View {
     .onReceive(
       libraryService.immediateProgressUpdatePublisher
         .filter { item.relativePath == $0["relativePath"] as? String }
+        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
     ) { params in
       if let percentCompleted = params["percentCompleted"] as? Double {
         self.progress = percentCompleted / 100


### PR DESCRIPTION
## Problem

When VoiceOver is enabled and a large number of books are loaded, the library list becomes noticeably laggy. Three separate issues compound to cause this:

1. **`DynamicAccessibilityLabelModifier` recomputes labels for every item on track change** — the `onChange(of: playerManager.currentItem?.relativePath)` handler calls `setupObserver()` unconditionally on every item in the list. For non-playing items this synchronously calls `VoiceOverService.getAccessibilityLabel()`, which does time arithmetic and `localizedStringWithFormat` with multiple arguments. With 100+ books this fires O(n) times on the main thread every time playback starts/stops/changes.

2. **Custom accessibility rotors call `getAccessibilityLabel` for all items on every rebuild** — `customBookRotor` and `customFolderRotor` pass `VoiceOverService.getAccessibilityLabel(for: item)` as the rotor entry label for every item. Rotors are rebuilt whenever `filteredResults` changes, and VoiceOver triggers these rebuilds frequently during navigation.

3. **`immediateProgressUpdatePublisher` in `ItemProgressView` is unthrottled** — the `folderProgressUpdated` subscription is throttled to 1s but `immediateProgressUpdatePublisher` is not, so rapid-fire progress writes hit every visible cell immediately.

## Changes

- **`DynamicAccessibilityLabelModifier`**: skip `setupObserver()` in the `onChange` handler for items that are neither currently playing nor have an active subscription. The expensive label recomputation now only runs for the one item that just started or stopped playing.

- **`ItemListView` custom rotors**: use `item.title` as the rotor entry label instead of calling `getAccessibilityLabel()`. The full rich label (with remaining time, progress %) is already applied by `dynamicAccessibilityLabel()` on each row — the rotor list only needs the title for navigation purposes.

- **`ItemProgressView`**: add `.throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)` to the `immediateProgressUpdatePublisher` subscription, consistent with the existing throttle on `folderProgressUpdated`.

## Testing

- Load 50+ books in the library
- Enable VoiceOver
- Navigate the list with swipe gestures — scrolling and focus changes should be noticeably smoother
- Start/pause/change playback — verify the playing item's label still updates with remaining time and the non-playing items are unaffected
- Use the Books and Folders rotors — verify items are correctly navigable by title