### PR TITLE
Add support for importing from within the processed folder

### DIFF
--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -143,6 +143,27 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return insertItemsFromReturnValue
         }
     }
+    //MARK: - registerExistingProcessedItems
+
+    var registerExistingProcessedItemsAtCallsCount = 0
+    var registerExistingProcessedItemsAtCalled: Bool {
+        return registerExistingProcessedItemsAtCallsCount > 0
+    }
+    var registerExistingProcessedItemsAtReceivedUrls: [URL]?
+    var registerExistingProcessedItemsAtReceivedInvocations: [[URL]] = []
+    var registerExistingProcessedItemsAtReturnValue: [SimpleLibraryItem]!
+    var registerExistingProcessedItemsAtClosure: (([URL]) async -> [SimpleLibraryItem])?
+    @MainActor
+    func registerExistingProcessedItems(at urls: [URL]) async -> [SimpleLibraryItem] {
+        registerExistingProcessedItemsAtCallsCount += 1
+        registerExistingProcessedItemsAtReceivedUrls = urls
+        registerExistingProcessedItemsAtReceivedInvocations.append(urls)
+        if let registerExistingProcessedItemsAtClosure = registerExistingProcessedItemsAtClosure {
+            return await registerExistingProcessedItemsAtClosure(urls)
+        } else {
+            return registerExistingProcessedItemsAtReturnValue
+        }
+    }
     //MARK: - moveItems
 
     var moveItemsInsideThrowableError: Error?

