### PR TITLE
Avoid redundant @Published writes when recalculating player progress

### DIFF
--- a/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
+++ b/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
@@ -10,6 +10,13 @@ import BookPlayerKit
 import SwiftUI
 
 struct ItemProgressView: View {
+  /// Throttle window applied to per-row progress publishers. Each visible row in a long
+  /// library list subscribes to three high-frequency progress streams; without throttling
+  /// SwiftUI re-diffs the circular indicators on every audio tick, which lags VoiceOver
+  /// and burns CPU. One second matches the existing `.folderProgressUpdated` cadence and
+  /// keeps the list feeling live.
+  private static let progressUpdateThrottleSeconds = 1
+
   let item: SimpleLibraryItem
   let isHighlighted: Bool
 
@@ -51,14 +58,14 @@ struct ItemProgressView: View {
     .onReceive(
       playerManager.currentProgressPublisher()
         .filter { $0.0 == item.relativePath }
-        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
+        .throttle(for: .seconds(Self.progressUpdateThrottleSeconds), scheduler: DispatchQueue.main, latest: true)
     ) { (_, progress) in
       self.progress = progress
     }
     .onReceive(
       libraryService.immediateProgressUpdatePublisher
         .filter { item.relativePath == $0["relativePath"] as? String }
-        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
+        .throttle(for: .seconds(Self.progressUpdateThrottleSeconds), scheduler: DispatchQueue.main, latest: true)
     ) { params in
       if let percentCompleted = params["percentCompleted"] as? Double {
         self.progress = percentCompleted / 100
@@ -69,7 +76,7 @@ struct ItemProgressView: View {
     }
     .onReceive(
       NotificationCenter.default.publisher(for: .folderProgressUpdated)
-        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
+        .throttle(for: .seconds(Self.progressUpdateThrottleSeconds), scheduler: DispatchQueue.main, latest: true)
         .filter { notification in
           guard
             item.type != .book,

--- a/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
+++ b/BookPlayer/Library/ItemList/Views/ItemProgressView.swift
@@ -51,12 +51,14 @@ struct ItemProgressView: View {
     .onReceive(
       playerManager.currentProgressPublisher()
         .filter { $0.0 == item.relativePath }
+        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
     ) { (_, progress) in
       self.progress = progress
     }
     .onReceive(
       libraryService.immediateProgressUpdatePublisher
         .filter { item.relativePath == $0["relativePath"] as? String }
+        .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
     ) { params in
       if let percentCompleted = params["percentCompleted"] as? Double {
         self.progress = percentCompleted / 100

--- a/BookPlayer/Player/Models/ProgressData.swift
+++ b/BookPlayer/Player/Models/ProgressData.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BookPlayerKit
 
-struct ProgressData {
+struct ProgressData: Equatable {
   var currentTime: TimeInterval = 0.0
   var progress: String?
   var maxTime: TimeInterval?

--- a/BookPlayer/Player/ViewModels/PlayerViewModel.swift
+++ b/BookPlayer/Player/ViewModels/PlayerViewModel.swift
@@ -223,7 +223,7 @@ final class PlayerViewModel: ObservableObject {
     
     self.playingProgressSubscriber?.cancel()
     self.playingProgressSubscriber = NotificationCenter.default.publisher(for: .bookPlaying)
-      .receive(on: DispatchQueue.main)
+      .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
       .sink { [weak self] _ in
         guard let self = self else { return }
         self.recalculateProgress()
@@ -231,7 +231,7 @@ final class PlayerViewModel: ObservableObject {
 
     self.listeningProgressSubscriber?.cancel()
     self.listeningProgressSubscriber = NotificationCenter.default.publisher(for: .listeningProgressChanged)
-      .receive(on: DispatchQueue.main)
+      .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
       .sink { [weak self] _ in
         guard let self = self else { return }
         self.recalculateProgress()

--- a/BookPlayer/Player/ViewModels/PlayerViewModel.swift
+++ b/BookPlayer/Player/ViewModels/PlayerViewModel.swift
@@ -21,6 +21,13 @@ enum PlayerSheetStyle: String, Identifiable {
 
 @MainActor
 final class PlayerViewModel: ObservableObject {
+  /// Throttle window applied to high-frequency playback-progress notifications
+  /// (`.bookPlaying`, `.listeningProgressChanged`) before they trigger a recompute of the
+  /// progress UI. Tuned to a roughly 2 Hz refresh — fast enough for the time/progress
+  /// readout to feel live, slow enough to keep the main thread out of the audio engine's
+  /// per-tick firehose.
+  private static let progressNotificationThrottleMs = 500
+
   @Published var progressData = ProgressData()
   @Published var isPlaying = false
   @Published var playbackSpeed: Float = 1.0
@@ -223,7 +230,7 @@ final class PlayerViewModel: ObservableObject {
     
     self.playingProgressSubscriber?.cancel()
     self.playingProgressSubscriber = NotificationCenter.default.publisher(for: .bookPlaying)
-      .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
+      .throttle(for: .milliseconds(Self.progressNotificationThrottleMs), scheduler: DispatchQueue.main, latest: true)
       .sink { [weak self] _ in
         guard let self = self else { return }
         self.recalculateProgress()
@@ -231,7 +238,7 @@ final class PlayerViewModel: ObservableObject {
 
     self.listeningProgressSubscriber?.cancel()
     self.listeningProgressSubscriber = NotificationCenter.default.publisher(for: .listeningProgressChanged)
-      .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
+      .throttle(for: .milliseconds(Self.progressNotificationThrottleMs), scheduler: DispatchQueue.main, latest: true)
       .sink { [weak self] _ in
         guard let self = self else { return }
         self.recalculateProgress()

--- a/BookPlayer/Player/ViewModels/PlayerViewModel.swift
+++ b/BookPlayer/Player/ViewModels/PlayerViewModel.swift
@@ -443,17 +443,33 @@ final class PlayerViewModel: ObservableObject {
       sliderValue = Float(currentItem?.progressPercentage ?? 0)
     }
     
-    self.hasPreviousChapter = self.hasChapter(before: currentItem?.currentChapter)
-    self.hasNextChapter = self.hasChapter(after: currentItem?.currentChapter)
+    // This runs on every playback tick; writing a @Published property fires
+    // objectWillChange even when the value is unchanged, so skip no-op writes
+    // and collapse the progressData field updates into a single assignment.
+    let hasPreviousChapter = self.hasChapter(before: currentItem?.currentChapter)
+    let hasNextChapter = self.hasChapter(after: currentItem?.currentChapter)
+
+    if self.hasPreviousChapter != hasPreviousChapter {
+      self.hasPreviousChapter = hasPreviousChapter
+    }
+    if self.hasNextChapter != hasNextChapter {
+      self.hasNextChapter = hasNextChapter
+    }
     self.chapterBeforeSliderValueChange = currentItem?.currentChapter
-    
-    progressData.chapterTitle = currentItem?.currentChapter?.title
-      ?? currentItem?.title
-      ?? ""
-    progressData.progress = progress
-    progressData.maxTime = maxTimeInContext
-    progressData.currentTime = currentTime
-    progressData.sliderValue = Double(sliderValue)
+
+    let newProgressData = ProgressData(
+      currentTime: currentTime,
+      progress: progress,
+      maxTime: maxTimeInContext,
+      sliderValue: Double(sliderValue),
+      chapterTitle: currentItem?.currentChapter?.title
+        ?? currentItem?.title
+        ?? ""
+    )
+
+    if progressData != newProgressData {
+      progressData = newProgressData
+    }
   }
   
   func handleNextTap() {


### PR DESCRIPTION
> **Maintainer edit:** this PR was refocused and rebased onto latest `develop`. Review of the original throttle approach found it couldn't reduce the 1 Hz update rate (a 500ms throttle over a 1/sec source passes every event through), and the throttle on `immediateProgressUpdatePublisher` could drop `isFinished` updates on folder rows. The branch now targets the redundant `@Published` churn directly.

## Summary

- Make `ProgressData` conform to `Equatable`
- `recalculateProgress()` now builds the new `ProgressData` locally and assigns the `@Published` property once, only when the value actually changed (previously five separate field writes, each firing `objectWillChange`)
- `hasPreviousChapter` / `hasNextChapter` are only written when their values change (previously rewritten on every playback tick)

## Context

Related to #1509. `recalculateProgress()` runs on every playback tick (1 Hz AVPlayer periodic observer), and previously fired `objectWillChange` up to seven times per tick even when most values were unchanged.

This does not fully close #1509: the library-list cost (the per-tick `lastPlayDate` fan-out to folder rows through the immediate metadata publisher, and the unthrottled `DynamicAccessibilityLabel` rebuild) is a separate follow-up.

## Test plan

- [ ] Play a chaptered book: slider, current/remaining time, chapter title, and prev/next chevrons update as before
- [ ] Toggle chapter-context and remaining-time preferences during playback
- [ ] Drag the slider across a chapter boundary and release; position sticks
- [ ] Play a book inside nested folders and verify library progress rings still update