### PR TITLE
Add fallback to extract chapters when not natively supported

### DIFF
--- a/Shared/Services/AudioMetadataService.swift
+++ b/Shared/Services/AudioMetadataService.swift
@@ -80,9 +80,11 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   /// A 100-hour book at one chapter per minute is ~6,000 — this is generous headroom.
   private static let maxChapterSampleCount = 100_000
 
-  /// Upper bound on the `moov` box we'll read into memory. Even chapter-rich audiobooks
-  /// keep `moov` well under a megabyte; this caps memory if a file declares a huge one.
-  private static let maxMoovSize = 256 * 1024 * 1024
+  /// Upper bound on the `moov` box we'll read into memory. `moov` is dominated by the main
+  /// audio track's sample tables (stsz/stco), so even a very long audiobook stays in the tens
+  /// of MB; 64 MB is generous headroom while avoiding a transient allocation large enough to
+  /// risk memory pressure / jetsam on constrained devices.
+  private static let maxMoovSize = 64 * 1024 * 1024
 
   public init() {}
   
@@ -197,6 +199,9 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
         if let textChapters {
           return textChapters
         }
+        // Unlike the other parsers, this path returns nil silently at many guards; log once
+        // so a "chapters missing" report on an MP4 file leaves a diagnostic trail.
+        Self.logger.debug("QuickTime text chapter parser found no chapters in \(url.lastPathComponent)")
       }
 
       // Third try: Check what metadata identifiers exist
@@ -343,7 +348,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
             identifier.hasPrefix("id3/CHAP"),
             let data = try? await item.load(.dataValue) else { continue }
 
-      if let parsed = parseID3ChapterFrame([UInt8](data)) {
+      if let parsed = parseID3ChapterFrame(data) {
         chapterData.append(parsed)
       }
     }