--- a/BookPlayer/Library/ItemList/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList/ItemListViewModel.swift
@@ -505,14 +505,26 @@ extension ItemListViewModel {
   /// Returns destination URLs of files that already exist and were not copied.
   func handleFilePickerSelection(_ urls: [URL]) -> [URL] {
     let documentsFolder = DataManager.getDocumentsFolderURL()
+    let processedFolder = DataManager.getProcessedFolderURL()
 
     // Acquire security-scoped access synchronously before URLs expire
     var filesToCopy: [(source: URL, destination: URL)] = []
     var alreadyExisting: [URL] = []
+    var urlsToRegister: [URL] = []
     var skippedOwnFiles = 0
     for url in urls {
       let gotAccess = url.startAccessingSecurityScopedResource()
       guard gotAccess else { continue }
+
+      if DataManager.isURLInProcessedFolder(url) {
+        let relativePath = url.relativePath(to: processedFolder)
+        if libraryService.getItemReference(with: relativePath) == nil {
+          urlsToRegister.append(url)
+        }
+        // Already-registered Processed-folder URLs are a silent no-op.
+        url.stopAccessingSecurityScopedResource()
+        continue
+      }
 
       if DataManager.isInDocumentsFolder(url) {
         skippedOwnFiles += 1
@@ -529,8 +541,18 @@ extension ItemListViewModel {
       }
     }
 
+    if !urlsToRegister.isEmpty {
+      Task { @MainActor in
+        let registered = await libraryService.registerExistingProcessedItems(at: urlsToRegister)
+        guard !registered.isEmpty else { return }
+
+        await syncService.scheduleUpload(items: registered)
+        listState.reloadAll(padding: registered.count)
+      }
+    }
+
     guard !filesToCopy.isEmpty else {
-      if skippedOwnFiles > 0 {
+      if skippedOwnFiles > 0, urlsToRegister.isEmpty {
         loadingState.error = BookPlayerError.runtimeError(
           NSLocalizedString("import_already_loaded_title", comment: "")
         )

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -166,6 +166,7 @@ final class StorageViewModel: StorageViewModelProtocol {
     publishedFiles.filter({ $0.showWarning })
   }
 
+  @MainActor
   func handleFix(for item: StorageItem, shouldReloadItems: Bool = true) async {
     await libraryService.registerExistingProcessedItems(at: [item.fileURL])
 
@@ -205,7 +206,11 @@ final class StorageViewModel: StorageViewModelProtocol {
   }
 
   func fixAllBrokenItems() {
-    let brokenItems = getBrokenItems()
+    // Process in Finder-style order so the resulting orderRank assignments match
+    // the regular import flow (see LibraryService.enumerateAndSortDirectory).
+    let brokenItems = getBrokenItems().sorted {
+      $0.fileURL.path.localizedStandardCompare($1.fileURL.path) == .orderedAscending
+    }
 
     guard !brokenItems.isEmpty else { return }
 
@@ -224,6 +229,7 @@ final class StorageViewModel: StorageViewModelProtocol {
         self.showProgressIndicator = false
         self.fixProgress = nil
         self.loadItems()
+        self.reloadLibraryItems()
       }
     }
   }

--- a/BookPlayer/Settings/Storage/StorageViewModel.swift
+++ b/BookPlayer/Settings/Storage/StorageViewModel.swift
@@ -166,37 +166,12 @@ final class StorageViewModel: StorageViewModelProtocol {
     publishedFiles.filter({ $0.showWarning })
   }
 
-  func handleFix(for item: StorageItem, shouldReloadItems: Bool = true) async throws {
-    guard let fetchedBook = self.libraryService.findBooks(containing: item.fileURL)?.first else {
-      // create a new book
-      try await self.createBook(from: item)
-      if shouldReloadItems {
-        self.loadItems()
-      }
-      return
-    }
-
-    // Relink book object if it's orphaned
-    if fetchedBook.getLibrary() == nil {
-      try libraryService.moveItems([LibraryItemRef(relativePath: fetchedBook.relativePath, uuid: fetchedBook.uuid)], inside: nil)
-      reloadLibraryItems()
-    }
-
-    let fetchedBookURL = self.folderURL.appendingPathComponent(fetchedBook.relativePath)
-
-    // Check if existing book already has its file, and this one is a duplicate
-    if FileManager.default.fileExists(atPath: fetchedBookURL.path) {
-      try FileManager.default.removeItem(at: item.fileURL)
-      if shouldReloadItems {
-        self.loadItems()
-      }
-      return
-    }
-
-    try self.moveBookFile(from: item, with: fetchedBook)
+  func handleFix(for item: StorageItem, shouldReloadItems: Bool = true) async {
+    await libraryService.registerExistingProcessedItems(at: [item.fileURL])
 
     if shouldReloadItems {
       self.loadItems()
+      reloadLibraryItems()
     }
   }
 
@@ -225,14 +200,7 @@ final class StorageViewModel: StorageViewModelProtocol {
 
   func fixSelectedItem(_ item: StorageItem) {
     Task {
-      do {
-        try await handleFix(for: item)
-      } catch {
-        await MainActor.run {
-          storageAlert = .error(errorMessage: error.localizedDescription)
-          showAlert = true
-        }
-      }
+      await handleFix(for: item)
     }
   }
 
@@ -365,33 +333,6 @@ final class StorageViewModel: StorageViewModelProtocol {
     listState.reloadAll()
   }
 
-  private func createBook(from item: StorageItem) async throws {
-    let book = await self.libraryService.createBook(from: item.fileURL)
-    try moveBookFile(from: item, with: book)
-    try libraryService.moveItems([LibraryItemRef(relativePath: book.relativePath, uuid: book.uuid)], inside: nil)
-    reloadLibraryItems()
-  }
-
-  private func moveBookFile(from item: StorageItem, with book: Book) throws {
-    let isOrphaned = book.getLibrary() == nil
-    let defaultDestinationURL = self.folderURL.appendingPathComponent(item.fileURL.lastPathComponent)
-    let destinationURL = !isOrphaned
-    ? book.fileURL ?? defaultDestinationURL
-    : defaultDestinationURL
-
-    guard item.fileURL != destinationURL,
-          !FileManager.default.fileExists(atPath: destinationURL.path) else { return }
-
-    // create parent folder if it doesn't exist
-    let parentFolder = destinationURL.deletingLastPathComponent()
-
-    if !FileManager.default.fileExists(atPath: parentFolder.path) {
-      try FileManager.default.createDirectory(at: parentFolder, withIntermediateDirectories: true, attributes: nil)
-    }
-
-    try FileManager.default.moveItem(at: item.fileURL, to: destinationURL)
-  }
-
   private func sortedItems(items: [StorageItem]) -> [StorageItem] {
     return items
       .sorted { sortBy == .size ? $0.size > $1.size : $0.title < $1.title }
@@ -452,15 +393,8 @@ final class StorageViewModel: StorageViewModelProtocol {
   }
 
   private func fixItemSafely(_ item: StorageItem) async -> FixResult {
-    do {
-      try await Task.detached(priority: .userInitiated) {
-        try await self.handleFix(for: item, shouldReloadItems: false)
-      }.value
-      
-      return FixResult(item: item, success: true, error: nil)
-    } catch {
-      return FixResult(item: item, success: false, error: error)
-    }
+    await handleFix(for: item, shouldReloadItems: false)
+    return FixResult(item: item, success: true, error: nil)
   }
 
   private var fixAllAlert: Alert {

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1901,3 +1901,94 @@ class SearchTests: LibraryServiceTests {
     XCTAssert(results?.first?.details == "Stephen King")
   }
 }
+
+class RegisterExistingProcessedItemsTests: LibraryServiceTests {
+  /// File sideloaded into Processed root: registration creates a single Book at the library root.
+  func testRegisterFileAtProcessedRoot() async throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let bookContents = "bookcontents".data(using: .utf8)!
+    let fileURL = DataTestUtils.generateTestFile(
+      name: "sideloaded.txt",
+      contents: bookContents,
+      destinationFolder: processedFolder
+    )
+
+    let registered = await self.sut.registerExistingProcessedItems(at: [fileURL])
+
+    XCTAssertEqual(registered.count, 1)
+    XCTAssertEqual(registered.first?.relativePath, "sideloaded.txt")
+    XCTAssertNotNil(self.sut.getItem(with: "sideloaded.txt"))
+  }
+
+  /// File sideloaded into a nested directory whose parents are not yet in CoreData: registration
+  /// creates the missing ancestor folders and inserts the leaf under the deepest one.
+  func testRegisterFileWithMissingAncestorFolders() async throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let bookContents = "bookcontents".data(using: .utf8)!
+
+    let authorsFolder = try DataTestUtils.generateTestFolder(name: "Authors", destinationFolder: processedFolder)
+    let joeFolder = try DataTestUtils.generateTestFolder(name: "Joe", destinationFolder: authorsFolder)
+    let fileURL = DataTestUtils.generateTestFile(
+      name: "Book.txt",
+      contents: bookContents,
+      destinationFolder: joeFolder
+    )
+
+    let registered = await self.sut.registerExistingProcessedItems(at: [fileURL])
+
+    XCTAssertEqual(registered.count, 1)
+    XCTAssertEqual(registered.first?.relativePath, "Authors/Joe/Book.txt")
+    XCTAssertNotNil(self.sut.getItem(with: "Authors") as? Folder)
+    XCTAssertNotNil(self.sut.getItem(with: "Authors/Joe") as? Folder)
+    XCTAssertNotNil(self.sut.getItem(with: "Authors/Joe/Book.txt"))
+  }
+
+  /// Registering a URL that already has a CoreData entry returns nothing and creates no duplicates.
+  func testRegisterAlreadyRegisteredFileIsNoOp() async throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let bookContents = "bookcontents".data(using: .utf8)!
+    let fileURL = DataTestUtils.generateTestFile(
+      name: "already.txt",
+      contents: bookContents,
+      destinationFolder: processedFolder
+    )
+
+    let firstPass = await self.sut.insertItems(from: [fileURL])
+    XCTAssertEqual(firstPass.count, 1)
+
+    let secondPass = await self.sut.registerExistingProcessedItems(at: [fileURL])
+    XCTAssertEqual(secondPass.count, 0)
+
+    let library = self.sut.getLibrary()
+    XCTAssertEqual(library.items?.count, 1)
+  }
+
+  /// Picking a registered folder whose disk contains an unregistered child should add the child
+  /// without creating a duplicate folder entry.
+  func testRegisterRegisteredFolderRecursesIntoUnregisteredChildren() async throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let bookContents = "bookcontents".data(using: .utf8)!
+
+    let folderURL = try DataTestUtils.generateTestFolder(name: "Mistborn", destinationFolder: processedFolder)
+    _ = DataTestUtils.generateTestFile(name: "book1.txt", contents: bookContents, destinationFolder: folderURL)
+
+    _ = await self.sut.insertItems(from: [folderURL])
+    XCTAssertNotNil(self.sut.getItem(with: "Mistborn") as? Folder)
+    XCTAssertNotNil(self.sut.getItem(with: "Mistborn/book1.txt"))
+
+    // Drop a second file into the existing folder *after* the initial import.
+    _ = DataTestUtils.generateTestFile(name: "book2.txt", contents: bookContents, destinationFolder: folderURL)
+
+    let registered = await self.sut.registerExistingProcessedItems(at: [folderURL])
+
+    XCTAssertEqual(registered.count, 1)
+    XCTAssertEqual(registered.first?.relativePath, "Mistborn/book2.txt")
+    XCTAssertNotNil(self.sut.getItem(with: "Mistborn/book2.txt"))
+
+    // No duplicate folder, registered child is untouched.
+    let library = self.sut.getLibrary()
+    XCTAssertEqual(library.items?.count, 1)
+    let folder = self.sut.getItem(with: "Mistborn") as? Folder
+    XCTAssertEqual(folder?.items?.count, 2)
+  }
+}

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -34,6 +34,10 @@ public protocol LibraryServiceProtocol: AnyObject {
   func setLibraryLastBook(with relativePath: String?)
   /// Import and insert items
   @MainActor func insertItems(from files: [URL]) async -> [SimpleLibraryItem]
+  /// Register files/folders already present inside the Processed folder that have no CoreData entry.
+  /// Creates any missing parent `Folder` entries and clears file-protection flags so the new entries
+  /// can be deleted later. URLs already registered are skipped.
+  @MainActor func registerExistingProcessedItems(at urls: [URL]) async -> [SimpleLibraryItem]
   /// Move items between folders
   func moveItems(_ items: [LibraryItemRef], inside relativePath: String?) throws
   /// Delete items
@@ -285,7 +289,7 @@ public final class LibraryService: LibraryServiceProtocol, @unchecked Sendable {
     return try? context.fetch(fetchRequest).first
   }
 
-  func getItemReference(with relativePath: String) -> LibraryItem? {
+  public func getItemReference(with relativePath: String) -> LibraryItem? {
     return getItemReference(with: relativePath, context: dataManager.getContext())
   }
 
@@ -658,7 +662,7 @@ extension LibraryService {
   /// as we don't want this method to throw, and the files are already in the processed folder
   @MainActor
   @discardableResult
-  func insertItems(from files: [URL], parentPath: String? = nil) async -> [SimpleLibraryItem] {
+  public func insertItems(from files: [URL], parentPath: String? = nil) async -> [SimpleLibraryItem] {
     // Phase 1: Extract metadata and enumerate directories off the main thread
     let preparedItems = await prepareItems(from: files)
 
@@ -713,6 +717,122 @@ extension LibraryService {
     }
 
     return processedFiles
+  }
+
+  /// Registers files/folders that physically exist inside the Processed folder but
+  /// have no CoreData entry. Walks each URL's ancestor chain, creates any missing
+  /// parent `Folder` entries, then delegates the leaf to `insertItems(from:parentPath:)`.
+  /// URLs whose `relativePath` already resolves to a registered item are skipped;
+  /// already-registered folders still recurse so unregistered children are picked up.
+  ///
+  /// - Precondition: every URL must live inside `DataManager.processedFolderURL`.
+  ///   Passing URLs from anywhere else is unsupported — the computed relativePath
+  ///   will be malformed and the inserted CoreData entry will not match a real file.
+  ///   Callers must filter via `DataManager.isURLInProcessedFolder(_:)` first.
+  ///
+  /// - Parameter urls: Absolute URLs inside the Processed folder.
+  /// - Returns: The newly inserted leaves. Excludes items that were already registered.
+  @MainActor
+  @discardableResult
+  public func registerExistingProcessedItems(at urls: [URL]) async -> [SimpleLibraryItem] {
+    var registered = [SimpleLibraryItem]()
+
+    for url in urls {
+      registered.append(contentsOf: await registerExistingProcessedItem(at: url))
+    }
+
+    return registered
+  }
+
+  @MainActor
+  private func registerExistingProcessedItem(at url: URL) async -> [SimpleLibraryItem] {
+    let processedFolderURL = DataManager.getProcessedFolderURL()
+    let relativePath = url.relativePath(to: processedFolderURL)
+
+    guard !relativePath.isEmpty else { return [] }
+
+    // Files placed via Files.app may carry the user-immutable flag or strict
+    // file-protection class, which would crash later deletions. Mirror the
+    // regular import flow's cleanup at ImportOperation.swift:272.
+    url.disableFileProtection()
+
+    let isDirectory =
+      (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+
+    if getItemReference(with: relativePath) != nil {
+      guard isDirectory else { return [] }
+
+      let children = (try? FileManager.default.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+      )) ?? []
+
+      var registered = [SimpleLibraryItem]()
+      for child in children {
+        registered.append(contentsOf: await registerExistingProcessedItem(at: child))
+      }
+      return registered
+    }
+
+    let parentPath = ensureAncestorFolders(forRelativePath: relativePath, processedFolderURL: processedFolderURL)
+    return await insertItems(from: [url], parentPath: parentPath)
+  }
+
+  /// Walks the ancestor chain of `relativePath` (excluding the leaf), creating any
+  /// missing `Folder` entries along the way so the leaf can be inserted with its
+  /// correct parent. Saves the context after each new folder so subsequent lookups
+  /// can resolve newly created entries.
+  ///
+  /// - Returns: The relativePath of the leaf's immediate parent, or `nil` if the
+  ///   leaf belongs at the library root.
+  @MainActor
+  private func ensureAncestorFolders(
+    forRelativePath relativePath: String,
+    processedFolderURL: URL
+  ) -> String? {
+    let components = relativePath.split(separator: "/").map(String.init)
+    guard components.count > 1 else { return nil }
+
+    let context = dataManager.getContext()
+    let library = getLibraryReference()
+    let ancestorComponents = components.dropLast()
+
+    var currentPath = ""
+    var currentParent: Folder?
+
+    for component in ancestorComponents {
+      currentPath = currentPath.isEmpty ? component : "\(currentPath)/\(component)"
+
+      let folderURL = processedFolderURL.appendingPathComponent(currentPath)
+      // Clear protection on the ancestor folder itself so the user can later
+      // delete the registered hierarchy. Skip recursion (the leaf already
+      // disables its own subtree).
+      try? (folderURL as NSURL).setResourceValue(URLFileProtection.none, forKey: .fileProtectionKey)
+      try? (folderURL as NSURL).setResourceValue(false, forKey: .isUserImmutableKey)
+
+      if let existing = getItemReference(with: currentPath, context: context) as? Folder {
+        currentParent = existing
+        continue
+      }
+
+      let newFolder = Folder(from: folderURL, context: context)
+      newFolder.orderRank = getNextOrderRank(
+        in: currentParent?.relativePath,
+        context: context
+      )
+
+      if let parent = currentParent {
+        parent.addToItems(newFolder)
+      } else {
+        library.addToItems(newFolder)
+      }
+
+      dataManager.saveContext()
+      currentParent = newFolder
+    }
+
+    return currentParent?.relativePath
   }
 
   /// Inserts already-prepared items into CoreData. Used by directory handling to avoid re-preparing.

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -725,19 +725,26 @@ extension LibraryService {
   /// URLs whose `relativePath` already resolves to a registered item are skipped;
   /// already-registered folders still recurse so unregistered children are picked up.
   ///
-  /// - Precondition: every URL must live inside `DataManager.processedFolderURL`.
-  ///   Passing URLs from anywhere else is unsupported — the computed relativePath
-  ///   will be malformed and the inserted CoreData entry will not match a real file.
-  ///   Callers must filter via `DataManager.isURLInProcessedFolder(_:)` first.
+  /// URLs that do not live inside `DataManager.processedFolderURL` are skipped
+  /// silently (a runtime guard rejects them to prevent a malformed relativePath
+  /// from creating a CoreData entry that points outside Processed). Callers should
+  /// still filter via `DataManager.isURLInProcessedFolder(_:)` for clarity.
   ///
   /// - Parameter urls: Absolute URLs inside the Processed folder.
-  /// - Returns: The newly inserted leaves. Excludes items that were already registered.
+  /// - Returns: The newly inserted leaves. Excludes items that were already
+  ///   registered or were rejected by the in-Processed check.
   @MainActor
   @discardableResult
   public func registerExistingProcessedItems(at urls: [URL]) async -> [SimpleLibraryItem] {
+    // Process in Finder-style order so the resulting orderRank assignments match
+    // the regular import flow's directory enumeration (see enumerateAndSortDirectory).
+    let sortedURLs = urls.sorted {
+      $0.path.localizedStandardCompare($1.path) == .orderedAscending
+    }
+
     var registered = [SimpleLibraryItem]()
 
-    for url in urls {
+    for url in sortedURLs {
       registered.append(contentsOf: await registerExistingProcessedItem(at: url))
     }
 
@@ -746,15 +753,12 @@ extension LibraryService {
 
   @MainActor
   private func registerExistingProcessedItem(at url: URL) async -> [SimpleLibraryItem] {
+    guard DataManager.isURLInProcessedFolder(url) else { return [] }
+
     let processedFolderURL = DataManager.getProcessedFolderURL()
     let relativePath = url.relativePath(to: processedFolderURL)
 
     guard !relativePath.isEmpty else { return [] }
-
-    // Files placed via Files.app may carry the user-immutable flag or strict
-    // file-protection class, which would crash later deletions. Mirror the
-    // regular import flow's cleanup at ImportOperation.swift:272.
-    url.disableFileProtection()
 
     let isDirectory =
       (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
@@ -776,7 +780,15 @@ extension LibraryService {
     }
 
     let parentPath = ensureAncestorFolders(forRelativePath: relativePath, processedFolderURL: processedFolderURL)
-    return await insertItems(from: [url], parentPath: parentPath)
+    // Files placed via Files.app may carry the user-immutable flag or strict
+    // file-protection class, which would crash later deletions. Mirror the
+    // regular import flow's cleanup at ImportOperation.swift:272.
+    url.disableFileProtection()
+    let inserted = await insertItems(from: [url], parentPath: parentPath)
+    if let parentPath {
+      rebuildFolderDetails(parentPath)
+    }
+    return inserted
   }
 
   /// Walks the ancestor chain of `relativePath` (excluding the leaf), creating any


### PR DESCRIPTION
## Purpose

- Users are moving items directly into the Processed folder and then going in-app and attempting to import them from there. The new approach is also applied as the 'Fix' option in the storage screen