### PR TITLE
Don't put the ABS token in download URLs

### DIFF
--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -104,9 +104,6 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     guard let serverUrl = pingedURL else {
       throw IntegrationError.urlMalformed(nil)
     }
-    // Drop the captured URL after this method runs — on success the connection is
-    // persisted, on failure the user must re-validate via Connect anyway.
-    defer { pingedURL = nil }
     do {
       // ABS auth doesn't trim whitespace server-side, so iOS autocorrect inserting a trailing
       // space on the username is enough to silently reject otherwise-correct credentials.
@@ -120,6 +117,13 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
         customHeaders: form.customHeadersDictionary()
       )
 
+      // Drop the captured URL only once the connection is persisted. Clearing it on every
+      // exit (an unconditional `defer`) stranded the user after a wrong password: the sheet
+      // stays on the credentials step, so the retry hit the `guard` above and threw
+      // `urlMalformed(nil)` instead of re-attempting sign-in. Keeping it across a failure
+      // preserves the safety property — credentials still only go to the pinged URL, and a
+      // form edit in between still can't redirect them.
+      pingedURL = nil
       isAddingServer = false
 
       if let data = connectionService.connection {

--- a/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
+++ b/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
@@ -521,22 +521,28 @@ class AudiobookShelfConnectionService: BPLogger {
       throw URLError(.userAuthenticationRequired)
     }
 
+    // The token is deliberately not appended as a query parameter. ABS accepts
+    // the bearer via `Authorization: Bearer` on this endpoint, and a token-bearing
+    // URL leaks: background URLSession serializes task URLs to disk, and query
+    // strings land in proxy/CDN access logs (Authorization headers don't).
     return connection.url
       .appendingPathComponent("api")
       .appendingPathComponent("items")
       .appendingPathComponent(item.id)
       .appendingPathComponent("download")
-      .appending(queryItems: [URLQueryItem(name: "token", value: connection.apiToken)])
   }
 