@@ -378,7 +383,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Parse a single ID3 `CHAP` frame body into its start/end times (seconds) and title.
-  private func parseID3ChapterFrame(_ body: [UInt8]) -> (start: Double, end: Double?, title: String)? {
+  private func parseID3ChapterFrame(_ body: Data) -> (start: Double, end: Double?, title: String)? {
     // Element ID is a null-terminated string.
     guard let terminator = body.firstIndex(of: 0) else { return nil }
     var cursor = terminator + 1
@@ -398,7 +403,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Walk the sub-frames of a CHAP frame and return the `TIT2` (title) text, if present.
-  private func parseID3ChapterTitle(_ body: [UInt8], from start: Int) -> String {
+  private func parseID3ChapterTitle(_ body: Data, from start: Int) -> String {
     var cursor = start
 
     // Each sub-frame: 4-byte frame ID, 4-byte size, 2-byte flags, then the payload.
@@ -588,7 +593,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
   /// Parse the sample table of a text chapter track and read each chapter's title and timing.
   private func parseTextChapters(
-    moov: [UInt8],
+    moov: Data,
     trakStart: Int,
     trakEnd: Int,
     handle: FileHandle,
@@ -646,7 +651,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
         sampleData.count >= 2
       else { continue }
 
-      let titleLength = Int(beUInt16([UInt8](sampleData), 0))
+      let titleLength = Int(beUInt16(sampleData, 0))
       let titleBytes = sampleData.dropFirst(2).prefix(titleLength)
       let title = decodeText(Array(titleBytes))
 
@@ -670,7 +675,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   // MARK: - Sample table parsing
 
   /// Per-sample durations expanded from the run-length encoded `stts` box.
-  private func parseSTTS(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [UInt32]? {
+  private func parseSTTS(_ data: Data, _ stbl: (start: Int, end: Int)) -> [UInt32]? {
     guard let box = firstChild(data, stbl.start, stbl.end, "stts"), box.start + 8 <= box.end else { return nil }
     let entryCount = Int(beUInt32(data, box.start + 4))
     var deltas: [UInt32] = []
@@ -689,7 +694,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Per-sample byte sizes from the `stsz` box (handles the shared-size form).
-  private func parseSTSZ(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [Int]? {
+  private func parseSTSZ(_ data: Data, _ stbl: (start: Int, end: Int)) -> [Int]? {
     guard let box = firstChild(data, stbl.start, stbl.end, "stsz"), box.start + 12 <= box.end else { return nil }
     let uniformSize = beUInt32(data, box.start + 4)
     let sampleCount = Int(beUInt32(data, box.start + 8))
@@ -710,7 +715,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Chunk file offsets from `stco` (32-bit) or `co64` (64-bit).
-  private func parseChunkOffsets(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [UInt64]? {
+  private func parseChunkOffsets(_ data: Data, _ stbl: (start: Int, end: Int)) -> [UInt64]? {
     if let box = firstChild(data, stbl.start, stbl.end, "stco") {
       return chunkOffsets(data, box, entrySize: 4) { UInt64(beUInt32(data, $0)) }
     }
@@ -722,7 +727,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
   /// Shared `stco`/`co64` reader: walk `entrySize`-byte chunk offsets, decoding each with `read`.
   private func chunkOffsets(
-    _ data: [UInt8],
+    _ data: Data,
     _ box: (start: Int, end: Int),
     entrySize: Int,
     read: (Int) -> UInt64
@@ -741,7 +746,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// `stsc` run table mapping chunk indices to samples-per-chunk.
-  private func parseSTSC(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [(firstChunk: Int, samplesPerChunk: Int)]? {
+  private func parseSTSC(_ data: Data, _ stbl: (start: Int, end: Int)) -> [(firstChunk: Int, samplesPerChunk: Int)]? {
     guard let box = firstChild(data, stbl.start, stbl.end, "stsc"), box.start + 8 <= box.end else { return nil }
     let entryCount = Int(beUInt32(data, box.start + 4))
     guard entryCount <= Self.maxChapterSampleCount else { return nil }
@@ -794,16 +799,15 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   // MARK: - Box navigation helpers
 
   /// Scan top-level boxes and return the payload bytes of the first box with the given type.
-  private func readTopLevelBox(named name: String, handle: FileHandle, fileSize: UInt64) -> [UInt8]? {
+  private func readTopLevelBox(named name: String, handle: FileHandle, fileSize: UInt64) -> Data? {
     var offset: UInt64 = 0
     while offset + 8 <= fileSize {
       try? handle.seek(toOffset: offset)
       guard
-        let headerData = try? handle.read(upToCount: 16),
-        headerData.count >= 8
+        let header = try? handle.read(upToCount: 16),
+        header.count >= 8
       else { return nil }
 
-      let header = [UInt8](headerData)
       let size32 = beUInt32(header, 0)
       var boxSize = UInt64(size32)
       var headerSize: UInt64 = 8
@@ -830,7 +834,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
           let payload = try? handle.read(upToCount: payloadLength),
           payload.count == payloadLength
         else { return nil }
-        return [UInt8](payload)
+        return payload
       }
 
       offset += boxSize
@@ -839,7 +843,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Immediate child boxes within the byte range `[start, end)`.
-  private func childBoxes(_ data: [UInt8], _ start: Int, _ end: Int) -> [(type: String, start: Int, end: Int)] {
+  private func childBoxes(_ data: Data, _ start: Int, _ end: Int) -> [(type: String, start: Int, end: Int)] {
     var children: [(String, Int, Int)] = []
     var cursor = start
     while cursor + 8 <= end {
@@ -864,7 +868,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// The first immediate child box of the given type within `[start, end)`.
-  private func firstChild(_ data: [UInt8], _ start: Int, _ end: Int, _ type: String) -> (start: Int, end: Int)? {
+  private func firstChild(_ data: Data, _ start: Int, _ end: Int, _ type: String) -> (start: Int, end: Int)? {
     for child in childBoxes(data, start, end) where child.type == type {
       return (child.start, child.end)
     }
@@ -872,7 +876,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Follow a chain of nested child box types, returning the innermost range.
-  private func descend(_ data: [UInt8], _ start: Int, _ end: Int, _ path: [String]) -> (start: Int, end: Int)? {
+  private func descend(_ data: Data, _ start: Int, _ end: Int, _ path: [String]) -> (start: Int, end: Int)? {
     var current = (start: start, end: end)
     for type in path {
       guard let next = firstChild(data, current.start, current.end, type) else { return nil }
@@ -882,7 +886,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Read a track's ID from its `tkhd` box (version 0 and 1 layouts differ).
-  private func trackID(of data: [UInt8], _ trakStart: Int, _ trakEnd: Int) -> UInt32? {
+  private func trackID(of data: Data, _ trakStart: Int, _ trakEnd: Int) -> UInt32? {
     guard let tkhd = firstChild(data, trakStart, trakEnd, "tkhd"), tkhd.start < tkhd.end else { return nil }
     let version = data[tkhd.start]
     let trackIDOffset = tkhd.start + (version == 1 ? 20 : 12)
@@ -907,15 +911,25 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
   private func readBytes(handle: FileHandle, offset: UInt64, length: Int) -> Data? {
     guard length > 0, (try? handle.seek(toOffset: offset)) != nil else { return nil }
-    return try? handle.read(upToCount: length)
+    // `read(upToCount:)` can return fewer bytes than requested (e.g. a truncated file). Treat
+    // a short read as a failure so callers never parse a partial sample as if it were complete.
+    guard let data = try? handle.read(upToCount: length), data.count == length else { return nil }
+    return data
   }
 
-  private func beUInt16(_ data: [UInt8], _ offset: Int) -> UInt16 {
+  // Primitive readers operate on `Data` directly so the (potentially large) `moov` and the
+  // ID3 frame blobs are parsed in place — no intermediate `[UInt8]` copy. They assume the
+  // passed `Data` is zero-based (a fresh buffer from `read`/`load(.dataValue)`, never a slice),
+  // since they index by absolute offset. A `Data` slice keeps its parent's indices, so the
+  // debug assert catches a future caller that passes one (it would read the wrong bytes).
+  private func beUInt16(_ data: Data, _ offset: Int) -> UInt16 {
+    assert(data.startIndex == 0, "byte readers require a zero-based Data")
     guard offset + 2 <= data.count else { return 0 }
     return (UInt16(data[offset]) << 8) | UInt16(data[offset + 1])
   }
 
-  private func beUInt32(_ data: [UInt8], _ offset: Int) -> UInt32 {
+  private func beUInt32(_ data: Data, _ offset: Int) -> UInt32 {
+    assert(data.startIndex == 0, "byte readers require a zero-based Data")
     guard offset + 4 <= data.count else { return 0 }
     return (UInt32(data[offset]) << 24)
       | (UInt32(data[offset + 1]) << 16)
@@ -924,7 +938,8 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   /// Read a 28-bit ID3v2 synchsafe integer (7 bits per byte, MSB always zero).
-  private func synchsafeUInt32(_ data: [UInt8], _ offset: Int) -> UInt32 {
+  private func synchsafeUInt32(_ data: Data, _ offset: Int) -> UInt32 {
+    assert(data.startIndex == 0, "byte readers require a zero-based Data")
     guard offset + 4 <= data.count else { return 0 }
     return (UInt32(data[offset] & 0x7F) << 21)
       | (UInt32(data[offset + 1] & 0x7F) << 14)
@@ -932,7 +947,8 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       | UInt32(data[offset + 3] & 0x7F)
   }
 
-  private func beUInt64(_ data: [UInt8], _ offset: Int) -> UInt64 {
+  private func beUInt64(_ data: Data, _ offset: Int) -> UInt64 {
+    assert(data.startIndex == 0, "byte readers require a zero-based Data")
     guard offset + 8 <= data.count else { return 0 }
     var value: UInt64 = 0
     for index in 0..<8 {
@@ -941,7 +957,8 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     return value
   }
 
-  private func typeString(_ data: [UInt8], _ offset: Int) -> String {
+  private func typeString(_ data: Data, _ offset: Int) -> String {
+    assert(data.startIndex == 0, "byte readers require a zero-based Data")
     guard offset + 4 <= data.count else { return "" }
     return String(bytes: data[offset..<offset + 4], encoding: .isoLatin1) ?? ""
   }

--- a/Shared/Services/AudioMetadataService.swift
+++ b/Shared/Services/AudioMetadataService.swift
@@ -63,7 +63,27 @@ public protocol AudioMetadataServiceProtocol {
 }
 
 public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
-  
+
+  /// File extensions whose containers can hold a QuickTime/MP4 text chapter track. This is
+  /// an explicit list rather than a `UTType` conformance check on purpose: no system UTType
+  /// models "ISO-BMFF container" — `m4b` resolves to `com.apple.protected-mpeg-4-audio-b`,
+  /// which conforms to none of `.mpeg4Audio`/`.mpeg4Movie`/`.quickTimeMovie`, and the only
+  /// broad-enough type, `.audiovisualContent`, also matches `mp3`/`flac`/`wav` (defeating the
+  /// gate) while still missing the unregistered `aaxc` UTI.
+  private static let quickTimeFileExtensions: Set<String> = ["m4b", "m4a", "mp4", "m4v", "mov", "aax", "aaxc"]
+
+  /// Upper bound on a single chapter text sample we'll read from disk. Chapter titles are
+  /// tiny; this caps memory use if a malformed `stsz` table declares an enormous sample.
+  private static let maxChapterSampleSize = 64 * 1024
+
+  /// Upper bound on the total number of samples we'll expand from a chapter track's tables.
+  /// A 100-hour book at one chapter per minute is ~6,000 — this is generous headroom.
+  private static let maxChapterSampleCount = 100_000
+
+  /// Upper bound on the `moov` box we'll read into memory. Even chapter-rich audiobooks
+  /// keep `moov` well under a megabyte; this caps memory if a file declares a huge one.
+  private static let maxMoovSize = 256 * 1024 * 1024
+
   public init() {}
   
   public func extractMetadata(from fileURL: URL) async -> AudioMetadata? {
@@ -151,9 +171,11 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     do {
       let availableChapterLocales = try await asset.load(.availableChapterLocales)
 
-      // First try: Native chapter support (works for M4B, some M4A, properly tagged files)
-      if !availableChapterLocales.isEmpty {
-        return await extractStandardChapters(from: asset, locales: availableChapterLocales)
+      // First try: Native chapter support (works for M4B, some M4A, properly tagged files).
+      // If locales exist but yield no usable chapters, fall through to the manual fallbacks.
+      if !availableChapterLocales.isEmpty,
+         let standardChapters = await extractStandardChapters(from: asset, locales: availableChapterLocales) {
+        return standardChapters
       }
 
       // Second try: Malformed QuickTime/MP4 chapter tracks that AVFoundation refuses
@@ -161,9 +183,20 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       // chapter track but tag it with an external `alis` data reference and/or an invalid
       // media language. AVFoundation then reports no `availableChapterLocales`, even though
       // the chapter samples are physically present in the file. Parse them directly.
+      // Gated to MP4/QuickTime containers so non-MP4 files (e.g. MP3) skip the box scan.
+      // The parser does blocking FileHandle I/O, so run it off the cooperative thread pool.
+      // This runs during import while the user waits for the book to appear, so use
+      // `.userInitiated` — `.utility` would let the OS throttle the disk reads.
       if let url = (asset as? AVURLAsset)?.url,
-         let textChapters = extractQuickTimeTextChapters(from: url, duration: duration) {
-        return textChapters
+         Self.quickTimeFileExtensions.contains(url.pathExtension.lowercased()) {
+        let textChapters = await withCheckedContinuation { continuation in
+          DispatchQueue.global(qos: .userInitiated).async {
+            continuation.resume(returning: self.extractQuickTimeTextChapters(from: url, duration: duration))
+          }
+        }
+        if let textChapters {
+          return textChapters
+        }
       }
 
       // Third try: Check what metadata identifiers exist
@@ -371,14 +404,26 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     // Each sub-frame: 4-byte frame ID, 4-byte size, 2-byte flags, then the payload.
     while cursor + 10 <= body.count {
       let frameID = typeString(body, cursor)
-      let declaredSize = Int(beUInt32(body, cursor + 4))
       let payloadStart = cursor + 10
 
-      // ID3v2.4 uses synchsafe sizes; v2.3 uses plain UInt32. When the plain size
-      // overruns the buffer, fall back to the synchsafe interpretation.
-      var size = declaredSize
+      // ID3v2.4 encodes frame sizes as synchsafe integers (every byte has bit 7 clear);
+      // v2.3 uses a plain UInt32. The CHAP blob doesn't carry the tag version, so we infer
+      // it: if all four size bytes have bit 7 clear the field is a valid synchsafe integer,
+      // which agrees with the plain value below 128 and is the correct reading for v2.4.
+      // Otherwise it can only be a plain v2.3 size. We fall back to the other interpretation
+      // if the chosen one overruns the buffer.
+      let plainSize = Int(beUInt32(body, cursor + 4))
+      let synchsafeSize = Int(synchsafeUInt32(body, cursor + 4))
+      let sizeBytesAreSynchsafe = (4...7).allSatisfy { (body[cursor + $0] & 0x80) == 0 }
+      var size = sizeBytesAreSynchsafe ? synchsafeSize : plainSize
       if payloadStart + size > body.count {
-        size = Int(synchsafeUInt32(body, cursor + 4))
+        // The chosen interpretation overruns; the other one must be correct.
+        size = sizeBytesAreSynchsafe ? plainSize : synchsafeSize
+      } else if sizeBytesAreSynchsafe, plainSize != synchsafeSize, payloadStart + plainSize == body.count {
+        // Ambiguous: the size bytes are valid synchsafe but also a valid plain UInt32. When
+        // the plain size lands exactly on the frame boundary it's a v2.3 frame whose size
+        // bytes happen to all have bit 7 clear (e.g. a 256-byte title) — prefer it.
+        size = plainSize
       }
       guard size > 0, payloadStart + size <= body.count else { break }
 
@@ -404,10 +449,10 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       if bytes.last == 0 { bytes.removeLast() }
       trimmed = String(bytes: bytes, encoding: .isoLatin1) ?? ""
     case 1: // UTF-16 with BOM
-      if bytes.count >= 2, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
-      trimmed = String(bytes: bytes, encoding: .utf16) ?? ""
+      if bytes.count >= 2, bytes.count % 2 == 0, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
+      trimmed = decodeUTF16WithBOM(bytes)
     case 2: // UTF-16BE without BOM
-      if bytes.count >= 2, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
+      if bytes.count >= 2, bytes.count % 2 == 0, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
       trimmed = String(bytes: bytes, encoding: .utf16BigEndian) ?? ""
     default: // 3 = UTF-8 (and any unknown value, treated leniently)
       if bytes.last == 0 { bytes.removeLast() }
@@ -415,6 +460,23 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     }
 
     return trimmed
+  }
+
+  /// Decode UTF-16 bytes, honoring a leading BOM. The ID3 spec requires a BOM for this
+  /// encoding, but some taggers omit it; we then default to little-endian (the common case
+  /// for Windows-authored tags) before falling back to big-endian.
+  private func decodeUTF16WithBOM(_ bytes: [UInt8]) -> String {
+    if bytes.count >= 2 {
+      if bytes[0] == 0xFF, bytes[1] == 0xFE {
+        return String(bytes: bytes.dropFirst(2), encoding: .utf16LittleEndian) ?? ""
+      }
+      if bytes[0] == 0xFE, bytes[1] == 0xFF {
+        return String(bytes: bytes.dropFirst(2), encoding: .utf16BigEndian) ?? ""
+      }
+    }
+    return String(bytes: bytes, encoding: .utf16LittleEndian)
+      ?? String(bytes: bytes, encoding: .utf16BigEndian)
+      ?? ""
   }
 
   private func extractOverdriveChapters(from metadata: [AVMetadataItem], duration: TimeInterval) async -> [ChapterMetadata]? {
@@ -505,7 +567,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       if chapterTrackID == nil,
          let tref = firstChild(moov, trak.start, trak.end, "tref"),
          let chap = firstChild(moov, tref.start, tref.end, "chap"),
-         tref.end >= chap.start + 4 {
+         chap.end >= chap.start + 4 {
         chapterTrackID = beUInt32(moov, chap.start)
       }
     }
@@ -537,7 +599,9 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       let stbl = descend(moov, trakStart, trakEnd, ["mdia", "minf", "stbl"])
     else { return nil }
 
-    // mdhd timescale: version (0/1) changes the field offset.
+    // mdhd timescale: version (0/1) changes the field offset. Guard the version-byte read
+    // against a zero-payload mdhd box (mdhd.start could equal moov.count).
+    guard mdhd.start < mdhd.end else { return nil }
     let mdhdVersion = moov[mdhd.start]
     let timescaleOffset = mdhd.start + (mdhdVersion == 1 ? 20 : 12)
     guard timescaleOffset + 4 <= mdhd.end else { return nil }
@@ -556,24 +620,28 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       chunkOffsets: chunkOffsets,
       sampleToChunk: sampleToChunk
     )
-    guard !locations.isEmpty else { return nil }
+    // A well-formed chapter track has one stts duration per sample. If the tables
+    // disagree (malformed), only trust as many samples as both tables describe so we
+    // don't emit trailing chapters that all share the same timestamp.
+    let sampleCount = min(locations.count, sampleDeltas.count)
+    guard sampleCount > 0 else { return nil }
 
     // Sample start times are the cumulative sum of per-sample durations (stts), in
     // the track's timescale. Chapter durations are derived from consecutive starts so
     // that empty/degenerate samples don't produce negative or zero-length spans.
     var starts: [TimeInterval] = []
     var cumulative: UInt64 = 0
-    for index in locations.indices {
+    for index in 0..<sampleCount {
       starts.append(TimeInterval(cumulative) / TimeInterval(timescale))
-      if index < sampleDeltas.count {
-        cumulative += UInt64(sampleDeltas[index])
-      }
+      cumulative += UInt64(sampleDeltas[index])
     }
 
     var chapters: [ChapterMetadata] = []
-    for (index, location) in locations.enumerated() {
+    for index in 0..<sampleCount {
+      let location = locations[index]
       guard
         location.size >= 2,
+        location.size <= Self.maxChapterSampleSize,
         let sampleData = readBytes(handle: handle, offset: location.offset, length: location.size),
         sampleData.count >= 2
       else { continue }
@@ -611,8 +679,9 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       guard cursor + 8 <= box.end else { break }
       let sampleCount = Int(beUInt32(data, cursor))
       let sampleDelta = beUInt32(data, cursor + 4)
-      // Guard against pathological counts that would exhaust memory.
-      guard sampleCount >= 0, sampleCount < 1_000_000 else { return nil }
+      // Guard against pathological counts that would exhaust memory — bounded cumulatively,
+      // since many entries could otherwise expand past the overall limit.
+      guard deltas.count + sampleCount <= Self.maxChapterSampleCount else { return nil }
       deltas.append(contentsOf: repeatElement(sampleDelta, count: sampleCount))
       cursor += 8
     }
@@ -624,7 +693,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     guard let box = firstChild(data, stbl.start, stbl.end, "stsz"), box.start + 12 <= box.end else { return nil }
     let uniformSize = beUInt32(data, box.start + 4)
     let sampleCount = Int(beUInt32(data, box.start + 8))
-    guard sampleCount >= 0, sampleCount < 1_000_000 else { return nil }
+    guard sampleCount <= Self.maxChapterSampleCount else { return nil }
 
     if uniformSize != 0 {
       return Array(repeating: Int(uniformSize), count: sampleCount)
@@ -642,37 +711,40 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
   /// Chunk file offsets from `stco` (32-bit) or `co64` (64-bit).
   private func parseChunkOffsets(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [UInt64]? {
-    if let box = firstChild(data, stbl.start, stbl.end, "stco"), box.start + 8 <= box.end {
-      let count = Int(beUInt32(data, box.start + 4))
-      var offsets: [UInt64] = []
-      var cursor = box.start + 8
-      for _ in 0..<count {
-        guard cursor + 4 <= box.end else { break }
-        offsets.append(UInt64(beUInt32(data, cursor)))
-        cursor += 4
-      }
-      return offsets
+    if let box = firstChild(data, stbl.start, stbl.end, "stco") {
+      return chunkOffsets(data, box, entrySize: 4) { UInt64(beUInt32(data, $0)) }
     }
-
-    if let box = firstChild(data, stbl.start, stbl.end, "co64"), box.start + 8 <= box.end {
-      let count = Int(beUInt32(data, box.start + 4))
-      var offsets: [UInt64] = []
-      var cursor = box.start + 8
-      for _ in 0..<count {
-        guard cursor + 8 <= box.end else { break }
-        offsets.append(beUInt64(data, cursor))
-        cursor += 8
-      }
-      return offsets
+    if let box = firstChild(data, stbl.start, stbl.end, "co64") {
+      return chunkOffsets(data, box, entrySize: 8) { beUInt64(data, $0) }
     }
-
     return nil
+  }
+
+  /// Shared `stco`/`co64` reader: walk `entrySize`-byte chunk offsets, decoding each with `read`.
+  private func chunkOffsets(
+    _ data: [UInt8],
+    _ box: (start: Int, end: Int),
+    entrySize: Int,
+    read: (Int) -> UInt64
+  ) -> [UInt64]? {
+    guard box.start + 8 <= box.end else { return nil }
+    let count = Int(beUInt32(data, box.start + 4))
+    guard count <= Self.maxChapterSampleCount else { return nil }
+    var offsets: [UInt64] = []
+    var cursor = box.start + 8
+    for _ in 0..<count {
+      guard cursor + entrySize <= box.end else { break }
+      offsets.append(read(cursor))
+      cursor += entrySize
+    }
+    return offsets
   }
 
   /// `stsc` run table mapping chunk indices to samples-per-chunk.
   private func parseSTSC(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [(firstChunk: Int, samplesPerChunk: Int)]? {
     guard let box = firstChild(data, stbl.start, stbl.end, "stsc"), box.start + 8 <= box.end else { return nil }
     let entryCount = Int(beUInt32(data, box.start + 4))
+    guard entryCount <= Self.maxChapterSampleCount else { return nil }
     var entries: [(Int, Int)] = []
     var cursor = box.start + 8
     for _ in 0..<entryCount {
@@ -744,11 +816,16 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
         boxSize = fileSize - offset
       }
 
-      guard boxSize >= headerSize else { return nil }
+      // A box must be at least its header and must fit within the remaining file. This
+      // also prevents both a UInt64->Int overflow trap below and an `offset` wraparound
+      // (an infinite loop) when a malformed file declares an absurd box size.
+      guard boxSize >= headerSize, boxSize <= fileSize - offset else { return nil }
 
       if typeString(header, 4) == name {
-        try? handle.seek(toOffset: offset + headerSize)
         let payloadLength = Int(boxSize - headerSize)
+        // Don't read an absurdly large box into memory.
+        guard payloadLength <= Self.maxMoovSize else { return nil }
+        try? handle.seek(toOffset: offset + headerSize)
         guard
           let payload = try? handle.read(upToCount: payloadLength),
           payload.count == payloadLength
@@ -771,7 +848,10 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       var headerSize = 8
       if size32 == 1 {
         guard cursor + 16 <= end else { break }
-        size = Int(beUInt64(data, cursor + 8))
+        // Clamp to the enclosing range so an oversized 64-bit size can't trap on the
+        // UInt64->Int conversion; the bounds guard below then rejects it.
+        let extendedSize = beUInt64(data, cursor + 8)
+        size = extendedSize > UInt64(end - cursor) ? (end - cursor + 1) : Int(extendedSize)
         headerSize = 16
       } else if size32 == 0 {
         size = end - cursor
@@ -803,7 +883,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
   /// Read a track's ID from its `tkhd` box (version 0 and 1 layouts differ).
   private func trackID(of data: [UInt8], _ trakStart: Int, _ trakEnd: Int) -> UInt32? {
-    guard let tkhd = firstChild(data, trakStart, trakEnd, "tkhd") else { return nil }
+    guard let tkhd = firstChild(data, trakStart, trakEnd, "tkhd"), tkhd.start < tkhd.end else { return nil }
     let version = data[tkhd.start]
     let trackIDOffset = tkhd.start + (version == 1 ? 20 : 12)
     guard trackIDOffset + 4 <= tkhd.end else { return nil }

--- a/Shared/Services/AudioMetadataService.swift
+++ b/Shared/Services/AudioMetadataService.swift
@@ -179,9 +179,10 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
         return await extractOverdriveChapters(from: metadata, duration: duration)
       }
 
-      // MP3 standard chapters (ID3v2.3+ CHAP frames)
-      // Note: Currently AVFoundation doesn't fully expose CHAP frame data,
-      // but this may be supported in future iOS releases.
+      // MP3 standard chapters (ID3v2.3+ CHAP frames).
+      // AVFoundation only assembles ID3 chapters into `availableChapterLocales` when a
+      // `CTOC` (table of contents) frame is present. Without it, the `CHAP` frames are
+      // surfaced only as opaque data blobs, so we parse them ourselves.
       if identifiers.contains(where: { $0.hasPrefix("id3/CHAP") }) {
         return await extractID3Chapters(from: metadata, duration: duration)
       }
@@ -293,21 +294,24 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
   }
 
   private func extractID3Chapters(from metadata: [AVMetadataItem], duration: TimeInterval) async -> [ChapterMetadata]? {
-    var chapterData: [(start: Double, title: String)] = []
+    // AVFoundation surfaces each CHAP frame as an opaque data blob (its `numberValue`
+    // and `stringValue` are nil), so we parse the raw frame body ourselves. The CHAP
+    // frame layout (ID3v2.3/2.4) is:
+    //   element ID  : null-terminated string
+    //   start time  : UInt32 BE, milliseconds
+    //   end time    : UInt32 BE, milliseconds
+    //   start offset: UInt32 BE, byte offset (0xFFFFFFFF when unused)
+    //   end offset  : UInt32 BE, byte offset (0xFFFFFFFF when unused)
+    //   sub-frames  : embedded ID3 frames (e.g. TIT2 for the chapter title)
+    var chapterData: [(start: Double, end: Double?, title: String)] = []
 
     for item in metadata {
       guard let identifier = item.identifier?.rawValue,
-            identifier.hasPrefix("id3/CHAP") else { continue }
+            identifier.hasPrefix("id3/CHAP"),
+            let data = try? await item.load(.dataValue) else { continue }
 
-      // Extract chapter start time and title from CHAP frame.
-      // CHAP timestamps are relative offsets from the start of the audio (not absolute dates).
-      // Note: AVFoundation may not fully expose CHAP frame timing data currently,
-      // but we attempt to load what's available for future compatibility.
-      if let numberValue = try? await item.load(.numberValue),
-         numberValue.doubleValue >= 0 {
-        let startTime = numberValue.doubleValue
-        let title = (try? await item.load(.stringValue)) ?? ""
-        chapterData.append((start: startTime, title: title))
+      if let parsed = parseID3ChapterFrame([UInt8](data)) {
+        chapterData.append(parsed)
       }
     }
 
@@ -316,10 +320,12 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
     var chapters: [ChapterMetadata] = []
     for (index, data) in chapterData.enumerated() {
+      // Prefer the frame's own end time; otherwise derive from the next chapter or the
+      // total duration. Guard against malformed end times that precede the start.
       let chapterDuration: TimeInterval
-
-      // Calculate duration
-      if index < chapterData.count - 1 {
+      if let end = data.end, end > data.start {
+        chapterDuration = end - data.start
+      } else if index < chapterData.count - 1 {
         chapterDuration = chapterData[index + 1].start - data.start
       } else {
         chapterDuration = duration - data.start
@@ -328,7 +334,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       let chapter = ChapterMetadata(
         title: data.title,
         start: data.start,
-        duration: chapterDuration,
+        duration: max(0, chapterDuration),
         index: index + 1
       )
 
@@ -336,6 +342,79 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     }
 
     return chapters.isEmpty ? nil : chapters
+  }
+
+  /// Parse a single ID3 `CHAP` frame body into its start/end times (seconds) and title.
+  private func parseID3ChapterFrame(_ body: [UInt8]) -> (start: Double, end: Double?, title: String)? {
+    // Element ID is a null-terminated string.
+    guard let terminator = body.firstIndex(of: 0) else { return nil }
+    var cursor = terminator + 1
+
+    // Need 16 bytes for the four UInt32 timing/offset fields.
+    guard cursor + 16 <= body.count else { return nil }
+    let startMS = beUInt32(body, cursor)
+    let endMS = beUInt32(body, cursor + 4)
+    cursor += 16
+
+    let start = Double(startMS) / 1000.0
+    // 0xFFFFFFFF / a non-increasing end signals "unset"; let the caller derive duration.
+    let end: Double? = (endMS == 0xFFFFFFFF || endMS <= startMS) ? nil : Double(endMS) / 1000.0
+
+    let title = parseID3ChapterTitle(body, from: cursor)
+    return (start: start, end: end, title: title)
+  }
+
+  /// Walk the sub-frames of a CHAP frame and return the `TIT2` (title) text, if present.
+  private func parseID3ChapterTitle(_ body: [UInt8], from start: Int) -> String {
+    var cursor = start
+
+    // Each sub-frame: 4-byte frame ID, 4-byte size, 2-byte flags, then the payload.
+    while cursor + 10 <= body.count {
+      let frameID = typeString(body, cursor)
+      let declaredSize = Int(beUInt32(body, cursor + 4))
+      let payloadStart = cursor + 10
+
+      // ID3v2.4 uses synchsafe sizes; v2.3 uses plain UInt32. When the plain size
+      // overruns the buffer, fall back to the synchsafe interpretation.
+      var size = declaredSize
+      if payloadStart + size > body.count {
+        size = Int(synchsafeUInt32(body, cursor + 4))
+      }
+      guard size > 0, payloadStart + size <= body.count else { break }
+
+      if frameID == "TIT2" {
+        return decodeID3Text(Array(body[payloadStart..<payloadStart + size]))
+      }
+
+      cursor = payloadStart + size
+    }
+
+    return ""
+  }
+
+  /// Decode an ID3 text-frame payload (a leading encoding byte followed by the text).
+  private func decodeID3Text(_ payload: [UInt8]) -> String {
+    guard let encoding = payload.first else { return "" }
+    var bytes = Array(payload.dropFirst())
+    // Strip a trailing null terminator (one byte for 8-bit encodings, two for UTF-16).
+    let trimmed: String
+
+    switch encoding {
+    case 0: // ISO-8859-1 (Latin-1)
+      if bytes.last == 0 { bytes.removeLast() }
+      trimmed = String(bytes: bytes, encoding: .isoLatin1) ?? ""
+    case 1: // UTF-16 with BOM
+      if bytes.count >= 2, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
+      trimmed = String(bytes: bytes, encoding: .utf16) ?? ""
+    case 2: // UTF-16BE without BOM
+      if bytes.count >= 2, bytes[bytes.count - 1] == 0, bytes[bytes.count - 2] == 0 { bytes.removeLast(2) }
+      trimmed = String(bytes: bytes, encoding: .utf16BigEndian) ?? ""
+    default: // 3 = UTF-8 (and any unknown value, treated leniently)
+      if bytes.last == 0 { bytes.removeLast() }
+      trimmed = String(bytes: bytes, encoding: .utf8) ?? ""
+    }
+
+    return trimmed
   }
 
   private func extractOverdriveChapters(from metadata: [AVMetadataItem], duration: TimeInterval) async -> [ChapterMetadata]? {
@@ -762,6 +841,15 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
       | (UInt32(data[offset + 1]) << 16)
       | (UInt32(data[offset + 2]) << 8)
       | UInt32(data[offset + 3])
+  }
+
+  /// Read a 28-bit ID3v2 synchsafe integer (7 bits per byte, MSB always zero).
+  private func synchsafeUInt32(_ data: [UInt8], _ offset: Int) -> UInt32 {
+    guard offset + 4 <= data.count else { return 0 }
+    return (UInt32(data[offset] & 0x7F) << 21)
+      | (UInt32(data[offset + 1] & 0x7F) << 14)
+      | (UInt32(data[offset + 2] & 0x7F) << 7)
+      | UInt32(data[offset + 3] & 0x7F)
   }
 
   private func beUInt64(_ data: [UInt8], _ offset: Int) -> UInt64 {

--- a/Shared/Services/AudioMetadataService.swift
+++ b/Shared/Services/AudioMetadataService.swift
@@ -32,20 +32,17 @@ public struct AudioMetadata {
   public let title: String
   public let artist: String
   public let duration: TimeInterval
-  public let artwork: Data?
   public let chapters: [ChapterMetadata]?
-  
+
   public init(
     title: String,
     artist: String = "",
     duration: TimeInterval = 0,
-    artwork: Data? = nil,
     chapters: [ChapterMetadata]? = nil
   ) {
     self.title = title
     self.artist = artist
     self.duration = duration
-    self.artwork = artwork
     self.chapters = chapters
   }
 }
@@ -101,14 +98,12 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
 
       let title = await extractTitle(from: metadata)
       let artist = await extractArtist(from: metadata)
-      let artwork = await extractArtwork(from: metadata)
       let chapters = await extractChapters(from: asset, metadata: metadata, duration: durationSeconds)
 
       return AudioMetadata(
         title: title,
         artist: artist,
         duration: durationSeconds,
-        artwork: artwork,
         chapters: chapters
       )
 
@@ -158,15 +153,7 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     
     return ""
   }
-  
-  private func extractArtwork(from metadata: [AVMetadataItem]) async -> Data? {
-    guard let artworkItem = metadata.first(where: { $0.commonKey == .commonKeyArtwork }) else {
-      return nil
-    }
-    
-    return try? await artworkItem.load(.dataValue)
-  }
-  
+
   // MARK: - Chapter Extraction
   
   private func extractChapters(from asset: AVAsset, metadata: [AVMetadataItem], duration: TimeInterval) async -> [ChapterMetadata]? {

--- a/Shared/Services/AudioMetadataService.swift
+++ b/Shared/Services/AudioMetadataService.swift
@@ -156,7 +156,17 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
         return await extractStandardChapters(from: asset, locales: availableChapterLocales)
       }
 
-      // Second try: Check what metadata identifiers exist
+      // Second try: Malformed QuickTime/MP4 chapter tracks that AVFoundation refuses
+      // to expose. Older tools (e.g. "MarkAble") create a valid `chap`-referenced text
+      // chapter track but tag it with an external `alis` data reference and/or an invalid
+      // media language. AVFoundation then reports no `availableChapterLocales`, even though
+      // the chapter samples are physically present in the file. Parse them directly.
+      if let url = (asset as? AVURLAsset)?.url,
+         let textChapters = extractQuickTimeTextChapters(from: url, duration: duration) {
+        return textChapters
+      }
+
+      // Third try: Check what metadata identifiers exist
       let identifiers = metadata.compactMap { $0.identifier?.rawValue }
 
       // FLAC/Vorbis chapters (CHAPTER tags)
@@ -384,5 +394,387 @@ public class AudioMetadataService: BPLogger, AudioMetadataServiceProtocol {
     }
 
     return finalChapters.isEmpty ? nil : finalChapters
+  }
+
+  // MARK: - QuickTime / MP4 text chapter track fallback
+
+  /// Parse chapters from a QuickTime-style text chapter track by reading the MP4 box
+  /// structure directly. Used when AVFoundation declines to expose chapters that are
+  /// nonetheless present (malformed data reference or invalid track language).
+  /// - Returns: The parsed chapters, or `nil` if the file has no readable text chapter track.
+  private func extractQuickTimeTextChapters(from url: URL, duration: TimeInterval) -> [ChapterMetadata]? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+
+    guard
+      let fileSize = try? handle.seekToEnd(),
+      let moov = readTopLevelBox(named: "moov", handle: handle, fileSize: fileSize)
+    else { return nil }
+
+    // Gather every track, then resolve the one referenced as the chapter track.
+    let traks = childBoxes(moov, 0, moov.count).filter { $0.type == "trak" }
+    guard !traks.isEmpty else { return nil }
+
+    var trackByID: [UInt32: (start: Int, end: Int)] = [:]
+    var chapterTrackID: UInt32?
+
+    for trak in traks {
+      guard let trackID = trackID(of: moov, trak.start, trak.end) else { continue }
+      trackByID[trackID] = (trak.start, trak.end)
+
+      // A track's `tref` of type `chap` lists the IDs of its chapter tracks.
+      if chapterTrackID == nil,
+         let tref = firstChild(moov, trak.start, trak.end, "tref"),
+         let chap = firstChild(moov, tref.start, tref.end, "chap"),
+         tref.end >= chap.start + 4 {
+        chapterTrackID = beUInt32(moov, chap.start)
+      }
+    }
+
+    guard
+      let chapterID = chapterTrackID,
+      let chapterTrak = trackByID[chapterID]
+    else { return nil }
+
+    return parseTextChapters(
+      moov: moov,
+      trakStart: chapterTrak.start,
+      trakEnd: chapterTrak.end,
+      handle: handle,
+      totalDuration: duration
+    )
+  }
+
+  /// Parse the sample table of a text chapter track and read each chapter's title and timing.
+  private func parseTextChapters(
+    moov: [UInt8],
+    trakStart: Int,
+    trakEnd: Int,
+    handle: FileHandle,
+    totalDuration: TimeInterval
+  ) -> [ChapterMetadata]? {
+    guard
+      let mdhd = descend(moov, trakStart, trakEnd, ["mdia", "mdhd"]),
+      let stbl = descend(moov, trakStart, trakEnd, ["mdia", "minf", "stbl"])
+    else { return nil }
+
+    // mdhd timescale: version (0/1) changes the field offset.
+    let mdhdVersion = moov[mdhd.start]
+    let timescaleOffset = mdhd.start + (mdhdVersion == 1 ? 20 : 12)
+    guard timescaleOffset + 4 <= mdhd.end else { return nil }
+    let timescale = beUInt32(moov, timescaleOffset)
+    guard timescale > 0 else { return nil }
+
+    guard
+      let sampleDeltas = parseSTTS(moov, stbl),
+      let sampleSizes = parseSTSZ(moov, stbl),
+      let chunkOffsets = parseChunkOffsets(moov, stbl),
+      let sampleToChunk = parseSTSC(moov, stbl)
+    else { return nil }
+
+    let locations = sampleLocations(
+      sizes: sampleSizes,
+      chunkOffsets: chunkOffsets,
+      sampleToChunk: sampleToChunk
+    )
+    guard !locations.isEmpty else { return nil }
+
+    // Sample start times are the cumulative sum of per-sample durations (stts), in
+    // the track's timescale. Chapter durations are derived from consecutive starts so
+    // that empty/degenerate samples don't produce negative or zero-length spans.
+    var starts: [TimeInterval] = []
+    var cumulative: UInt64 = 0
+    for index in locations.indices {
+      starts.append(TimeInterval(cumulative) / TimeInterval(timescale))
+      if index < sampleDeltas.count {
+        cumulative += UInt64(sampleDeltas[index])
+      }
+    }
+
+    var chapters: [ChapterMetadata] = []
+    for (index, location) in locations.enumerated() {
+      guard
+        location.size >= 2,
+        let sampleData = readBytes(handle: handle, offset: location.offset, length: location.size),
+        sampleData.count >= 2
+      else { continue }
+
+      let titleLength = Int(beUInt16([UInt8](sampleData), 0))
+      let titleBytes = sampleData.dropFirst(2).prefix(titleLength)
+      let title = decodeText(Array(titleBytes))
+
+      let start = starts[index]
+      let nextStart = index < starts.count - 1 ? starts[index + 1] : totalDuration
+      let chapterDuration = max(0, nextStart - start)
+
+      chapters.append(
+        ChapterMetadata(
+          title: title,
+          start: start,
+          duration: chapterDuration,
+          index: index + 1
+        )
+      )
+    }
+
+    return chapters.isEmpty ? nil : chapters
+  }
+
+  // MARK: - Sample table parsing
+
+  /// Per-sample durations expanded from the run-length encoded `stts` box.
+  private func parseSTTS(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [UInt32]? {
+    guard let box = firstChild(data, stbl.start, stbl.end, "stts"), box.start + 8 <= box.end else { return nil }
+    let entryCount = Int(beUInt32(data, box.start + 4))
+    var deltas: [UInt32] = []
+    var cursor = box.start + 8
+    for _ in 0..<entryCount {
+      guard cursor + 8 <= box.end else { break }
+      let sampleCount = Int(beUInt32(data, cursor))
+      let sampleDelta = beUInt32(data, cursor + 4)
+      // Guard against pathological counts that would exhaust memory.
+      guard sampleCount >= 0, sampleCount < 1_000_000 else { return nil }
+      deltas.append(contentsOf: repeatElement(sampleDelta, count: sampleCount))
+      cursor += 8
+    }
+    return deltas
+  }
+
+  /// Per-sample byte sizes from the `stsz` box (handles the shared-size form).
+  private func parseSTSZ(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [Int]? {
+    guard let box = firstChild(data, stbl.start, stbl.end, "stsz"), box.start + 12 <= box.end else { return nil }
+    let uniformSize = beUInt32(data, box.start + 4)
+    let sampleCount = Int(beUInt32(data, box.start + 8))
+    guard sampleCount >= 0, sampleCount < 1_000_000 else { return nil }
+
+    if uniformSize != 0 {
+      return Array(repeating: Int(uniformSize), count: sampleCount)
+    }
+
+    var sizes: [Int] = []
+    var cursor = box.start + 12
+    for _ in 0..<sampleCount {
+      guard cursor + 4 <= box.end else { break }
+      sizes.append(Int(beUInt32(data, cursor)))
+      cursor += 4
+    }
+    return sizes
+  }
+
+  /// Chunk file offsets from `stco` (32-bit) or `co64` (64-bit).
+  private func parseChunkOffsets(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [UInt64]? {
+    if let box = firstChild(data, stbl.start, stbl.end, "stco"), box.start + 8 <= box.end {
+      let count = Int(beUInt32(data, box.start + 4))
+      var offsets: [UInt64] = []
+      var cursor = box.start + 8
+      for _ in 0..<count {
+        guard cursor + 4 <= box.end else { break }
+        offsets.append(UInt64(beUInt32(data, cursor)))
+        cursor += 4
+      }
+      return offsets
+    }
+
+    if let box = firstChild(data, stbl.start, stbl.end, "co64"), box.start + 8 <= box.end {
+      let count = Int(beUInt32(data, box.start + 4))
+      var offsets: [UInt64] = []
+      var cursor = box.start + 8
+      for _ in 0..<count {
+        guard cursor + 8 <= box.end else { break }
+        offsets.append(beUInt64(data, cursor))
+        cursor += 8
+      }
+      return offsets
+    }
+
+    return nil
+  }
+
+  /// `stsc` run table mapping chunk indices to samples-per-chunk.
+  private func parseSTSC(_ data: [UInt8], _ stbl: (start: Int, end: Int)) -> [(firstChunk: Int, samplesPerChunk: Int)]? {
+    guard let box = firstChild(data, stbl.start, stbl.end, "stsc"), box.start + 8 <= box.end else { return nil }
+    let entryCount = Int(beUInt32(data, box.start + 4))
+    var entries: [(Int, Int)] = []
+    var cursor = box.start + 8
+    for _ in 0..<entryCount {
+      guard cursor + 12 <= box.end else { break }
+      let firstChunk = Int(beUInt32(data, cursor))
+      let samplesPerChunk = Int(beUInt32(data, cursor + 4))
+      entries.append((firstChunk, samplesPerChunk))
+      cursor += 12
+    }
+    return entries.isEmpty ? nil : entries
+  }
+
+  /// Resolve each sample's absolute file offset and size by walking chunks (stsc + stco + stsz).
+  private func sampleLocations(
+    sizes: [Int],
+    chunkOffsets: [UInt64],
+    sampleToChunk: [(firstChunk: Int, samplesPerChunk: Int)]
+  ) -> [(offset: UInt64, size: Int)] {
+    var locations: [(UInt64, Int)] = []
+    var sampleIndex = 0
+
+    for chunkIndex in 0..<chunkOffsets.count {
+      // The applicable run is the last entry whose firstChunk <= this chunk (1-based).
+      let chunkNumber = chunkIndex + 1
+      var samplesPerChunk = sampleToChunk[0].samplesPerChunk
+      for entry in sampleToChunk {
+        if entry.firstChunk <= chunkNumber {
+          samplesPerChunk = entry.samplesPerChunk
+        } else {
+          break
+        }
+      }
+
+      var offsetWithinChunk = chunkOffsets[chunkIndex]
+      for _ in 0..<samplesPerChunk {
+        guard sampleIndex < sizes.count else { return locations }
+        let size = sizes[sampleIndex]
+        locations.append((offsetWithinChunk, size))
+        offsetWithinChunk += UInt64(size)
+        sampleIndex += 1
+      }
+    }
+
+    return locations
+  }
+
+  // MARK: - Box navigation helpers
+
+  /// Scan top-level boxes and return the payload bytes of the first box with the given type.
+  private func readTopLevelBox(named name: String, handle: FileHandle, fileSize: UInt64) -> [UInt8]? {
+    var offset: UInt64 = 0
+    while offset + 8 <= fileSize {
+      try? handle.seek(toOffset: offset)
+      guard
+        let headerData = try? handle.read(upToCount: 16),
+        headerData.count >= 8
+      else { return nil }
+
+      let header = [UInt8](headerData)
+      let size32 = beUInt32(header, 0)
+      var boxSize = UInt64(size32)
+      var headerSize: UInt64 = 8
+
+      if size32 == 1 {
+        guard header.count >= 16 else { return nil }
+        boxSize = beUInt64(header, 8)
+        headerSize = 16
+      } else if size32 == 0 {
+        boxSize = fileSize - offset
+      }
+
+      guard boxSize >= headerSize else { return nil }
+
+      if typeString(header, 4) == name {
+        try? handle.seek(toOffset: offset + headerSize)
+        let payloadLength = Int(boxSize - headerSize)
+        guard
+          let payload = try? handle.read(upToCount: payloadLength),
+          payload.count == payloadLength
+        else { return nil }
+        return [UInt8](payload)
+      }
+
+      offset += boxSize
+    }
+    return nil
+  }
+
+  /// Immediate child boxes within the byte range `[start, end)`.
+  private func childBoxes(_ data: [UInt8], _ start: Int, _ end: Int) -> [(type: String, start: Int, end: Int)] {
+    var children: [(String, Int, Int)] = []
+    var cursor = start
+    while cursor + 8 <= end {
+      let size32 = beUInt32(data, cursor)
+      var size = Int(size32)
+      var headerSize = 8
+      if size32 == 1 {
+        guard cursor + 16 <= end else { break }
+        size = Int(beUInt64(data, cursor + 8))
+        headerSize = 16
+      } else if size32 == 0 {
+        size = end - cursor
+      }
+      guard size >= headerSize, cursor + size <= end else { break }
+      children.append((typeString(data, cursor + 4), cursor + headerSize, cursor + size))
+      cursor += size
+    }
+    return children
+  }
+
+  /// The first immediate child box of the given type within `[start, end)`.
+  private func firstChild(_ data: [UInt8], _ start: Int, _ end: Int, _ type: String) -> (start: Int, end: Int)? {
+    for child in childBoxes(data, start, end) where child.type == type {
+      return (child.start, child.end)
+    }
+    return nil
+  }
+
+  /// Follow a chain of nested child box types, returning the innermost range.
+  private func descend(_ data: [UInt8], _ start: Int, _ end: Int, _ path: [String]) -> (start: Int, end: Int)? {
+    var current = (start: start, end: end)
+    for type in path {
+      guard let next = firstChild(data, current.start, current.end, type) else { return nil }
+      current = next
+    }
+    return current
+  }
+
+  /// Read a track's ID from its `tkhd` box (version 0 and 1 layouts differ).
+  private func trackID(of data: [UInt8], _ trakStart: Int, _ trakEnd: Int) -> UInt32? {
+    guard let tkhd = firstChild(data, trakStart, trakEnd, "tkhd") else { return nil }
+    let version = data[tkhd.start]
+    let trackIDOffset = tkhd.start + (version == 1 ? 20 : 12)
+    guard trackIDOffset + 4 <= tkhd.end else { return nil }
+    return beUInt32(data, trackIDOffset)
+  }
+
+  // MARK: - Primitive readers
+
+  /// Decode QuickTime text sample bytes, trying UTF-16 (when a BOM is present), then
+  /// UTF-8, then Mac Roman (the legacy default for text tracks).
+  private func decodeText(_ bytes: [UInt8]) -> String {
+    guard !bytes.isEmpty else { return "" }
+
+    if bytes.count >= 2, (bytes[0] == 0xFE && bytes[1] == 0xFF) || (bytes[0] == 0xFF && bytes[1] == 0xFE) {
+      if let utf16 = String(bytes: bytes, encoding: .utf16) { return utf16 }
+    }
+    if let utf8 = String(bytes: bytes, encoding: .utf8) { return utf8 }
+    if let macRoman = String(bytes: bytes, encoding: .macOSRoman) { return macRoman }
+    return String(bytes: bytes, encoding: .isoLatin1) ?? ""
+  }
+
+  private func readBytes(handle: FileHandle, offset: UInt64, length: Int) -> Data? {
+    guard length > 0, (try? handle.seek(toOffset: offset)) != nil else { return nil }
+    return try? handle.read(upToCount: length)
+  }
+
+  private func beUInt16(_ data: [UInt8], _ offset: Int) -> UInt16 {
+    guard offset + 2 <= data.count else { return 0 }
+    return (UInt16(data[offset]) << 8) | UInt16(data[offset + 1])
+  }
+
+  private func beUInt32(_ data: [UInt8], _ offset: Int) -> UInt32 {
+    guard offset + 4 <= data.count else { return 0 }
+    return (UInt32(data[offset]) << 24)
+      | (UInt32(data[offset + 1]) << 16)
+      | (UInt32(data[offset + 2]) << 8)
+      | UInt32(data[offset + 3])
+  }
+
+  private func beUInt64(_ data: [UInt8], _ offset: Int) -> UInt64 {
+    guard offset + 8 <= data.count else { return 0 }
+    var value: UInt64 = 0
+    for index in 0..<8 {
+      value = (value << 8) | UInt64(data[offset + index])
+    }
+    return value
+  }
+
+  private func typeString(_ data: [UInt8], _ offset: Int) -> String {
+    guard offset + 4 <= data.count else { return "" }
+    return String(bytes: data[offset..<offset + 4], encoding: .isoLatin1) ?? ""
   }
 }


### PR DESCRIPTION
## Purpose

- If the m4b file is not properly formatted like AVFoundation wants, the chapters won't get recognized, this PR adds a fallback to manually how through the chapter and assemble the list
- Same thing happens with mp3s that are missing the tag CTOC