### PR TITLE
Allow web URL imports via the share extension

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		41F1A20D254B0A0C0043FCF3 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A20C254B0A0C0043FCF3 /* Sentry */; };
 		41F1A228254B0C6C0043FCF3 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A227254B0C6C0043FCF3 /* ZipArchive */; };
 		6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */; };
+		7B91D2C3E04F1B8A7E62C805 /* ShareDownloadSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */; };
 		4645F9FD2D1E46AC00A04257 /* SwipeInlineTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */; };
 		465D87522D3195D600A4AA47 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87512D3195D600A4AA47 /* BookmarksView.swift */; };
 		465D87542D31965100A4AA47 /* BookmarksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87532D31965100A4AA47 /* BookmarksViewModel.swift */; };
@@ -1812,6 +1813,7 @@
 		D6BA8F172A4D66CD00C2BD9A /* StorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageView.swift; sourceTree = "<group>"; };
 		D6F6A0DE6FBE7828D4C7EC9C /* m4b_WELLFORMED.m4b */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = m4b_WELLFORMED.m4b; sourceTree = "<group>"; };
 		6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportFailureStore.swift; sourceTree = "<group>"; };
+		7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDownloadSupport.swift; sourceTree = "<group>"; };
 		E1FDA0B60D7BE4CFE100A612 /* IntegrationDisconnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationDisconnectedView.swift; sourceTree = "<group>"; };
 		E4D25EF2A5FFF30CF12F2C21 /* PreferencesSyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferencesSyncService.swift; sourceTree = "<group>"; };
 		E55F466D61AE62A69DE4D371 /* BPNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPNavigation.swift; sourceTree = "<group>"; };
@@ -2644,6 +2646,7 @@
 				41EB071A2752FA6B00EFEE13 /* PlaybackService.swift */,
 				63344C012EA7097D00B90DF7 /* DatabaseBackupService.swift */,
 				6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */,
+				7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */,
 				63125D102C36D96800D35533 /* Events */,
 				9FC1E4612814F68F00522FA8 /* Account */,
 				9FD8FE4C286566FF00EB2C3D /* Sync */,
@@ -5026,6 +5029,7 @@
 				A13B98C548AA6BFD0E6FC0C7 /* PreferencesSyncService.swift in Sources */,
 				52AA441379FD94339FEECB55 /* SortPreferencesResolving.swift in Sources */,
 				6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */,
+				7B91D2C3E04F1B8A7E62C805 /* ShareDownloadSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		41F1A204254B09C00043FCF3 /* Themeable in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A203254B09C00043FCF3 /* Themeable */; };
 		41F1A20D254B0A0C0043FCF3 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A20C254B0A0C0043FCF3 /* Sentry */; };
 		41F1A228254B0C6C0043FCF3 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A227254B0C6C0043FCF3 /* ZipArchive */; };
+		6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */; };
 		4645F9FD2D1E46AC00A04257 /* SwipeInlineTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */; };
 		465D87522D3195D600A4AA47 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87512D3195D600A4AA47 /* BookmarksView.swift */; };
 		465D87542D31965100A4AA47 /* BookmarksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87532D31965100A4AA47 /* BookmarksViewModel.swift */; };
@@ -1810,6 +1811,7 @@
 		D6BA8F152A4CA94800C2BD9A /* StorageRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRowView.swift; sourceTree = "<group>"; };
 		D6BA8F172A4D66CD00C2BD9A /* StorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageView.swift; sourceTree = "<group>"; };
 		D6F6A0DE6FBE7828D4C7EC9C /* m4b_WELLFORMED.m4b */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = m4b_WELLFORMED.m4b; sourceTree = "<group>"; };
+		6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportFailureStore.swift; sourceTree = "<group>"; };
 		E1FDA0B60D7BE4CFE100A612 /* IntegrationDisconnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationDisconnectedView.swift; sourceTree = "<group>"; };
 		E4D25EF2A5FFF30CF12F2C21 /* PreferencesSyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferencesSyncService.swift; sourceTree = "<group>"; };
 		E55F466D61AE62A69DE4D371 /* BPNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPNavigation.swift; sourceTree = "<group>"; };
@@ -2641,6 +2643,7 @@
 				9FDDD2E0289BFCE20020C428 /* LibraryService+Sync.swift */,
 				41EB071A2752FA6B00EFEE13 /* PlaybackService.swift */,
 				63344C012EA7097D00B90DF7 /* DatabaseBackupService.swift */,
+				6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */,
 				63125D102C36D96800D35533 /* Events */,
 				9FC1E4612814F68F00522FA8 /* Account */,
 				9FD8FE4C286566FF00EB2C3D /* Sync */,
@@ -5022,6 +5025,7 @@
 				FF95F8C692908D744A32D761 /* PreferencesAPI.swift in Sources */,
 				A13B98C548AA6BFD0E6FC0C7 /* PreferencesSyncService.swift in Sources */,
 				52AA441379FD94339FEECB55 /* SortPreferencesResolving.swift in Sources */,
+				6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		41F1A228254B0C6C0043FCF3 /* ZipArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 41F1A227254B0C6C0043FCF3 /* ZipArchive */; };
 		6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */; };
 		7B91D2C3E04F1B8A7E62C805 /* ShareDownloadSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */; };
+		8C91D2C3E04F1B8A7E62C807 /* ShareCancelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C91D2C3E04F1B8A7E62C808 /* ShareCancelStore.swift */; };
 		4645F9FD2D1E46AC00A04257 /* SwipeInlineTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4645F9FC2D1E46AC00A04257 /* SwipeInlineTip.swift */; };
 		465D87522D3195D600A4AA47 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87512D3195D600A4AA47 /* BookmarksView.swift */; };
 		465D87542D31965100A4AA47 /* BookmarksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465D87532D31965100A4AA47 /* BookmarksViewModel.swift */; };
@@ -1814,6 +1815,7 @@
 		D6F6A0DE6FBE7828D4C7EC9C /* m4b_WELLFORMED.m4b */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; path = m4b_WELLFORMED.m4b; sourceTree = "<group>"; };
 		6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareImportFailureStore.swift; sourceTree = "<group>"; };
 		7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDownloadSupport.swift; sourceTree = "<group>"; };
+		8C91D2C3E04F1B8A7E62C808 /* ShareCancelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareCancelStore.swift; sourceTree = "<group>"; };
 		E1FDA0B60D7BE4CFE100A612 /* IntegrationDisconnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationDisconnectedView.swift; sourceTree = "<group>"; };
 		E4D25EF2A5FFF30CF12F2C21 /* PreferencesSyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferencesSyncService.swift; sourceTree = "<group>"; };
 		E55F466D61AE62A69DE4D371 /* BPNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPNavigation.swift; sourceTree = "<group>"; };
@@ -2647,6 +2649,7 @@
 				63344C012EA7097D00B90DF7 /* DatabaseBackupService.swift */,
 				6A91D2C3E04F1B8A7E62C804 /* ShareImportFailureStore.swift */,
 				7B91D2C3E04F1B8A7E62C806 /* ShareDownloadSupport.swift */,
+				8C91D2C3E04F1B8A7E62C808 /* ShareCancelStore.swift */,
 				63125D102C36D96800D35533 /* Events */,
 				9FC1E4612814F68F00522FA8 /* Account */,
 				9FD8FE4C286566FF00EB2C3D /* Sync */,
@@ -5030,6 +5033,7 @@
 				52AA441379FD94339FEECB55 /* SortPreferencesResolving.swift in Sources */,
 				6A91D2C3E04F1B8A7E62C803 /* ShareImportFailureStore.swift in Sources */,
 				7B91D2C3E04F1B8A7E62C805 /* ShareDownloadSupport.swift in Sources */,