-  /// Returns a URLRequest for downloading a library item, carrying the user-defined
+  /// Returns a URLRequest for downloading a library item, carrying the bearer
+  /// token via the standard `Authorization: Bearer` header plus the user-defined
   /// custom HTTP headers (needed for servers behind Cloudflare Access etc.).
   public func createItemDownloadRequest(_ item: AudiobookShelfLibraryItem) throws -> URLRequest {
-    guard connection != nil else {
+    guard let connection else {
       throw URLError(.userAuthenticationRequired)
     }
     let url = try createItemDownloadUrl(item)
-    return wrapWithCustomHeaders(url)
+    var request = wrapWithCustomHeaders(url)
+    applyAuthenticatedHeaders(to: &request, connection: connection)
+    return request
   }
 
   /// Wraps an arbitrary URL (e.g. a cover image or stream URL) in a URLRequest that carries

--- a/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
+++ b/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
@@ -516,15 +516,18 @@ class AudiobookShelfConnectionService: BPLogger {
     return AudiobookShelfAudiobookDetailsData(apiResponse: detailsResponse)
   }
 
-  public func createItemDownloadUrl(_ item: AudiobookShelfLibraryItem) throws -> URL {
-    guard let connection else {
-      throw URLError(.userAuthenticationRequired)
-    }
-
-    // The token is deliberately not appended as a query parameter. ABS accepts
-    // the bearer via `Authorization: Bearer` on this endpoint, and a token-bearing
-    // URL leaks: background URLSession serializes task URLs to disk, and query
-    // strings land in proxy/CDN access logs (Authorization headers don't).
+  /// Builds the download URL. The token is deliberately **not** appended as a query
+  /// parameter: ABS documents `Authorization: Bearer` as the primary scheme (`?token=`
+  /// is only an optional convenience for GETs), and a token-bearing URL leaks into
+  /// proxy/CDN access logs and into the download task's persisted `taskDescription`.
+  ///
+  /// Kept private because the returned URL is *not* self-authenticating — handing it
+  /// straight to `URLSession`/`AVURLAsset` would 401. Go through
+  /// `createItemDownloadRequest(_:)`, which attaches the bearer.
+  private func createItemDownloadUrl(
+    _ item: AudiobookShelfLibraryItem,
+    connection: AudiobookShelfConnectionData
+  ) -> URL {
     return connection.url
       .appendingPathComponent("api")
       .appendingPathComponent("items")
@@ -539,17 +542,9 @@ class AudiobookShelfConnectionService: BPLogger {
     guard let connection else {
       throw URLError(.userAuthenticationRequired)
     }
-    let url = try createItemDownloadUrl(item)
-    var request = wrapWithCustomHeaders(url)
-    applyAuthenticatedHeaders(to: &request, connection: connection)
-    return request
-  }
-
-  /// Wraps an arbitrary URL (e.g. a cover image or stream URL) in a URLRequest that carries
-  /// the current connection's custom HTTP headers.
-  public func wrapWithCustomHeaders(_ url: URL) -> URLRequest {
+    let url = createItemDownloadUrl(item, connection: connection)
     var request = URLRequest(url: url)
-    applyCustomHeaders(to: &request, headers: connection?.customHeaders ?? [:])
+    applyAuthenticatedHeaders(to: &request, connection: connection)
     return request
   }
 

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -95,10 +95,6 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     guard let pending = pendingServer else {
       throw IntegrationError.noClient("Jellyfin")
     }
-    // Always drop the transient `pending` after this method runs — on success the
-    // service commits it as `self.client`, on failure it's no longer reusable
-    // (credentials may be wrong, URL may be stale relative to what the user typed next).
-    defer { pendingServer = nil }
     do {
       try await connectionService.signIn(
         pending: pending,
@@ -108,6 +104,13 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
         customHeaders: form.customHeadersDictionary()
       )
 
+      // Drop the transient `pending` only once the service has committed it as
+      // `self.client`. Clearing it on every exit (an unconditional `defer`) stranded the
+      // user after a wrong password: the sheet stays on the credentials step, so the retry
+      // hit the `guard` above and threw `noClient` instead of re-attempting sign-in.
+      // `signIn(pending:)` only reads `pending.client` and commits nothing on failure, so
+      // the validated client is still good for another attempt.
+      pendingServer = nil
       isAddingServer = false
 
       if let data = connectionService.connection {

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
@@ -88,6 +88,17 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
       }
     }
     .toolbar {
+      // Shown in every state, including Add Server. Without it that flow renders a
+      // bare Cancel/Connect bar, and since both integrations share this screen there
+      // is nothing on it telling you whether you're adding a Jellyfin or an
+      // AudiobookShelf server — entering one server's URL into the other's flow just
+      // fails with an opaque 404 from the wrong probe endpoint.
+      ToolbarItem(placement: .principal) {
+        Text(localizedNavigationTitle)
+          .bpFont(.headline)
+          .foregroundStyle(theme.primaryColor)
+          .accessibilityAddTraits(.isHeader)
+      }
       if viewModel.isAddingServer {
         ToolbarItem(placement: .cancellationAction) {
           Button("cancel_button".localized) {
@@ -103,11 +114,6 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
           }
         }
       } else {
-        ToolbarItem(placement: .principal) {
-          Text(localizedNavigationTitle)
-            .bpFont(.headline)
-            .foregroundStyle(theme.primaryColor)
-        }
         ToolbarItemGroup(placement: .confirmationAction) {
           switch viewModel.signInFlow {
           case .enteringServerURL: connectToolbarButton


### PR DESCRIPTION
Download URLs for Audiobookshelf carry the api token as a query param. Background URLSession writes task URLs to disk, and query strings end up in proxy and CDN logs, so the token leaks. Switched it to the Authorization header, which the download endpoint already accepts like every other call in the service.