### PR TITLE
Fix Jellyfin search returning folders alongside audiobooks

### DIFF
--- a/BookPlayer/Jellyfin/Network/JellyfinConnectionService.swift
+++ b/BookPlayer/Jellyfin/Network/JellyfinConnectionService.swift
@@ -148,7 +148,7 @@ class JellyfinConnectionService: BPLogger {
     }
 
     let isRecursive = recursive || searchTerm != nil || folderID == nil
-    let itemTypes: [JellyfinAPI.BaseItemKind] = recursive ? [.audioBook] : [.audioBook, .folder]
+    let itemTypes: [JellyfinAPI.BaseItemKind] = (recursive || searchTerm != nil) ? [.audioBook] : [.audioBook, .folder]
 
     let parameters = Paths.GetItemsParameters(
       startIndex: startIndex,


### PR DESCRIPTION
## Purpose

Fixes a bug where Jellyfin search results include both folders and audiobooks when they share the same name. Only audiobooks should appear in search results.

This is Jellyfin-specific — AudiobookShelf uses a dedicated `/search` endpoint that only returns books server-side, so it's not affected.

## Approach

One-line change in `JellyfinConnectionService.fetchItems` — the `itemTypes` filter now also checks for `searchTerm != nil`, excluding folders from search results while preserving them for normal folder-level browsing.

## Related tasks

Fixes #1502

## Things to be aware of

- When browsing (no search term, not recursive): both audiobooks and folders are returned for navigation
- When searching or browsing recursively: only audiobooks are returned