+				8C91D2C3E04F1B8A7E62C807 /* ShareCancelStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -79,7 +79,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
     // Setup core services
     AppServices.shared.setupCoreServices()
 
+    /// Hook the URLSession delegate that handles share-extension background downloads.
+    /// Touching the lazy session re-attaches us as delegate for any transfer iOS already
+    /// has in flight from a prior share — without this, completions queued before the app
+    /// launched would be silently dropped.
+    BackgroundShareDownloadDelegate.shared.ensureSessionReady()
+
     return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
+    /// iOS calls this when a background URLSession we own has events to deliver and the app
+    /// was suspended/terminated. We only own the share-extension session; ignore others.
+    guard identifier == Constants.shareExtensionBackgroundSessionIdentifier else {
+      completionHandler()
+      return
+    }
+    BackgroundShareDownloadDelegate.shared.backgroundCompletionHandler = completionHandler
+    BackgroundShareDownloadDelegate.shared.ensureSessionReady()
   }
 
   func application(
@@ -466,5 +487,96 @@ extension AppDelegate {
     queue.maxConcurrentOperationCount = 1
 
     queue.addOperation(backupOperation)
+  }
+}
+
+/// Receives completion events for the background `URLSession` that the share extension
+/// uses to download shared web URLs. The share extension cannot keep its own foreground
+/// session alive after dismissal, so it kicks off the transfer with a background session
+/// keyed by `Constants.shareExtensionBackgroundSessionIdentifier`. When the download
+/// completes, iOS launches BookPlayer (in the background if needed) and routes events
+/// here. The delegate moves the temp file into the app group's shared folder, where
+/// BookPlayer's normal `ImportManager` pipeline picks it up the next time the user
+/// foregrounds the app.
+final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegate, BPLogger {
+  static let shared = BackgroundShareDownloadDelegate()
+
+  /// Stored from `application(_:handleEventsForBackgroundURLSession:completionHandler:)` —
+  /// must be invoked once `urlSessionDidFinishEvents` fires so iOS can take a fresh app
+  /// snapshot.
+  var backgroundCompletionHandler: (() -> Void)?
+
+  /// The session is recreated lazily with the same identifier the share extension uses,
+  /// which connects this delegate to any in-flight transfers iOS is already running for us.
+  private(set) lazy var session: URLSession = {
+    let config = URLSessionConfiguration.background(
+      withIdentifier: Constants.shareExtensionBackgroundSessionIdentifier
+    )
+    config.sharedContainerIdentifier = Constants.ApplicationGroupIdentifier
+    config.sessionSendsLaunchEvents = true
+    config.isDiscretionary = false
+    return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+  }()
+
+  /// Touch the lazy session so it hooks up as the delegate for any pending transfers. Call
+  /// from `AppDelegate.didFinishLaunching` so completions don't get lost when the app cold-
+  /// starts after a download finished while the app was suspended.
+  func ensureSessionReady() {
+    _ = session
+  }
+
+  // MARK: - URLSessionDownloadDelegate
+
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didFinishDownloadingTo location: URL
+  ) {
+    /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
+    /// file just contains the error body. Don't deposit garbage into the library.
+    if let httpResponse = downloadTask.response as? HTTPURLResponse,
+       !(200..<300).contains(httpResponse.statusCode)
+    {
+      Self.logger.error(
+        "share download \(downloadTask.originalRequest?.url?.absoluteString ?? "?") returned status \(httpResponse.statusCode)"
+      )
+      return
+    }
+
+    let originalURL = downloadTask.originalRequest?.url
+    let filename =
+      downloadTask.response?.suggestedFilename
+      ?? originalURL?.lastPathComponent
+      ?? "shared-\(UUID().uuidString)"
+    let destinationURL = DataManager.getSharedFilesFolderURL().appendingPathComponent(filename)
+
+    /// Replace any same-named stale download from a previous attempt.
+    try? FileManager.default.removeItem(at: destinationURL)
+    do {
+      try FileManager.default.moveItem(at: location, to: destinationURL)
+      Self.logger.info("share download landed at \(destinationURL.lastPathComponent)")
+    } catch {
+      Self.logger.error("share download move failed: \(error.localizedDescription)")
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    if let error {
+      Self.logger.error(
+        "share download task error: \(error.localizedDescription) for \(task.originalRequest?.url?.absoluteString ?? "?")"
+      )
+    }
+  }
+
+  func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    DispatchQueue.main.async { [weak self] in
+      let handler = self?.backgroundCompletionHandler
+      self?.backgroundCompletionHandler = nil
+      handler?()
+    }
   }
 }

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -545,6 +545,17 @@ final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegat
     let originalURL = downloadTask.originalRequest?.url
     let source = originalURL?.absoluteString ?? "shared file"
 
+    // If the user canceled this share before iOS finished the download, drop the temp
+    // file and bail out. Important for the case where the share extension was killed
+    // before its in-memory `task.cancel()` could propagate — the durable cancel marker
+    // in ShareCancelStore is the only signal left to honor the user's intent.
+    if let shareID = downloadTask.taskDescription, ShareCancelStore.isCanceled(shareID) {
+      Self.logger.info("share download \(source) canceled by user; dropping temp file")
+      try? FileManager.default.removeItem(at: location)
+      ShareCancelStore.clear(shareID)
+      return
+    }
+
     /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
     /// file just contains the error body. Don't deposit garbage into the library, and
     /// surface the failure to the user (via the share-import failure store) so they know

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -542,18 +542,31 @@ final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegat
     downloadTask: URLSessionDownloadTask,
     didFinishDownloadingTo location: URL
   ) {
+    let originalURL = downloadTask.originalRequest?.url
+    let source = originalURL?.absoluteString ?? "shared file"
+
     /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
-    /// file just contains the error body. Don't deposit garbage into the library.
+    /// file just contains the error body. Don't deposit garbage into the library, and
+    /// surface the failure to the user (via the share-import failure store) so they know
+    /// the share didn't actually succeed.
     if let httpResponse = downloadTask.response as? HTTPURLResponse,
        !(200..<300).contains(httpResponse.statusCode)
     {
       Self.logger.error(
-        "share download \(downloadTask.originalRequest?.url?.absoluteString ?? "?") returned status \(httpResponse.statusCode)"
+        "share download \(source) returned status \(httpResponse.statusCode)"
+      )
+      ShareImportFailureStore.append(
+        ShareImportFailure(
+          source: source,
+          message: String(
+            format: "share_import_failure_http_status".localized,
+            httpResponse.statusCode
+          )
+        )
       )
       return
     }
 
-    let originalURL = downloadTask.originalRequest?.url
     let filename =
       downloadTask.response?.suggestedFilename
       ?? originalURL?.lastPathComponent
@@ -567,6 +580,16 @@ final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegat
       Self.logger.info("share download landed at \(destinationURL.lastPathComponent)")
     } catch {
       Self.logger.error("share download move failed: \(error.localizedDescription)")
+      ShareImportFailureStore.append(
+        ShareImportFailure(
+          source: filename,
+          message: String(
+            format: "share_import_failure_move_failed".localized,
+            filename,
+            error.localizedDescription
+          )
+        )
+      )
     }
   }
 

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -567,14 +567,25 @@ final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegat
       return
     }
 
-    let filename =
+    let suggested =
       downloadTask.response?.suggestedFilename
       ?? originalURL?.lastPathComponent
       ?? "shared-\(UUID().uuidString)"
-    let destinationURL = DataManager.getSharedFilesFolderURL().appendingPathComponent(filename)
+    let filename = ShareDownloadSupport.sanitizedFilename(suggested)
+    let mime = (downloadTask.response as? HTTPURLResponse)?.mimeType?.lowercased()
 
-    /// Replace any same-named stale download from a previous attempt.
-    try? FileManager.default.removeItem(at: destinationURL)
+    if let rejection = ShareDownloadSupport.rejectionReason(forMIME: mime, filename: filename) {
+      Self.logger.error("share download \(source) rejected: \(rejection)")
+      ShareImportFailureStore.append(
+        ShareImportFailure(source: source, message: rejection)
+      )
+      try? FileManager.default.removeItem(at: location)
+      return
+    }
+
+    // Avoid collisions from concurrent shares of the same URL by prefixing a short UUID.
+    let destinationURL = DataManager.getSharedFilesFolderURL()
+      .appendingPathComponent(ShareDownloadSupport.uniqueDestinationName(for: filename))
     do {
       try FileManager.default.moveItem(at: location, to: destinationURL)
       Self.logger.info("share download landed at \(destinationURL.lastPathComponent)")

--- a/BookPlayer/AppDelegate.swift
+++ b/BookPlayer/AppDelegate.swift
@@ -81,7 +81,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate, BPLogger {
     // Setup core services
     AppServices.shared.setupCoreServices()
 
+    /// Hook the URLSession delegate that handles share-extension background downloads.
+    /// Touching the lazy session re-attaches us as delegate for any transfer iOS already
+    /// has in flight from a prior share — without this, completions queued before the app
+    /// launched would be silently dropped.
+    BackgroundShareDownloadDelegate.shared.ensureSessionReady()
+
     return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
+    /// iOS calls this when a background URLSession we own has events to deliver and the app
+    /// was suspended/terminated. We only own the share-extension session; ignore others.
+    guard identifier == Constants.shareExtensionBackgroundSessionIdentifier else {
+      completionHandler()
+      return
+    }
+    BackgroundShareDownloadDelegate.shared.backgroundCompletionHandler = completionHandler
+    BackgroundShareDownloadDelegate.shared.ensureSessionReady()
   }
 
   func application(
@@ -476,5 +497,96 @@ extension AppDelegate {
     queue.maxConcurrentOperationCount = 1
 
     queue.addOperation(backupOperation)
+  }
+}
+
+/// Receives completion events for the background `URLSession` that the share extension
+/// uses to download shared web URLs. The share extension cannot keep its own foreground
+/// session alive after dismissal, so it kicks off the transfer with a background session
+/// keyed by `Constants.shareExtensionBackgroundSessionIdentifier`. When the download
+/// completes, iOS launches BookPlayer (in the background if needed) and routes events
+/// here. The delegate moves the temp file into the app group's shared folder, where
+/// BookPlayer's normal `ImportManager` pipeline picks it up the next time the user
+/// foregrounds the app.
+final class BackgroundShareDownloadDelegate: NSObject, URLSessionDownloadDelegate, BPLogger {
+  static let shared = BackgroundShareDownloadDelegate()
+
+  /// Stored from `application(_:handleEventsForBackgroundURLSession:completionHandler:)` —
+  /// must be invoked once `urlSessionDidFinishEvents` fires so iOS can take a fresh app
+  /// snapshot.
+  var backgroundCompletionHandler: (() -> Void)?
+
+  /// The session is recreated lazily with the same identifier the share extension uses,
+  /// which connects this delegate to any in-flight transfers iOS is already running for us.
+  private(set) lazy var session: URLSession = {
+    let config = URLSessionConfiguration.background(
+      withIdentifier: Constants.shareExtensionBackgroundSessionIdentifier
+    )
+    config.sharedContainerIdentifier = Constants.ApplicationGroupIdentifier
+    config.sessionSendsLaunchEvents = true
+    config.isDiscretionary = false
+    return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+  }()
+
+  /// Touch the lazy session so it hooks up as the delegate for any pending transfers. Call
+  /// from `AppDelegate.didFinishLaunching` so completions don't get lost when the app cold-
+  /// starts after a download finished while the app was suspended.
+  func ensureSessionReady() {
+    _ = session
+  }
+
+  // MARK: - URLSessionDownloadDelegate
+
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didFinishDownloadingTo location: URL
+  ) {
+    /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
+    /// file just contains the error body. Don't deposit garbage into the library.
+    if let httpResponse = downloadTask.response as? HTTPURLResponse,
+       !(200..<300).contains(httpResponse.statusCode)
+    {
+      Self.logger.error(
+        "share download \(downloadTask.originalRequest?.url?.absoluteString ?? "?") returned status \(httpResponse.statusCode)"
+      )
+      return
+    }
+
+    let originalURL = downloadTask.originalRequest?.url
+    let filename =
+      downloadTask.response?.suggestedFilename
+      ?? originalURL?.lastPathComponent
+      ?? "shared-\(UUID().uuidString)"
+    let destinationURL = DataManager.getSharedFilesFolderURL().appendingPathComponent(filename)
+
+    /// Replace any same-named stale download from a previous attempt.
+    try? FileManager.default.removeItem(at: destinationURL)
+    do {
+      try FileManager.default.moveItem(at: location, to: destinationURL)
+      Self.logger.info("share download landed at \(destinationURL.lastPathComponent)")
+    } catch {
+      Self.logger.error("share download move failed: \(error.localizedDescription)")
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    if let error {
+      Self.logger.error(
+        "share download task error: \(error.localizedDescription) for \(task.originalRequest?.url?.absoluteString ?? "?")"
+      )
+    }
+  }
+
+  func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    DispatchQueue.main.async { [weak self] in
+      let handler = self?.backgroundCompletionHandler
+      self?.backgroundCompletionHandler = nil
+      handler?()
+    }
   }
 }

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -366,6 +366,8 @@ We're working hard on providing a seamless experience, if possible, please conta
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Connect to your %@ server";

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -362,6 +362,11 @@ We're working hard on providing a seamless experience, if possible, please conta
 "integration_connect_button" = "Connect";
 "integration_sign_in_button" = "Sign In";
 "integration_retry_button" = "Retry";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Connect to your %@ server";
 "integration_section_server" = "Server";

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -92,6 +92,7 @@ struct LibraryRootView: View {
       }
       .onChange(of: scenePhase) {
         guard scenePhase == .active else { return }
+        drainPendingShareDownloadURLs()
         showImport()
       }
       .onReceive(syncService.downloadErrorPublisher) { (relativePath, error) in
@@ -143,18 +144,28 @@ struct LibraryRootView: View {
       ActionParserService.handleAction(action)
     }
 
-    /// Drain web URLs queued by the share extension into `SingleFileDownloadService` so
-    /// they download with progress in BookPlayer's normal UI and land directly in the
-    /// library (no separate AirDrop-style import confirmation).
+    drainPendingShareDownloadURLs()
+  }
+
+  /// Drain web URLs the share extension queued in shared `UserDefaults` and feed them
+  /// to `SingleFileDownloadService` so the download runs in BookPlayer's normal UI and
+  /// lands directly in the library. Called both on initial library load and on every
+  /// `scenePhase == .active` transition: handleLibraryLoaded only fires once per
+  /// `LibraryRootView` lifecycle, but the user can share to BookPlayer while it's still
+  /// in memory in the background, in which case the drain has to run on warm-foreground
+  /// too. Idempotent: removing the UserDefaults key first means re-runs are no-ops.
+  func drainPendingShareDownloadURLs() {
     let pendingShareURLStrings =
       UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
       ?? []
-    if !pendingShareURLStrings.isEmpty {
-      UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-      let urls = pendingShareURLStrings.compactMap(URL.init(string:))
-      if !urls.isEmpty {
-        singleFileDownloadService.handleDownload(urls)
-      }
+    NSLog("BP-DRAIN: drainPendingShareDownloadURLs called, found %d URLs", pendingShareURLStrings.count)
+    guard !pendingShareURLStrings.isEmpty else { return }
+
+    UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+    let urls = pendingShareURLStrings.compactMap(URL.init(string:))
+    if !urls.isEmpty {
+      NSLog("BP-DRAIN: handing %d URLs to singleFileDownloadService", urls.count)
+      singleFileDownloadService.handleDownload(urls)
     }
   }
 

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -142,6 +142,20 @@ struct LibraryRootView: View {
     for action in pendingActions {
       ActionParserService.handleAction(action)
     }
+
+    /// Drain web URLs queued by the share extension into `SingleFileDownloadService` so
+    /// they download with progress in BookPlayer's normal UI and land directly in the
+    /// library (no separate AirDrop-style import confirmation).
+    let pendingShareURLStrings =
+      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+      ?? []
+    if !pendingShareURLStrings.isEmpty {
+      UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+      let urls = pendingShareURLStrings.compactMap(URL.init(string:))
+      if !urls.isEmpty {
+        singleFileDownloadService.handleDownload(urls)
+      }
+    }
   }
 
   func loadLastBookIfNeeded() async {

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -92,7 +92,6 @@ struct LibraryRootView: View {
       }
       .onChange(of: scenePhase) {
         guard scenePhase == .active else { return }
-        drainPendingShareDownloadURLs()
         showImport()
       }
       .onReceive(syncService.downloadErrorPublisher) { (relativePath, error) in
@@ -142,30 +141,6 @@ struct LibraryRootView: View {
     AppServices.shared.pendingURLActions.removeAll()
     for action in pendingActions {
       ActionParserService.handleAction(action)
-    }
-
-    drainPendingShareDownloadURLs()
-  }
-
-  /// Drain web URLs the share extension queued in shared `UserDefaults` and feed them
-  /// to `SingleFileDownloadService` so the download runs in BookPlayer's normal UI and
-  /// lands directly in the library. Called both on initial library load and on every
-  /// `scenePhase == .active` transition: handleLibraryLoaded only fires once per
-  /// `LibraryRootView` lifecycle, but the user can share to BookPlayer while it's still
-  /// in memory in the background, in which case the drain has to run on warm-foreground
-  /// too. Idempotent: removing the UserDefaults key first means re-runs are no-ops.
-  func drainPendingShareDownloadURLs() {
-    let pendingShareURLStrings =
-      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-      ?? []
-    NSLog("BP-DRAIN: drainPendingShareDownloadURLs called, found %d URLs", pendingShareURLStrings.count)
-    guard !pendingShareURLStrings.isEmpty else { return }
-
-    UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-    let urls = pendingShareURLStrings.compactMap(URL.init(string:))
-    if !urls.isEmpty {
-      NSLog("BP-DRAIN: handing %d URLs to singleFileDownloadService", urls.count)
-      singleFileDownloadService.handleDownload(urls)
     }
   }
 

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -92,7 +92,6 @@ struct LibraryRootView: View {
       }
       .onChange(of: scenePhase) {
         guard scenePhase == .active else { return }
-        drainPendingShareDownloadURLs()
         showImport()
       }
       .onReceive(syncService.downloadErrorPublisher) { (relativePath, error) in
@@ -150,30 +149,6 @@ struct LibraryRootView: View {
     AppServices.shared.pendingURLActions.removeAll()
     for action in pendingActions {
       ActionParserService.handleAction(action)
-    }
-
-    drainPendingShareDownloadURLs()
-  }
-
-  /// Drain web URLs the share extension queued in shared `UserDefaults` and feed them
-  /// to `SingleFileDownloadService` so the download runs in BookPlayer's normal UI and
-  /// lands directly in the library. Called both on initial library load and on every
-  /// `scenePhase == .active` transition: handleLibraryLoaded only fires once per
-  /// `LibraryRootView` lifecycle, but the user can share to BookPlayer while it's still
-  /// in memory in the background, in which case the drain has to run on warm-foreground
-  /// too. Idempotent: removing the UserDefaults key first means re-runs are no-ops.
-  func drainPendingShareDownloadURLs() {
-    let pendingShareURLStrings =
-      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-      ?? []
-    NSLog("BP-DRAIN: drainPendingShareDownloadURLs called, found %d URLs", pendingShareURLStrings.count)
-    guard !pendingShareURLStrings.isEmpty else { return }
-
-    UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-    let urls = pendingShareURLStrings.compactMap(URL.init(string:))
-    if !urls.isEmpty {
-      NSLog("BP-DRAIN: handing %d URLs to singleFileDownloadService", urls.count)
-      singleFileDownloadService.handleDownload(urls)
     }
   }
 

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -150,6 +150,20 @@ struct LibraryRootView: View {
     for action in pendingActions {
       ActionParserService.handleAction(action)
     }
+
+    /// Drain web URLs queued by the share extension into `SingleFileDownloadService` so
+    /// they download with progress in BookPlayer's normal UI and land directly in the
+    /// library (no separate AirDrop-style import confirmation).
+    let pendingShareURLStrings =
+      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+      ?? []
+    if !pendingShareURLStrings.isEmpty {
+      UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+      let urls = pendingShareURLStrings.compactMap(URL.init(string:))
+      if !urls.isEmpty {
+        singleFileDownloadService.handleDownload(urls)
+      }
+    }
   }
 
   func loadLastBookIfNeeded() async {

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -92,6 +92,7 @@ struct LibraryRootView: View {
       }
       .onChange(of: scenePhase) {
         guard scenePhase == .active else { return }
+        drainPendingShareDownloadURLs()
         showImport()
       }
       .onReceive(syncService.downloadErrorPublisher) { (relativePath, error) in
@@ -151,18 +152,28 @@ struct LibraryRootView: View {
       ActionParserService.handleAction(action)
     }
 
-    /// Drain web URLs queued by the share extension into `SingleFileDownloadService` so
-    /// they download with progress in BookPlayer's normal UI and land directly in the
-    /// library (no separate AirDrop-style import confirmation).
+    drainPendingShareDownloadURLs()
+  }
+
+  /// Drain web URLs the share extension queued in shared `UserDefaults` and feed them
+  /// to `SingleFileDownloadService` so the download runs in BookPlayer's normal UI and
+  /// lands directly in the library. Called both on initial library load and on every
+  /// `scenePhase == .active` transition: handleLibraryLoaded only fires once per
+  /// `LibraryRootView` lifecycle, but the user can share to BookPlayer while it's still
+  /// in memory in the background, in which case the drain has to run on warm-foreground
+  /// too. Idempotent: removing the UserDefaults key first means re-runs are no-ops.
+  func drainPendingShareDownloadURLs() {
     let pendingShareURLStrings =
       UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
       ?? []
-    if !pendingShareURLStrings.isEmpty {
-      UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-      let urls = pendingShareURLStrings.compactMap(URL.init(string:))
-      if !urls.isEmpty {
-        singleFileDownloadService.handleDownload(urls)
-      }
+    NSLog("BP-DRAIN: drainPendingShareDownloadURLs called, found %d URLs", pendingShareURLStrings.count)
+    guard !pendingShareURLStrings.isEmpty else { return }
+
+    UserDefaults.sharedDefaults.removeObject(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+    let urls = pendingShareURLStrings.compactMap(URL.init(string:))
+    if !urls.isEmpty {
+      NSLog("BP-DRAIN: handing %d URLs to singleFileDownloadService", urls.count)
+      singleFileDownloadService.handleDownload(urls)
     }
   }
 

--- a/BookPlayer/Library/ItemList/LibraryRootView.swift
+++ b/BookPlayer/Library/ItemList/LibraryRootView.swift
@@ -22,6 +22,11 @@ struct LibraryRootView: View {
   @State private var importOperationState = ImportOperationState()
   @State private var loadingState = LoadingOverlayState()
 
+  /// Failures recovered from `ShareImportFailureStore` on foreground — drained once per scene
+  /// activation, surfaced in an alert plus a VoiceOver announcement. Cleared when the user
+  /// dismisses the alert.
+  @State private var pendingShareImportFailures: [ShareImportFailure] = []
+
   @StateObject private var documentFolderWatcher = DirectoryWatcher.watch(
     DataManager.getDocumentsFolderURL(),
     ignoreDirectories: false
@@ -93,7 +98,21 @@ struct LibraryRootView: View {
       .onChange(of: scenePhase) {
         guard scenePhase == .active else { return }
         showImport()
+        drainShareImportFailures()
       }
+      .alert(
+        "share_import_failure_alert_title".localized,
+        isPresented: Binding(
+          get: { !pendingShareImportFailures.isEmpty },
+          set: { if !$0 { pendingShareImportFailures = [] } }
+        ),
+        actions: {
+          Button("ok_button".localized) { pendingShareImportFailures = [] }
+        },
+        message: {
+          Text(pendingShareImportFailures.map { "• \($0.message)" }.joined(separator: "\n"))
+        }
+      )
       .onReceive(syncService.downloadErrorPublisher) { (relativePath, error) in
         let errorMessage = "\(relativePath)\n\(error.localizedDescription)"
         loadingState.error = BookPlayerError.networkError(errorMessage)
@@ -150,6 +169,28 @@ struct LibraryRootView: View {
     for action in pendingActions {
       ActionParserService.handleAction(action)
     }
+  }
+
+  /// Drain share-import failures that piled up while the app wasn't foregrounded — these come
+  /// from the share extension's synchronous copy errors and the main app's background-download
+  /// delegate move/HTTP errors. We surface them via the alert (visible) and a VoiceOver
+  /// announcement so a blind user knows the share didn't actually succeed.
+  func drainShareImportFailures() {
+    let failures = ShareImportFailureStore.drain()
+    guard !failures.isEmpty else { return }
+    pendingShareImportFailures = failures
+
+    let announcement: String = {
+      if failures.count == 1 {
+        return failures[0].message
+      }
+      let summary = String(
+        format: "share_import_failure_announcement_multiple".localized,
+        failures.count
+      )
+      return summary + " " + failures.map(\.message).joined(separator: ". ")
+    }()
+    UIAccessibility.post(notification: .announcement, argument: announcement)
   }
 
   func loadLastBookIfNeeded() async {

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -363,6 +363,11 @@
 "integration_retry_button" = "إعادة المحاولة";
 "integration_add_server_button" = "إضافة خادم";
 "media_servers_title" = "خوادم الوسائط";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "عنوان URL للخادم";
 "integration_section_server_url_footer" = "الاتصال بخادم @% الخاص بك";
 "integration_section_server" = "الخادم";

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -367,6 +367,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "عنوان URL للخادم";
 "integration_section_server_url_footer" = "الاتصال بخادم @% الخاص بك";

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -367,6 +367,8 @@ Estem treballant dur per oferir una experiència perfecta; si és possible, pose
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del servidor";
 "integration_section_server_url_footer" = "Connecteu-vos al vostre servidor %@";

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -363,6 +363,11 @@ Estem treballant dur per oferir una experiència perfecta; si és possible, pose
 "integration_retry_button" = "Torna-ho a provar";
 "integration_add_server_button" = "Afegeix un servidor";
 "media_servers_title" = "Servidors multimèdia";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del servidor";
 "integration_section_server_url_footer" = "Connecteu-vos al vostre servidor %@";
 "integration_section_server" = "Servidor";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adresa URL serveru";
 "integration_section_server_url_footer" = "Připojte se k serveru %@";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Zkusit znovu";
 "integration_add_server_button" = "Přidat server";
 "media_servers_title" = "Mediální servery";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adresa URL serveru";
 "integration_section_server_url_footer" = "Připojte se k serveru %@";
 "integration_section_server" = "Server";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Opret forbindelse til din %@-server";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Prøv igen";
 "integration_add_server_button" = "Tilføj server";
 "media_servers_title" = "Medieservere";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Opret forbindelse til din %@-server";
 "integration_section_server" = "Server";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server-URL";
 "integration_section_server_url_footer" = "Stelle eine Verbindung zu deinem %@-Server her";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Erneut versuchen";
 "integration_add_server_button" = "Server hinzufügen";
 "media_servers_title" = "Medienserver";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server-URL";
 "integration_section_server_url_footer" = "Stelle eine Verbindung zu deinem %@-Server her";
 "integration_section_server" = "Server";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -363,6 +363,11 @@
 "integration_retry_button" = "Επανάληψη";
 "integration_add_server_button" = "Προσθήκη διακομιστή";
 "media_servers_title" = "Διακομιστές πολυμέσων";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL διακομιστή";
 "integration_section_server_url_footer" = "Συνδεθείτε στον διακομιστή %@";
 "integration_section_server" = "Υπηρέτης";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -367,6 +367,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL διακομιστή";
 "integration_section_server_url_footer" = "Συνδεθείτε στον διακομιστή %@";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -367,6 +367,8 @@ We're working hard on providing a seamless experience, if possible, please conta
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Connect to your %@ server";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -363,6 +363,11 @@ We're working hard on providing a seamless experience, if possible, please conta
 "integration_connect_button" = "Connect";
 "integration_sign_in_button" = "Sign In";
 "integration_retry_button" = "Retry";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Connect to your %@ server";
 "integration_section_server" = "Server";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Reintentar";
 "integration_add_server_button" = "Añadir servidor";
 "media_servers_title" = "Servidores multimedia";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del servidor";
 "integration_section_server_url_footer" = "Conéctese a su servidor %@";
 "integration_section_server" = "Servidor";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del servidor";
 "integration_section_server_url_footer" = "Conéctese a su servidor %@";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Palvelimen URL-osoite";
 "integration_section_server_url_footer" = "Yhdistä %@-palvelimeesi";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Yritä uudelleen";
 "integration_add_server_button" = "Lisää palvelin";
 "media_servers_title" = "Mediapalvelimet";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Palvelimen URL-osoite";
 "integration_section_server_url_footer" = "Yhdistä %@-palvelimeesi";
 "integration_section_server" = "Palvelin";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL du serveur";
 "integration_section_server_url_footer" = "Connectez-vous à votre serveur %@";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Réessayer";
 "integration_add_server_button" = "Ajouter un serveur";
 "media_servers_title" = "Serveurs multimédias";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL du serveur";
 "integration_section_server_url_footer" = "Connectez-vous à votre serveur %@";
 "integration_section_server" = "Serveur";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -363,6 +363,11 @@
 "integration_retry_button" = "Újrapróbálkozás";
 "integration_add_server_button" = "Kiszolgáló hozzáadása";
 "media_servers_title" = "Médiakiszolgálók";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Szerver URL";
 "integration_section_server_url_footer" = "Csatlakozás %@ szerverhez";
 "integration_section_server" = "Szerver";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -367,6 +367,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Szerver URL";
 "integration_section_server_url_footer" = "Csatlakozás %@ szerverhez";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del server";
 "integration_section_server_url_footer" = "Connettiti al tuo server %@";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Riprova";
 "integration_add_server_button" = "Aggiungi server";
 "media_servers_title" = "Server multimediali";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL del server";
 "integration_section_server_url_footer" = "Connettiti al tuo server %@";
 "integration_section_server" = "Server";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -363,6 +363,11 @@
 "integration_retry_button" = "再試行";
 "integration_add_server_button" = "サーバーを追加";
 "media_servers_title" = "メディアサーバー";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "サーバURL";
 "integration_section_server_url_footer" = "%@サーバに接続する";
 "integration_section_server" = "サーバ";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -367,6 +367,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "サーバURL";
 "integration_section_server_url_footer" = "%@サーバに接続する";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -362,6 +362,11 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "integration_retry_button" = "Prøv igjen";
 "integration_add_server_button" = "Legg til server";
 "media_servers_title" = "Medieservere";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Koble til %@-serveren din";
 "integration_section_server" = "Server";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -366,6 +366,8 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Koble til %@-serveren din";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server-URL";
 "integration_section_server_url_footer" = "Maak verbinding met uw %@-server";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Opnieuw proberen";
 "integration_add_server_button" = "Server toevoegen";
 "media_servers_title" = "Mediaservers";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server-URL";
 "integration_section_server_url_footer" = "Maak verbinding met uw %@-server";
 "integration_section_server" = "Server";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adres URL serwera";
 "integration_section_server_url_footer" = "Połącz się ze swoim serwerem %@";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Spróbuj ponownie";
 "integration_add_server_button" = "Dodaj serwer";
 "media_servers_title" = "Serwery multimediów";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adres URL serwera";
 "integration_section_server_url_footer" = "Połącz się ze swoim serwerem %@";
 "integration_section_server" = "Serwer";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL do servidor";
 "integration_section_server_url_footer" = "Conecte-se ao seu servidor %@";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Tentar novamente";
 "integration_add_server_button" = "Adicionar servidor";
 "media_servers_title" = "Servidores de mídia";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL do servidor";
 "integration_section_server_url_footer" = "Conecte-se ao seu servidor %@";
 "integration_section_server" = "Servidor";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL do servidor";
 "integration_section_server_url_footer" = "Conecte-se ao seu servidor %@";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Tentar novamente";
 "integration_add_server_button" = "Adicionar servidor";
 "media_servers_title" = "Servidores de multimédia";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL do servidor";
 "integration_section_server_url_footer" = "Conecte-se ao seu servidor %@";
 "integration_section_server" = "Servidor";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Reîncearcă";
 "integration_add_server_button" = "Adaugă server";
 "media_servers_title" = "Servere media";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adresa URL a serverului";
 "integration_section_server_url_footer" = "Conectați-vă la serverul dvs. %@";
 "integration_section_server" = "Server";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Adresa URL a serverului";
 "integration_section_server_url_footer" = "Conectați-vă la serverul dvs. %@";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Повторить";
 "integration_add_server_button" = "Добавить сервер";
 "media_servers_title" = "Медиасерверы";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL-адрес сервера";
 "integration_section_server_url_footer" = "Подключитесь к вашему серверу %@";
 "integration_section_server" = "Сервер";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL-адрес сервера";
 "integration_section_server_url_footer" = "Подключитесь к вашему серверу %@";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -363,6 +363,11 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "integration_retry_button" = "Skúsiť znova";
 "integration_add_server_button" = "Pridať server";
 "media_servers_title" = "Mediálne servery";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL servera";
 "integration_section_server_url_footer" = "Pripojenie sa k serveru %@";
 "integration_section_server" = "Server";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -367,6 +367,8 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL servera";
 "integration_section_server_url_footer" = "Pripojenie sa k serveru %@";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Anslut till din %@-server";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Försök igen";
 "integration_add_server_button" = "Lägg till server";
 "media_servers_title" = "Medieservrar";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Server URL";
 "integration_section_server_url_footer" = "Anslut till din %@-server";
 "integration_section_server" = "Server";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Sunucu URL'si";
 "integration_section_server_url_footer" = "%@ sunucunuza bağlanın";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Yeniden dene";
 "integration_add_server_button" = "Sunucu ekle";
 "media_servers_title" = "Medya sunucuları";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "Sunucu URL'si";
 "integration_section_server_url_footer" = "%@ sunucunuza bağlanın";
 "integration_section_server" = "Sunucu";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "Повторити";
 "integration_add_server_button" = "Додати сервер";
 "media_servers_title" = "Медіасервери";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL-адреса сервера";
 "integration_section_server_url_footer" = "Підключіться до свого сервера %@";
 "integration_section_server" = "Сервер";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "URL-адреса сервера";
 "integration_section_server_url_footer" = "Підключіться до свого сервера %@";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -362,6 +362,11 @@
 "integration_retry_button" = "重试";
 "integration_add_server_button" = "添加服务器";
 "media_servers_title" = "媒体服务器";
+"share_import_failure_alert_title" = "Some shared files didn’t import";
+"share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
+"share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
+"share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "服务器 URL";
 "integration_section_server_url_footer" = "连接到您的 %@ 服务器";
 "integration_section_server" = "服务器";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -366,6 +366,8 @@
 "share_import_failure_copy_failed" = "Couldn’t copy “%1$@” to BookPlayer: %2$@";
 "share_import_failure_move_failed" = "Couldn’t save “%1$@” to BookPlayer: %2$@";
 "share_import_failure_http_status" = "Download failed with HTTP status %d.";
+"share_import_failure_unsupported_type" = "Download returned content type “%@”, which isn’t an audiobook file. Try the direct download link.";
+"share_import_failure_unsupported_extension" = "Download did not look like an audiobook file (no recognized extension on “%@”). Try the direct download link.";
 "share_import_failure_announcement_multiple" = "%d shared imports failed.";
 "integration_section_server_url" = "服务器 URL";
 "integration_section_server_url_footer" = "连接到您的 %@ 服务器";

--- a/BookPlayerShareExtension/Info.plist
+++ b/BookPlayerShareExtension/Info.plist
@@ -20,6 +20,7 @@
         || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.folder&quot;
         || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.movie&quot;
         || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;com.pkware.zip-archive&quot;
+        || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.url&quot;
         )
         ).@count &gt; 0
         ).@count &gt; 0

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -223,7 +223,23 @@ class ShareViewController: UIViewController {
 
     for item in fileItems {
       let destinationURL = sharedFolder.appendingPathComponent(item.lastPathComponent)
-      try? FileManager.default.copyItem(at: item, to: destinationURL)
+      do {
+        try FileManager.default.copyItem(at: item, to: destinationURL)
+      } catch {
+        // Don't swallow disk-full / permission / collision errors. The user is blind
+        // and the share sheet is already gone by the time the main app foregrounds, so
+        // we persist the failure into the App Group for the host to surface.
+        ShareImportFailureStore.append(
+          ShareImportFailure(
+            source: item.lastPathComponent,
+            message: String(
+              format: "share_import_failure_copy_failed".localized,
+              item.lastPathComponent,
+              error.localizedDescription
+            )
+          )
+        )
+      }
     }
 
     if !webItems.isEmpty {
@@ -353,15 +369,26 @@ final class BackgroundDownloadCoordinator: NSObject, URLSessionDownloadDelegate 
     downloadTask: URLSessionDownloadTask,
     didFinishDownloadingTo location: URL
   ) {
+    let originalURL = downloadTask.originalRequest?.url
+    let source = originalURL?.absoluteString ?? "shared file"
+
     /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
-    /// file just contains the error body.
+    /// file just contains the error body. Record the failure so the host app can surface it.
     if let httpResponse = downloadTask.response as? HTTPURLResponse,
        !(200..<300).contains(httpResponse.statusCode)
     {
+      ShareImportFailureStore.append(
+        ShareImportFailure(
+          source: source,
+          message: String(
+            format: "share_import_failure_http_status".localized,
+            httpResponse.statusCode
+          )
+        )
+      )
       return
     }
 
-    let originalURL = downloadTask.originalRequest?.url
     let filename =
       downloadTask.response?.suggestedFilename
       ?? originalURL?.lastPathComponent
@@ -370,6 +397,19 @@ final class BackgroundDownloadCoordinator: NSObject, URLSessionDownloadDelegate 
 
     /// Replace any same-named stale download from a previous attempt.
     try? FileManager.default.removeItem(at: destinationURL)
-    try? FileManager.default.moveItem(at: location, to: destinationURL)
+    do {
+      try FileManager.default.moveItem(at: location, to: destinationURL)
+    } catch {
+      ShareImportFailureStore.append(
+        ShareImportFailure(
+          source: filename,
+          message: String(
+            format: "share_import_failure_move_failed".localized,
+            filename,
+            error.localizedDescription
+          )
+        )
+      )
+    }
   }
 }

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -215,35 +215,60 @@ class ShareViewController: UIViewController {
 
     /// Share extensions only ever receive a single URL in practice (Safari and most apps
     /// share one item at a time), so handing off the first web URL covers the realistic case.
+    /// We must defer `completeRequest` until *after* the URL has been handed to the host —
+    /// completing the extension request first dismisses the extension's process and iOS
+    /// drops the in-flight URL open.
     if let webURL = webItems.first {
-      openInHostApp(downloadURL: webURL)
-    }
-
-    DispatchQueue.main.async { [weak self] in
-      self?.extensionContext?.completeRequest(returningItems: nil)
+      openInHostApp(downloadURL: webURL) { [weak self] in
+        DispatchQueue.main.async {
+          self?.extensionContext?.completeRequest(returningItems: nil)
+        }
+      }
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        self?.extensionContext?.completeRequest(returningItems: nil)
+      }
     }
   }
 
   /// Hand a shareable URL to the main BookPlayer app via the `bookplayer://download?url=…`
   /// custom URL scheme.
   ///
-  /// Share extensions can't call `UIApplication.shared.open(_:)` directly, so we walk the
-  /// responder chain to find the `UIApplication` and invoke its `openURL:` selector. This
-  /// pattern is widely used by share extensions (1Password, Pocket, etc.) and is accepted
-  /// by App Review.
-  private func openInHostApp(downloadURL: URL) {
+  /// Tries `NSExtensionContext.open(_:completionHandler:)` first — Apple's docs claim it's
+  /// unavailable for share extensions, but in practice it works on iOS 14+ and is the only
+  /// reliable path on iOS 18+, where the older responder-chain `openURL:` walk no longer
+  /// reaches a live `UIApplication` from a share-extension context. Falls back to the
+  /// responder-chain walk for older iOS versions where the extensionContext path may return
+  /// false synchronously.
+  private func openInHostApp(downloadURL: URL, completion: @escaping () -> Void) {
     guard
       let escaped = downloadURL.absoluteString.addingPercentEncoding(
         withAllowedCharacters: .urlQueryAllowed
       ),
       let actionURL = URL(string: "bookplayer://download?url=\(escaped)")
-    else { return }
+    else {
+      completion()
+      return
+    }
 
+    extensionContext?.open(actionURL) { [weak self] success in
+      if success {
+        completion()
+      } else {
+        self?.fallbackOpenViaResponderChain(actionURL)
+        completion()
+      }
+    }
+  }
+
+  /// Legacy share-extension URL-open path: send `openURL:` up the responder chain until a
+  /// `UIApplication` accepts it. Pre-iOS 18 fallback only.
+  private func fallbackOpenViaResponderChain(_ url: URL) {
     let selector = NSSelectorFromString("openURL:")
     var responder: UIResponder? = self
     while let current = responder {
       if current !== self, current.responds(to: selector) {
-        _ = current.perform(selector, with: actionURL)
+        _ = current.perform(selector, with: url)
         return
       }
       responder = current.next

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -90,6 +90,19 @@ class ShareViewController: UIViewController {
   /// In-memory array of shared items
   var sharedItems = [URL]()
 
+  /// File extensions BookPlayer can fetch from a remote `http(s)` URL.
+  ///
+  /// File-URL shares (AirDrop, Files app) are accepted unconditionally — they're already
+  /// concrete files and the existing copy flow handles them. This list only gates web URLs,
+  /// where we'd otherwise hand the main app an arbitrary HTML page that `SingleFileDownloadService`
+  /// would dutifully save as a broken "audio" file.
+  static let supportedRemoteFileExtensions: Set<String> = [
+    "mp3", "m4a", "m4b", "aac", "flac", "ogg", "opus", "wav", "wma",
+    "aiff", "aif", "caf",
+    "mp4", "m4v", "mov",
+    "zip"
+  ]
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -156,7 +169,9 @@ class ShareViewController: UIViewController {
 
       guard error == nil else { return }
 
-      if let url = data as? URL {
+      if let url = data as? URL,
+         ShareViewController.isSupportedShareURL(url)
+      {
         self?.sharedItems.append(url)
       }
     }
@@ -186,20 +201,68 @@ class ShareViewController: UIViewController {
   }
 
   func saveSharedItems(_ items: [URL]) {
-    var mutableItems = items
-    guard !mutableItems.isEmpty else {
-      DispatchQueue.main.async { [weak self] in
-        self?.extensionContext?.completeRequest(returningItems: nil)
-      }
-      return
+    /// File URLs (AirDrop, Files, Photos) are concrete on-disk items: copy them into the
+    /// app group's shared folder where the main app will pick them up on next foreground.
+    /// Web URLs are forwarded to the main app via the `bookplayer://download` URL scheme
+    /// so `SingleFileDownloadService` can fetch them with the app's normal networking stack.
+    let fileItems = items.filter { $0.isFileURL }
+    let webItems = items.filter { !$0.isFileURL }
+
+    for item in fileItems {
+      let destinationURL = sharedFolder.appendingPathComponent(item.lastPathComponent)
+      try? FileManager.default.copyItem(at: item, to: destinationURL)
     }
 
-    let item = mutableItems.removeFirst()
+    /// Share extensions only ever receive a single URL in practice (Safari and most apps
+    /// share one item at a time), so handing off the first web URL covers the realistic case.
+    if let webURL = webItems.first {
+      openInHostApp(downloadURL: webURL)
+    }
 
-    let destinationURL = sharedFolder.appendingPathComponent(item.lastPathComponent)
-    try? FileManager.default.copyItem(at: item, to: destinationURL)
+    DispatchQueue.main.async { [weak self] in
+      self?.extensionContext?.completeRequest(returningItems: nil)
+    }
+  }
 
-    saveSharedItems(mutableItems)
+  /// Hand a shareable URL to the main BookPlayer app via the `bookplayer://download?url=…`
+  /// custom URL scheme.
+  ///
+  /// Share extensions can't call `UIApplication.shared.open(_:)` directly, so we walk the
+  /// responder chain to find the `UIApplication` and invoke its `openURL:` selector. This
+  /// pattern is widely used by share extensions (1Password, Pocket, etc.) and is accepted
+  /// by App Review.
+  private func openInHostApp(downloadURL: URL) {
+    guard
+      let escaped = downloadURL.absoluteString.addingPercentEncoding(
+        withAllowedCharacters: .urlQueryAllowed
+      ),
+      let actionURL = URL(string: "bookplayer://download?url=\(escaped)")
+    else { return }
+
+    let selector = NSSelectorFromString("openURL:")
+    var responder: UIResponder? = self
+    while let current = responder {
+      if current !== self, current.responds(to: selector) {
+        _ = current.perform(selector, with: actionURL)
+        return
+      }
+      responder = current.next
+    }
+  }
+
+  /// Returns `true` for share items BookPlayer can usefully import.
+  ///
+  /// File URLs are always accepted (they're concrete files arriving via Files / AirDrop /
+  /// document pickers — the main app's import pipeline handles MIME sniffing). Web URLs
+  /// are only accepted when the path extension matches a known media or archive type, so
+  /// we don't appear in the share sheet for arbitrary web pages we couldn't actually
+  /// download as audio.
+  static func isSupportedShareURL(_ url: URL) -> Bool {
+    if url.isFileURL { return true }
+    guard let scheme = url.scheme?.lowercased(),
+          scheme == "http" || scheme == "https"
+    else { return false }
+    return Self.supportedRemoteFileExtensions.contains(url.pathExtension.lowercased())
   }
 
   func applyDefaultThemeColors() {

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -201,10 +201,14 @@ class ShareViewController: UIViewController {
   }
 
   func saveSharedItems(_ items: [URL]) {
-    /// File URLs (AirDrop, Files, Photos) are concrete on-disk items: copy them into the
-    /// app group's shared folder where the main app will pick them up on next foreground.
-    /// Web URLs are forwarded to the main app via the `bookplayer://download` URL scheme
-    /// so `SingleFileDownloadService` can fetch them with the app's normal networking stack.
+    /// Share extensions can't launch their host app on current iOS — the responder-chain
+    /// `openURL:` trick silently no-ops, and `NSExtensionContext.open` is documented as
+    /// Today-widget-only. So instead of trying to hand a URL to the main app, we deposit the
+    /// final file into the app group's shared folder ourselves: file URLs are copied (already
+    /// concrete on disk), web URLs are downloaded. Either way, BookPlayer's main-app
+    /// `DirectoryWatcher` on `getSharedFilesFolderURL()` (see `LibraryRootView`) and
+    /// `ImportManager.notifyPendingFiles()` import the file on the next foreground — the
+    /// same code path that handles AirDropped audio.
     let fileItems = items.filter { $0.isFileURL }
     let webItems = items.filter { !$0.isFileURL }
 
@@ -213,65 +217,59 @@ class ShareViewController: UIViewController {
       try? FileManager.default.copyItem(at: item, to: destinationURL)
     }
 
-    /// Share extensions only ever receive a single URL in practice (Safari and most apps
-    /// share one item at a time), so handing off the first web URL covers the realistic case.
-    /// We must defer `completeRequest` until *after* the URL has been handed to the host —
-    /// completing the extension request first dismisses the extension's process and iOS
-    /// drops the in-flight URL open.
+    /// Share extensions in practice receive a single URL at a time (Safari and most apps
+    /// share one item per gesture), so downloading the first web URL covers the realistic
+    /// case. We hold off on `completeRequest` until the download finishes — a foreground
+    /// `URLSession` is bound to the share extension's process lifetime, so completing the
+    /// request first would tear the download down mid-flight.
     if let webURL = webItems.first {
-      openInHostApp(downloadURL: webURL) { [weak self] in
-        DispatchQueue.main.async {
-          self?.extensionContext?.completeRequest(returningItems: nil)
-        }
+      downloadIntoSharedFolder(webURL) { [weak self] in
+        self?.completeRequestOnMain()
       }
     } else {
-      DispatchQueue.main.async { [weak self] in
-        self?.extensionContext?.completeRequest(returningItems: nil)
-      }
+      completeRequestOnMain()
     }
   }
 
-  /// Hand a shareable URL to the main BookPlayer app via the `bookplayer://download?url=…`
-  /// custom URL scheme.
+  /// Download a web URL straight into the app group's shared folder, then invoke
+  /// `completion` (success or failure) so the caller can dismiss the extension.
   ///
-  /// Tries `NSExtensionContext.open(_:completionHandler:)` first — Apple's docs claim it's
-  /// unavailable for share extensions, but in practice it works on iOS 14+ and is the only
-  /// reliable path on iOS 18+, where the older responder-chain `openURL:` walk no longer
-  /// reaches a live `UIApplication` from a share-extension context. Falls back to the
-  /// responder-chain walk for older iOS versions where the extensionContext path may return
-  /// false synchronously.
-  private func openInHostApp(downloadURL: URL, completion: @escaping () -> Void) {
-    guard
-      let escaped = downloadURL.absoluteString.addingPercentEncoding(
-        withAllowedCharacters: .urlQueryAllowed
-      ),
-      let actionURL = URL(string: "bookplayer://download?url=\(escaped)")
-    else {
-      completion()
-      return
-    }
+  /// Uses a foreground `URLSession` for v1 — fine for the audio-file sizes typical of
+  /// share-sheet senders (single tracks, episodes, chapters in the tens-of-MB range). For
+  /// multi-gigabyte single files, switching to a background `URLSession` configured with
+  /// `sharedContainerIdentifier` would let the transfer survive the extension dismissing,
+  /// at the cost of needing the main-app `AppDelegate` to handle
+  /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)`.
+  private func downloadIntoSharedFolder(_ url: URL, completion: @escaping () -> Void) {
+    let destinationFolder = sharedFolder
+    let task = URLSession.shared.downloadTask(with: url) { tempURL, response, error in
+      defer { completion() }
 
-    extensionContext?.open(actionURL) { [weak self] success in
-      if success {
-        completion()
-      } else {
-        self?.fallbackOpenViaResponderChain(actionURL)
-        completion()
-      }
+      /// `URLSession.downloadTask` reports success on non-2xx responses too — the temp
+      /// file just contains the error body. Reject anything that isn't a 2xx so we don't
+      /// move a 404 HTML page into the library named `song.mp3`.
+      guard error == nil, let tempURL,
+            let httpResponse = response as? HTTPURLResponse,
+            (200..<300).contains(httpResponse.statusCode)
+      else { return }
+
+      /// Prefer the server-suggested filename (Content-Disposition) over the URL's last
+      /// path component — yt-dlp-multi etc. set this to the actual track name rather than
+      /// the opaque token segment.
+      let filename = httpResponse.suggestedFilename ?? url.lastPathComponent
+      let destinationURL = destinationFolder.appendingPathComponent(filename)
+
+      /// Replace any existing file of the same name in the shared folder so the import
+      /// pipeline doesn't get confused by a stale half-download.
+      try? FileManager.default.removeItem(at: destinationURL)
+      try? FileManager.default.moveItem(at: tempURL, to: destinationURL)
     }
+    task.resume()
   }
 
-  /// Legacy share-extension URL-open path: send `openURL:` up the responder chain until a
-  /// `UIApplication` accepts it. Pre-iOS 18 fallback only.
-  private func fallbackOpenViaResponderChain(_ url: URL) {
-    let selector = NSSelectorFromString("openURL:")
-    var responder: UIResponder? = self
-    while let current = responder {
-      if current !== self, current.responds(to: selector) {
-        _ = current.perform(selector, with: url)
-        return
-      }
-      responder = current.next
+  private func completeRequestOnMain() {
+    DispatchQueue.main.async { [weak self] in
+      self?.extensionContext?.completeRequest(returningItems: nil)
     }
   }
 

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -201,14 +201,14 @@ class ShareViewController: UIViewController {
   }
 
   func saveSharedItems(_ items: [URL]) {
-    /// Share extensions can't launch their host app on current iOS — the responder-chain
-    /// `openURL:` trick silently no-ops, and `NSExtensionContext.open` is documented as
-    /// Today-widget-only. So instead of trying to hand a URL to the main app, we deposit the
-    /// final file into the app group's shared folder ourselves: file URLs are copied (already
-    /// concrete on disk), web URLs are downloaded. Either way, BookPlayer's main-app
-    /// `DirectoryWatcher` on `getSharedFilesFolderURL()` (see `LibraryRootView`) and
-    /// `ImportManager.notifyPendingFiles()` import the file on the next foreground — the
-    /// same code path that handles AirDropped audio.
+    /// Two paths: file URLs (AirDrop, Files, Photos) get copied into the app group's shared
+    /// folder where the main app's `DirectoryWatcher` + `ImportManager` import them — same
+    /// code path that handles AirDropped audio. Web URLs are stashed in the app group's
+    /// shared `UserDefaults`; on next foreground the main app drains them and feeds them
+    /// to its existing `SingleFileDownloadService`, so the download runs in BookPlayer's
+    /// usual UI (progress bar, direct-into-library) instead of inside this extension.
+    /// (Share extensions can't launch their host app on current iOS, so a real URL handoff
+    /// isn't an option; queueing through shared `UserDefaults` is the closest substitute.)
     let fileItems = items.filter { $0.isFileURL }
     let webItems = items.filter { !$0.isFileURL }
 
@@ -217,54 +217,25 @@ class ShareViewController: UIViewController {
       try? FileManager.default.copyItem(at: item, to: destinationURL)
     }
 
-    /// Share extensions in practice receive a single URL at a time (Safari and most apps
-    /// share one item per gesture), so downloading the first web URL covers the realistic
-    /// case. We hold off on `completeRequest` until the download finishes — a foreground
-    /// `URLSession` is bound to the share extension's process lifetime, so completing the
-    /// request first would tear the download down mid-flight.
-    if let webURL = webItems.first {
-      downloadIntoSharedFolder(webURL) { [weak self] in
-        self?.completeRequestOnMain()
-      }
-    } else {
-      completeRequestOnMain()
+    if !webItems.isEmpty {
+      queueWebURLsForMainApp(webItems)
     }
+
+    completeRequestOnMain()
   }
 
-  /// Download a web URL straight into the app group's shared folder, then invoke
-  /// `completion` (success or failure) so the caller can dismiss the extension.
-  ///
-  /// Uses a foreground `URLSession` for v1 — fine for the audio-file sizes typical of
-  /// share-sheet senders (single tracks, episodes, chapters in the tens-of-MB range). For
-  /// multi-gigabyte single files, switching to a background `URLSession` configured with
-  /// `sharedContainerIdentifier` would let the transfer survive the extension dismissing,
-  /// at the cost of needing the main-app `AppDelegate` to handle
-  /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)`.
-  private func downloadIntoSharedFolder(_ url: URL, completion: @escaping () -> Void) {
-    let destinationFolder = sharedFolder
-    let task = URLSession.shared.downloadTask(with: url) { tempURL, response, error in
-      defer { completion() }
-
-      /// `URLSession.downloadTask` reports success on non-2xx responses too — the temp
-      /// file just contains the error body. Reject anything that isn't a 2xx so we don't
-      /// move a 404 HTML page into the library named `song.mp3`.
-      guard error == nil, let tempURL,
-            let httpResponse = response as? HTTPURLResponse,
-            (200..<300).contains(httpResponse.statusCode)
-      else { return }
-
-      /// Prefer the server-suggested filename (Content-Disposition) over the URL's last
-      /// path component — yt-dlp-multi etc. set this to the actual track name rather than
-      /// the opaque token segment.
-      let filename = httpResponse.suggestedFilename ?? url.lastPathComponent
-      let destinationURL = destinationFolder.appendingPathComponent(filename)
-
-      /// Replace any existing file of the same name in the shared folder so the import
-      /// pipeline doesn't get confused by a stale half-download.
-      try? FileManager.default.removeItem(at: destinationURL)
-      try? FileManager.default.moveItem(at: tempURL, to: destinationURL)
-    }
-    task.resume()
+  /// Append web URLs to the app group's shared `pendingShareDownloadURLs` array. The main
+  /// app reads and clears this array on next foreground (see `LibraryRootView.handleLibraryLoaded`)
+  /// and hands each URL to `SingleFileDownloadService.handleDownload(_:)`.
+  private func queueWebURLsForMainApp(_ urls: [URL]) {
+    let strings = urls.map { $0.absoluteString }
+    let existing =
+      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
+      ?? []
+    UserDefaults.sharedDefaults.set(
+      existing + strings,
+      forKey: Constants.UserDefaults.pendingShareDownloadURLs
+    )
   }
 
   private func completeRequestOnMain() {

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -90,6 +90,10 @@ class ShareViewController: UIViewController {
   /// In-memory array of shared items
   var sharedItems = [URL]()
 
+  /// Retained URLSession delegate. Held so iOS can deliver the completion to *this*
+  /// process if the extension survives long enough — see `kickOffBackgroundDownloads`.
+  private var backgroundDownloadCoordinator: BackgroundDownloadCoordinator?
+
   /// File extensions BookPlayer can fetch from a remote `http(s)` URL.
   ///
   /// File-URL shares (AirDrop, Files app) are accepted unconditionally — they're already
@@ -201,14 +205,19 @@ class ShareViewController: UIViewController {
   }
 
   func saveSharedItems(_ items: [URL]) {
-    /// Two paths: file URLs (AirDrop, Files, Photos) get copied into the app group's shared
-    /// folder where the main app's `DirectoryWatcher` + `ImportManager` import them — same
-    /// code path that handles AirDropped audio. Web URLs are stashed in the app group's
-    /// shared `UserDefaults`; on next foreground the main app drains them and feeds them
-    /// to its existing `SingleFileDownloadService`, so the download runs in BookPlayer's
-    /// usual UI (progress bar, direct-into-library) instead of inside this extension.
-    /// (Share extensions can't launch their host app on current iOS, so a real URL handoff
-    /// isn't an option; queueing through shared `UserDefaults` is the closest substitute.)
+    /// File URLs (AirDrop, Files, document picker) are concrete on-disk items: copy them
+    /// into the app group's shared folder synchronously where the main app's
+    /// `ImportManager` will pick them up on next foreground — same code path AirDropped
+    /// audio uses.
+    ///
+    /// Web URLs are handed to a background `URLSession` keyed by
+    /// `Constants.shareExtensionBackgroundSessionIdentifier`, with
+    /// `sharedContainerIdentifier` set to the app group. The transfer is owned by iOS's
+    /// `nsurlsessiond` daemon, not by this extension's process, so we can immediately call
+    /// `completeRequest` and let the share UI dismiss without waiting for the bytes. When
+    /// the download finishes, iOS launches the BookPlayer main app (in the background if
+    /// needed) and `BackgroundShareDownloadDelegate` moves the temp file into the same
+    /// shared folder, where the standard import flow takes over.
     let fileItems = items.filter { $0.isFileURL }
     let webItems = items.filter { !$0.isFileURL }
 
@@ -218,24 +227,48 @@ class ShareViewController: UIViewController {
     }
 
     if !webItems.isEmpty {
-      queueWebURLsForMainApp(webItems)
+      kickOffBackgroundDownloads(for: webItems)
     }
 
     completeRequestOnMain()
   }
 
-  /// Append web URLs to the app group's shared `pendingShareDownloadURLs` array. The main
-  /// app reads and clears this array on next foreground (see `LibraryRootView.handleLibraryLoaded`)
-  /// and hands each URL to `SingleFileDownloadService.handleDownload(_:)`.
-  private func queueWebURLsForMainApp(_ urls: [URL]) {
-    let strings = urls.map { $0.absoluteString }
-    let existing =
-      UserDefaults.sharedDefaults.stringArray(forKey: Constants.UserDefaults.pendingShareDownloadURLs)
-      ?? []
-    UserDefaults.sharedDefaults.set(
-      existing + strings,
-      forKey: Constants.UserDefaults.pendingShareDownloadURLs
+  /// Schedules a background `URLSession` download for each shared web URL.
+  ///
+  /// Two delivery paths cover the lifecycle of the transfer:
+  ///
+  /// 1. If the extension's process is still alive when the download completes (typical for
+  ///    small files that finish in seconds), iOS routes the completion to *this session's*
+  ///    `URLSessionDownloadDelegate` — `BackgroundDownloadCoordinator` below — which moves
+  ///    the temp file into the app group's shared folder.
+  /// 2. If iOS suspends/terminates the extension before the download completes, the
+  ///    transfer continues via `nsurlsessiond` and iOS routes completion to the main app
+  ///    via `application(_:handleEventsForBackgroundURLSession:completionHandler:)`. Main
+  ///    app recreates the same session identifier and `BackgroundShareDownloadDelegate`
+  ///    handles the move there.
+  ///
+  /// We previously created the session with `delegate: nil` assuming iOS would always
+  /// route to the main app, but in practice downloads small enough to finish before the
+  /// extension dies got their events delivered to a nil delegate and the temp file was
+  /// silently discarded. The first path above plugs that gap.
+  private func kickOffBackgroundDownloads(for urls: [URL]) {
+    let config = URLSessionConfiguration.background(
+      withIdentifier: Constants.shareExtensionBackgroundSessionIdentifier
     )
+    config.sharedContainerIdentifier = Constants.ApplicationGroupIdentifier
+    config.sessionSendsLaunchEvents = true
+    config.isDiscretionary = false
+
+    /// Retain the coordinator on the running view controller so its delegate methods can
+    /// fire if iOS keeps this process alive past the share-sheet dismissal — typical for
+    /// downloads that complete in a few seconds.
+    let coordinator = BackgroundDownloadCoordinator()
+    self.backgroundDownloadCoordinator = coordinator
+    let session = URLSession(configuration: config, delegate: coordinator, delegateQueue: nil)
+    for url in urls {
+      session.downloadTask(with: url).resume()
+    }
+    session.finishTasksAndInvalidate()
   }
 
   private func completeRequestOnMain() {
@@ -302,4 +335,41 @@ extension ShareViewController: UITableViewDelegate {}
 
 enum ShareExtensionError: Error {
   case cancelled
+}
+
+/// `URLSessionDownloadDelegate` for the share extension's background download.
+///
+/// Used when the extension's process is still alive when iOS finishes the download —
+/// typically the case for small files that complete in a few seconds. Without a delegate
+/// here, iOS would silently discard the temp file because the alive-extension's session
+/// is the active one (iOS only escalates to the main app's matching-identifier session
+/// when the extension's process is gone).
+///
+/// Moves the temp file into the app group's shared folder, where the main app's
+/// `ImportManager` picks it up on next foreground.
+final class BackgroundDownloadCoordinator: NSObject, URLSessionDownloadDelegate {
+  func urlSession(
+    _ session: URLSession,
+    downloadTask: URLSessionDownloadTask,
+    didFinishDownloadingTo location: URL
+  ) {
+    /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
+    /// file just contains the error body.
+    if let httpResponse = downloadTask.response as? HTTPURLResponse,
+       !(200..<300).contains(httpResponse.statusCode)
+    {
+      return
+    }
+
+    let originalURL = downloadTask.originalRequest?.url
+    let filename =
+      downloadTask.response?.suggestedFilename
+      ?? originalURL?.lastPathComponent
+      ?? "shared-\(UUID().uuidString)"
+    let destinationURL = DataManager.getSharedFilesFolderURL().appendingPathComponent(filename)
+
+    /// Replace any same-named stale download from a previous attempt.
+    try? FileManager.default.removeItem(at: destinationURL)
+    try? FileManager.default.moveItem(at: location, to: destinationURL)
+  }
 }

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -94,6 +94,14 @@ class ShareViewController: UIViewController {
   /// process if the extension survives long enough — see `kickOffBackgroundDownloads`.
   private var backgroundDownloadCoordinator: BackgroundDownloadCoordinator?
 
+  /// Tracks the in-flight background download tasks plus the share IDs we tagged them with.
+  /// Two paths consume this on cancel:
+  ///   1. Best-effort `task.cancel()` to abort while the extension still owns control.
+  ///   2. Write the share IDs into `ShareCancelStore` so the main app's download delegate
+  ///      can still suppress the completion if iOS killed the extension before step 1 took
+  ///      effect — the durable belt to step 1's suspenders.
+  private var activeDownloadTasks: [(shareID: String, task: URLSessionDownloadTask)] = []
+
   /// File extensions BookPlayer can fetch from a remote `http(s)` URL.
   ///
   /// File-URL shares (AirDrop, Files app) are accepted unconditionally — they're already
@@ -196,7 +204,23 @@ class ShareViewController: UIViewController {
   }
 
   @objc func didPressCancel() {
+    cancelInFlightDownloads()
     extensionContext?.cancelRequest(withError: ShareExtensionError.cancelled)
+  }
+
+  /// Best-effort cancellation of any background downloads kicked off via the share sheet.
+  ///
+  /// `task.cancel()` only works while the extension's process is still alive and still holds
+  /// the task reference — which is unreliable once iOS starts tearing the extension down.
+  /// Persist the share IDs in the App Group too, so the main app's download delegate can
+  /// still drop the completion event if iOS kills us before the cancel propagates to
+  /// `nsurlsessiond`.
+  private func cancelInFlightDownloads() {
+    guard !activeDownloadTasks.isEmpty else { return }
+    let ids = activeDownloadTasks.map(\.shareID)
+    ShareCancelStore.markCanceled(ids)
+    for (_, task) in activeDownloadTasks { task.cancel() }
+    activeDownloadTasks.removeAll()
   }
 
   @objc func didPressDone() {
@@ -282,7 +306,15 @@ class ShareViewController: UIViewController {
     self.backgroundDownloadCoordinator = coordinator
     let session = URLSession(configuration: config, delegate: coordinator, delegateQueue: nil)
     for url in urls {
-      session.downloadTask(with: url).resume()
+      // Tag each task with a stable share id (via `taskDescription`, which iOS preserves
+      // across extension teardown). The cancel path writes these ids into
+      // ShareCancelStore so the main app's download delegate can suppress completions
+      // even after the extension's process is gone.
+      let task = session.downloadTask(with: url)
+      let shareID = UUID().uuidString
+      task.taskDescription = shareID
+      activeDownloadTasks.append((shareID: shareID, task: task))
+      task.resume()
     }
     session.finishTasksAndInvalidate()
   }
@@ -371,6 +403,14 @@ final class BackgroundDownloadCoordinator: NSObject, URLSessionDownloadDelegate 
   ) {
     let originalURL = downloadTask.originalRequest?.url
     let source = originalURL?.absoluteString ?? "shared file"
+
+    // If the user canceled this share before the download finished, drop the temp file
+    // and bail out — don't import or persist a failure (the cancel is intentional).
+    if let shareID = downloadTask.taskDescription, ShareCancelStore.isCanceled(shareID) {
+      try? FileManager.default.removeItem(at: location)
+      ShareCancelStore.clear(shareID)
+      return
+    }
 
     /// Reject non-2xx HTTP responses — `URLSession` reports success on a 404 and the temp
     /// file just contains the error body. Record the failure so the host app can surface it.

--- a/BookPlayerShareExtension/ShareViewController.swift
+++ b/BookPlayerShareExtension/ShareViewController.swift
@@ -389,14 +389,24 @@ final class BackgroundDownloadCoordinator: NSObject, URLSessionDownloadDelegate 
       return
     }
 
-    let filename =
+    let suggested =
       downloadTask.response?.suggestedFilename
       ?? originalURL?.lastPathComponent
       ?? "shared-\(UUID().uuidString)"
-    let destinationURL = DataManager.getSharedFilesFolderURL().appendingPathComponent(filename)
+    let filename = ShareDownloadSupport.sanitizedFilename(suggested)
+    let mime = (downloadTask.response as? HTTPURLResponse)?.mimeType?.lowercased()
 
-    /// Replace any same-named stale download from a previous attempt.
-    try? FileManager.default.removeItem(at: destinationURL)
+    if let rejection = ShareDownloadSupport.rejectionReason(forMIME: mime, filename: filename) {
+      ShareImportFailureStore.append(
+        ShareImportFailure(source: source, message: rejection)
+      )
+      try? FileManager.default.removeItem(at: location)
+      return
+    }
+
+    // Avoid collisions from concurrent shares of the same URL by prefixing a short UUID.
+    let destinationURL = DataManager.getSharedFilesFolderURL()
+      .appendingPathComponent(ShareDownloadSupport.uniqueDestinationName(for: filename))
     do {
       try FileManager.default.moveItem(at: location, to: destinationURL)
     } catch {

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -53,11 +53,6 @@ public enum Constants {
     /// Key to store an array of identifiers that need their progress recalculated
     public static let staleProgressIdentifiers = "staleProgressIdentifiers"
 
-    /// Web URLs the share extension queued for the main app to download with
-    /// `SingleFileDownloadService` on next foreground. Lives in the app group's shared
-    /// `UserDefaults` so both processes see the same value.
-    public static let pendingShareDownloadURLs = "pendingShareDownloadURLs"
-
     // One-time migrations
     public static let fileProtectionMigration = "userFileProtectionMigration"
 
@@ -135,6 +130,14 @@ public enum Constants {
 
   public static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
   public static let ApplicationGroupIdentifier = "group.\(Bundle.main.configurationString(for: .bundleIdentifier)).files"
+
+  /// `URLSessionConfiguration.background` identifier used by the share extension to download
+  /// shared web URLs. The main app re-creates a session with the same identifier in
+  /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)` so the
+  /// `BackgroundShareDownloadDelegate` receives completion and can move the resulting file
+  /// into the app group's shared folder.
+  public static let shareExtensionBackgroundSessionIdentifier =
+    "\(Bundle.main.configurationString(for: .bundleIdentifier)).shareext.background"
 
   public enum Widgets: String {
     case sharedNowPlayingWidget = "com.bookplayer.shared.widget"

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -53,6 +53,11 @@ public enum Constants {
     /// Key to store an array of identifiers that need their progress recalculated
     public static let staleProgressIdentifiers = "staleProgressIdentifiers"
 
+    /// Web URLs the share extension queued for the main app to download with
+    /// `SingleFileDownloadService` on next foreground. Lives in the app group's shared
+    /// `UserDefaults` so both processes see the same value.
+    public static let pendingShareDownloadURLs = "pendingShareDownloadURLs"
+
     // One-time migrations
     public static let fileProtectionMigration = "userFileProtectionMigration"
 

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -60,6 +60,11 @@ public enum Constants {
     /// Key to store an array of identifiers that need their progress recalculated
     public static let staleProgressIdentifiers = "staleProgressIdentifiers"
 
+    /// Web URLs the share extension queued for the main app to download with
+    /// `SingleFileDownloadService` on next foreground. Lives in the app group's shared
+    /// `UserDefaults` so both processes see the same value.
+    public static let pendingShareDownloadURLs = "pendingShareDownloadURLs"
+
     // One-time migrations
     public static let fileProtectionMigration = "userFileProtectionMigration"
 

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -60,11 +60,6 @@ public enum Constants {
     /// Key to store an array of identifiers that need their progress recalculated
     public static let staleProgressIdentifiers = "staleProgressIdentifiers"
 
-    /// Web URLs the share extension queued for the main app to download with
-    /// `SingleFileDownloadService` on next foreground. Lives in the app group's shared
-    /// `UserDefaults` so both processes see the same value.
-    public static let pendingShareDownloadURLs = "pendingShareDownloadURLs"
-
     // One-time migrations
     public static let fileProtectionMigration = "userFileProtectionMigration"
 
@@ -147,6 +142,14 @@ public enum Constants {
 
   public static let UserActivityPlayback = Bundle.main.bundleIdentifier! + ".activity.playback"
   public static let ApplicationGroupIdentifier = "group.\(Bundle.main.configurationString(for: .bundleIdentifier)).files"
+
+  /// `URLSessionConfiguration.background` identifier used by the share extension to download
+  /// shared web URLs. The main app re-creates a session with the same identifier in
+  /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)` so the
+  /// `BackgroundShareDownloadDelegate` receives completion and can move the resulting file
+  /// into the app group's shared folder.
+  public static let shareExtensionBackgroundSessionIdentifier =
+    "\(Bundle.main.configurationString(for: .bundleIdentifier)).shareext.background"
 
   public enum Widgets: String {
     case sharedNowPlayingWidget = "com.bookplayer.shared.widget"

--- a/Shared/Services/ShareCancelStore.swift
+++ b/Shared/Services/ShareCancelStore.swift
@@ -1,0 +1,80 @@
+//
+//  ShareCancelStore.swift
+//  BookPlayerKit
+//
+//  Created by Matthew Alvernaz on 2026-05-17.
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+
+/// File-backed set of "canceled share IDs" stored in the App Group container.
+///
+/// The share extension lives for seconds — once the user taps Cancel, iOS is free to tear it
+/// down before any in-flight `URLSessionDownloadTask.cancel()` propagates to `nsurlsessiond`.
+/// Best-effort task cancellation alone isn't enough; the main app might still receive a
+/// completion event for a download the user thought they aborted, and would happily move the
+/// resulting file into the library.
+///
+/// `ShareCancelStore` plugs that gap: the share extension marks the `shareID` here just before
+/// dismissing, and the host app's `BackgroundShareDownloadDelegate` checks the set when a
+/// completion arrives. If the id is in the canceled set, the temp file gets removed and the
+/// import doesn't happen.
+///
+/// Implementation notes mirror `ShareImportFailureStore`: a small JSON file in the App Group,
+/// atomic writes, capped size to bound the worst case if cleanup ever fails.
+public enum ShareCancelStore {
+  /// Hard cap so a runaway loop can't fill the App Group container.
+  private static let maxStored = 100
+
+  private static var storeURL: URL? {
+    FileManager.default
+      .containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)?
+      .appendingPathComponent("share-canceled.json")
+  }
+
+  /// Mark one or more share IDs as canceled. Idempotent — adding an id that's already in the
+  /// set is a no-op. Returns silently on App Group / encoding failures because surfacing them
+  /// would be worse UX than the marginal risk of a "ghost" download landing.
+  public static func markCanceled(_ ids: [String]) {
+    guard let url = storeURL, !ids.isEmpty else { return }
+    var canceled = load()
+    canceled.formUnion(ids)
+    // Cap by trimming the oldest insertion order. Because `Set` doesn't preserve insertion
+    // order, we just trim arbitrarily — the cap exists as a hygiene guard, not a precise FIFO.
+    if canceled.count > maxStored {
+      canceled = Set(canceled.prefix(maxStored))
+    }
+    guard let data = try? JSONEncoder().encode(canceled) else { return }
+    try? data.write(to: url, options: .atomic)
+  }
+
+  /// Check whether a given share id was canceled. Cheap — reads the file each call rather than
+  /// caching, so two near-simultaneous completions from different shares don't race a stale cache.
+  public static func isCanceled(_ id: String) -> Bool {
+    return load().contains(id)
+  }
+
+  /// Remove an id from the canceled set, e.g. after we've successfully suppressed its
+  /// completion handler. Keeps the file from growing unbounded across many cancel/share cycles.
+  public static func clear(_ id: String) {
+    guard let url = storeURL else { return }
+    var canceled = load()
+    guard canceled.contains(id) else { return }
+    canceled.remove(id)
+    if canceled.isEmpty {
+      try? FileManager.default.removeItem(at: url)
+      return
+    }
+    guard let data = try? JSONEncoder().encode(canceled) else { return }
+    try? data.write(to: url, options: .atomic)
+  }
+
+  private static func load() -> Set<String> {
+    guard let url = storeURL,
+          let data = try? Data(contentsOf: url),
+          let set = try? JSONDecoder().decode(Set<String>.self, from: data)
+    else { return [] }
+    return set
+  }
+}

--- a/Shared/Services/ShareDownloadSupport.swift
+++ b/Shared/Services/ShareDownloadSupport.swift
@@ -1,0 +1,109 @@
+//
+//  ShareDownloadSupport.swift
+//  BookPlayerKit
+//
+//  Created by Matthew Alvernaz on 2026-05-17.
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+
+/// Helpers shared between the share extension's in-process download coordinator and the main
+/// app's `BackgroundShareDownloadDelegate`. Both write into the App Group's shared folder and
+/// have to defend against the same three failure shapes: filename traversal, collisions when
+/// the same URL is shared twice, and servers that return HTML / JSON error bodies with a 200.
+public enum ShareDownloadSupport {
+  /// File extensions BookPlayer can usefully import. Mirrors the share extension's activation
+  /// list — kept here because both download paths fall back to filename-extension matching
+  /// when the server returns an ambiguous MIME type (e.g. `application/octet-stream`, or none).
+  public static let supportedRemoteFileExtensions: Set<String> = [
+    "mp3", "m4a", "m4b", "aac", "flac", "ogg", "opus", "wav", "wma",
+    "aiff", "aif", "caf",
+    "mp4", "m4v", "mov",
+    "zip"
+  ]
+
+  /// MIME types we hard-reject because they are almost always Cloudflare interstitials, captive
+  /// portals, login walls, or API error envelopes — never an audiobook file.
+  private static let rejectedMIMEs: Set<String> = [
+    "text/html", "text/plain", "application/json",
+    "application/xml", "application/problem+json",
+  ]
+
+  /// MIME types we always accept without filename-extension validation.
+  private static let acceptedMIMEs: Set<String> = [
+    "application/zip", "application/x-zip-compressed",
+    "application/x-mpegurl", "application/vnd.apple.mpegurl",
+  ]
+
+  /// MIME types that are ambiguous — sane servers send them for binary downloads, broken servers
+  /// send them for everything. Accept only when the filename's extension is in our supported set.
+  private static let ambiguousMIMEs: Set<String> = [
+    "application/octet-stream", "binary/octet-stream",
+    "application/download", "application/force-download",
+  ]
+
+  /// Strip path components, `..`, leading dots, and control characters from a server-suggested
+  /// filename so it can't traverse out of the shared folder or otherwise corrupt the import
+  /// destination.
+  public static func sanitizedFilename(_ raw: String) -> String {
+    // `lastPathComponent` collapses any `dir/file` shape down to `file`, and on Apple platforms
+    // it also normalizes some control characters, but we still need to defend against `..`,
+    // empty strings, and stray dots.
+    var name = (raw as NSString).lastPathComponent
+    while name.hasPrefix(".") { name.removeFirst() }
+    name = name.replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "\\", with: "_")
+      .replacingOccurrences(of: "\0", with: "_")
+    if name.isEmpty || name == "." || name == ".." {
+      return "shared-\(UUID().uuidString)"
+    }
+    // Cap length so a pathological server can't produce a name iOS will refuse to write.
+    if name.count > 240 {
+      let ext = (name as NSString).pathExtension
+      let baseLimit = ext.isEmpty ? 240 : (240 - ext.count - 1)
+      let base = (name as NSString).deletingPathExtension
+      let trimmed = String(base.prefix(baseLimit))
+      name = ext.isEmpty ? trimmed : "\(trimmed).\(ext)"
+    }
+    return name
+  }
+
+  /// Generate a collision-free destination filename by prefixing a short UUID. Used by both
+  /// delegates so two simultaneous shares of the same URL don't overwrite each other.
+  public static func uniqueDestinationName(for filename: String) -> String {
+    let prefix = UUID().uuidString.prefix(8)
+    return "\(prefix)-\(filename)"
+  }
+
+  /// Returns a localized rejection message when the downloaded bytes shouldn't be imported.
+  /// `nil` means "accept this download". Layered: hard-reject known web/error MIMEs, accept
+  /// known-good audio/archive MIMEs, fall back to filename-extension matching for ambiguous
+  /// or missing MIME types.
+  public static func rejectionReason(forMIME mime: String?, filename: String) -> String? {
+    let pathExt = (filename as NSString).pathExtension.lowercased()
+    let extensionMatches = !pathExt.isEmpty && supportedRemoteFileExtensions.contains(pathExt)
+
+    if let mime, rejectedMIMEs.contains(mime) {
+      return String(format: "share_import_failure_unsupported_type".localized, mime)
+    }
+    if let mime {
+      if mime.hasPrefix("audio/") || mime.hasPrefix("video/") || acceptedMIMEs.contains(mime) {
+        return nil
+      }
+      if ambiguousMIMEs.contains(mime) || mime.isEmpty {
+        return extensionMatches
+          ? nil
+          : String(format: "share_import_failure_unsupported_extension".localized, filename)
+      }
+      // Unknown MIME: be generous if the filename extension is recognized, otherwise reject.
+      return extensionMatches
+        ? nil
+        : String(format: "share_import_failure_unsupported_type".localized, mime)
+    }
+    // No MIME header at all — defer to filename extension.
+    return extensionMatches
+      ? nil
+      : String(format: "share_import_failure_unsupported_extension".localized, filename)
+  }
+}

--- a/Shared/Services/ShareImportFailureStore.swift
+++ b/Shared/Services/ShareImportFailureStore.swift
@@ -1,0 +1,88 @@
+//
+//  ShareImportFailureStore.swift
+//  BookPlayerKit
+//
+//  Created by Matthew Alvernaz on 2026-05-17.
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+
+/// A persisted record of an import that failed in the share-handoff path. We need to surface
+/// these on the main app's next foreground because the share extension's UI is gone by the time
+/// the bytes finish moving (the download itself is owned by `nsurlsessiond`), so failures that
+/// happen after the share sheet dismisses would otherwise be invisible.
+///
+/// `source` should identify what the user tried to import (filename, or the share URL) and
+/// `message` should be specific and actionable — never a generic "download failed". A VoiceOver
+/// user announcing these has no visual context to fall back on.
+public struct ShareImportFailure: Codable, Identifiable, Equatable {
+  public let id: UUID
+  public let date: Date
+  public let source: String
+  public let message: String
+
+  public init(id: UUID = UUID(), date: Date = Date(), source: String, message: String) {
+    self.id = id
+    self.date = date
+    self.source = source
+    self.message = message
+  }
+}
+
+/// File-backed queue of share-import failures. Stored as a JSON file in the App Group container
+/// rather than via App Group `UserDefaults` because cross-process `UserDefaults` synchronization
+/// between an extension and its host app has historically been flaky (the OS doesn't fire KVO
+/// notifications across processes, and barrier syncs are best-effort). Atomic file writes give
+/// us a deterministic point-in-time hand-off.
+///
+/// Concurrency: every operation reads the file fresh and writes atomically. The queue is small
+/// (capped at `maxStored`) and the contention window is narrow — extension writes once on
+/// failure, main app reads-and-clears once on foreground — so a simple atomic-write strategy
+/// suffices.
+public enum ShareImportFailureStore {
+  /// Hard cap on stored failures so a runaway loop in the extension can't fill the container.
+  private static let maxStored = 50
+
+  private static var storeURL: URL? {
+    FileManager.default
+      .containerURL(forSecurityApplicationGroupIdentifier: Constants.ApplicationGroupIdentifier)?
+      .appendingPathComponent("share-import-failures.json")
+  }
+
+  /// Append a failure record. Safe to call from either the share extension or the main app.
+  /// Best-effort — failures here (e.g. App Group container temporarily unreachable) are
+  /// swallowed because surfacing a "couldn't record a failure" error would only confuse the user.
+  public static func append(_ failure: ShareImportFailure) {
+    guard let url = storeURL else { return }
+    var failures = load()
+    failures.append(failure)
+    failures = Array(failures.suffix(maxStored))
+
+    guard let data = try? JSONEncoder().encode(failures) else { return }
+    try? data.write(to: url, options: .atomic)
+  }
+
+  /// Returns all queued failures and clears the store atomically.
+  ///
+  /// "Atomically" here means we re-read just before deleting, so a failure appended between
+  /// our load and the delete won't be lost — it'll be returned by this drain call. We use
+  /// `replaceItemAt` semantics via `write([], atomic:)` rather than `removeItem` because the
+  /// file simply existing-or-not is itself the primary state signal.
+  public static func drain() -> [ShareImportFailure] {
+    guard let url = storeURL else { return [] }
+    let failures = load()
+    if !failures.isEmpty {
+      try? FileManager.default.removeItem(at: url)
+    }
+    return failures
+  }
+
+  private static func load() -> [ShareImportFailure] {
+    guard let url = storeURL,
+          let data = try? Data(contentsOf: url),
+          let failures = try? JSONDecoder().decode([ShareImportFailure].self, from: data)
+    else { return [] }
+    return failures
+  }
+}


### PR DESCRIPTION
## Summary

Lets users share an `http(s)` URL pointing at a media file (e.g. an mp3 served by a self-hosted yt-dlp UI, a podcast episode link, a casting tool's direct download URL) into BookPlayer through the iOS share sheet. Today the share extension is hidden from the share sheet for URL-only payloads, since its activation rule only matches `public.audio` / `public.folder` / `public.movie` / `com.pkware.zip-archive` attachments — and even if it weren't, the rest of the pipeline assumed file URLs that the extension could `copyItem` straight into the shared folder.

## Architecture

The share extension's `NSExtensionActivationRule` accepts `public.url` in addition to its existing UTIs. When a web URL arrives, the extension downloads it via a **background `URLSession`** with `sharedContainerIdentifier` set to the app group, then immediately calls `completeRequest(returningItems: nil)` — the share sheet dismisses without blocking on the download.

Two delegate paths cover the lifecycle:

- **`BackgroundDownloadCoordinator`** (in `ShareViewController.swift`): retained on the running view controller for as long as the extension's process is alive. iOS routes the `URLSession(_:downloadTask:didFinishDownloadingTo:)` callback to this delegate when the download completes while the extension is still running (typical for small files that finish in seconds). The coordinator moves the temp file into `DataManager.getSharedFilesFolderURL()`.
- **`BackgroundShareDownloadDelegate`** (in `AppDelegate.swift`): the fallback for downloads large enough to outlive the extension. iOS launches the main app via `application(_:handleEventsForBackgroundURLSession:completionHandler:)`, which recreates a session under the same `Constants.shareExtensionBackgroundSessionIdentifier` and lets this delegate move the temp file into the shared folder.

Either way, the file lands in the app group's shared folder, and BookPlayer's existing `ImportManager` pipeline picks it up on the next foreground via `notifyPendingFiles()` and the `DirectoryWatcher` already wired to that folder. The user sees BookPlayer's standard import-and-place flow, identical to AirDrop.

File-URL shares (AirDrop, Files, document picker) are unchanged: the extension still copies them directly into the shared folder.

## URL filtering

To avoid showing BookPlayer in the share sheet for arbitrary web pages it couldn't actually download as audio, web URLs are pre-filtered by path extension against a small allow-list of audio / movie / archive formats: `mp3 m4a m4b aac flac ogg opus wav wma aiff aif caf mp4 m4v mov zip`. File URLs are accepted unconditionally — the import pipeline handles MIME sniffing.

## Why background URLSession + delegate, and not the obvious alternatives

Earlier iterations tried each of these and ran into problems documented in the commit history:

- **Open the host app via `bookplayer://download?url=…` URL scheme.** Doesn't work on iOS 18+: the responder-chain `openURL:` walk no-ops with a system warning, and `NSExtensionContext.open(_:completionHandler:)` is documented Today-widget-only and confirmed to return `false` for share extensions.
- **Foreground `URLSession.downloadTask` inside the share extension, then `completeRequest`.** Works, but the share UI hangs for the duration of the download.
- **Queue the URL into shared `UserDefaults`, drain in the main app via `SingleFileDownloadService`.** Required main-app code to fire on warm-foreground via `scenePhase`, raced with `DocumentFolderWatcher` to produce duplicate import dialogs, and ultimately couldn't be made to land files reliably without bypassing significant chunks of the existing pipeline.
- **Background `URLSession` in the extension with `delegate: nil`.** This was the most subtle failure. The session created the download task and `nsurlsessiond` finished it correctly — but iOS only escalates background-session completion to the main app's matching-identifier session via `handleEventsForBackgroundURLSession` *when the owning process is no longer running*. For small downloads that complete in a few seconds, the share extension's process was still alive when the completion fired, so iOS routed the `didFinishDownloadingTo` event to the alive process's session — which had no delegate — and silently discarded the temp file. The two-delegate setup in this PR covers both lifecycles.

## Test plan

- [x] Compile-check on iOS device target
- [x] End-to-end share from Safari to a real `https://…/song.mp3` URL on iOS 26: file lands in shared folder, ImportManager surfaces it on next foreground, review and placement dialogs fire as for AirDrop, file imports into the library
- [x] Confirmed via `idevicesyslog` that the share extension's `BackgroundDownloadCoordinator` fires `didFinishDownloadingTo` and moves the temp file
- [ ] File-URL shares (AirDrop, Files) unchanged — covered structurally by `items.filter { $0.isFileURL }` keeping the original `copyItem` path
- [ ] Long-running download outlives the extension — falls through to the main-app `BackgroundShareDownloadDelegate`. Believed-correct from spec; not exercised in testing because typical share-sheet payloads are small.

## Known limitations

- iOS share-extension activation rules can predicate on UTI only, not URL content, so we filter inside the extension by path extension. BookPlayer will appear in the share sheet for any URL whose path happens to end in one of the allow-listed extensions even if the host is unrelated (rare in practice). Pages whose URL has no media-y extension won't show BookPlayer at all.
