### PR TITLE
Groundwork for the connection-flow redesign

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		5163037679ED3EE0D1866A8F /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC8B923A5506F865253B97C /* AppServices.swift */; };
 		52AA441379FD94339FEECB55 /* SortPreferencesResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6BC9E7E76B9BAB7A0D88D2 /* SortPreferencesResolving.swift */; };
 		59384C1A0B33B9EB42AE4C75 /* ChaptersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F496A2BF4CBFFC745C453D42 /* ChaptersViewModelTests.swift */; };
+		5A9506FC8DAB858289E0EF89 /* IntegrationServerAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623E13D0C96857091397B5EF /* IntegrationServerAddressTests.swift */; };
 		5E20E8B93A65A58C51F1FF52 /* PKCETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A989BA90E16F60920A1DB0 /* PKCETests.swift */; };
 		62793611272CBE910097837D /* ImportFileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4163E3102148606600072AA2 /* ImportFileItem.swift */; };
 		62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
@@ -644,6 +645,7 @@
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
 		69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */; };
 		6C25A0E1ADBF2325CA78E8A4 /* mp3_NO_toc_v23.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 1BA32C89144C68DD64FD0B62 /* mp3_NO_toc_v23.mp3 */; };
+		6DF751D96098B1A3224FDF43 /* IntegrationServerAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFF7B7B6E62B274D230C207 /* IntegrationServerAddress.swift */; };
 		6EC082E4BEF0CC2FAA42C0A7 /* mp3_WITH_toc.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 8D3EFD93E6D1E0366A3FD1E9 /* mp3_WITH_toc.mp3 */; };
 		760180C62F243705DE6B3224 /* IntegrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0FA9BA32EDF5F367C757B /* IntegrationError.swift */; };
 		78D8C50324731BBDF9E9281E /* LibraryOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBF775DDE66D0AA08818D45 /* LibraryOptionsView.swift */; };
@@ -1053,6 +1055,7 @@
 		12EDB8401F38342155CBBC91 /* mp3_NO_chapters.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = mp3_NO_chapters.mp3; sourceTree = "<group>"; };
 		13C407B5BD19D3CF9CC64EC7 /* IntegrationLibraryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationLibraryView.swift; sourceTree = "<group>"; };
 		1BA32C89144C68DD64FD0B62 /* mp3_NO_toc_v23.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = mp3_NO_toc_v23.mp3; sourceTree = "<group>"; };
+		1FFF7B7B6E62B274D230C207 /* IntegrationServerAddress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationServerAddress.swift; sourceTree = "<group>"; };
 		22E85F55E03D1981F097661C /* PKCE.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
 		269BB56618B150DCAA2CA5FB /* IntegrationConnectionStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationConnectionStoreTests.swift; sourceTree = "<group>"; };
 		2BB8BD2F5EC900DC51D5D02D /* IntegrationConnectionDataDecodingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationConnectionDataDecodingTests.swift; sourceTree = "<group>"; };
@@ -1319,6 +1322,7 @@
 		5F847DAE94054533AACF8D85 /* PlayBookIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayBookIntent.swift; sourceTree = "<group>"; };
 		620C73C7275DA00300D495AA /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ar; path = ar.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		620C73C8275DA00400D495AA /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		623E13D0C96857091397B5EF /* IntegrationServerAddressTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationServerAddressTests.swift; sourceTree = "<group>"; };
 		624AB20A2724808600F6A486 /* AVAudioAssetImageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAudioAssetImageDataProvider.swift; sourceTree = "<group>"; };
 		624EB9832755D8E700D462A8 /* Audiobook Player 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 8.xcdatamodel"; sourceTree = "<group>"; };
 		62AAE22B274AA3EB001EB9FF /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
@@ -2565,6 +2569,7 @@
 				638A9B40CE7EECEF80FA9935 /* AudiobookShelfConnectionViewModelTests.swift */,
 				F4388D9707FA7C85F9D07E75 /* WebAuthenticatingTests.swift */,
 				8B8DAE18EF12485AD3509B2D /* JellyfinQuickConnectTests.swift */,
+				623E13D0C96857091397B5EF /* IntegrationServerAddressTests.swift */,
 			);
 			name = MediaServerIntegration;
 			path = MediaServerIntegration;
@@ -3221,6 +3226,7 @@
 			children = (
 				7A8030B619D18CA088DAA40A /* IntegrationConnectionPayload.swift */,
 				587EDC7DEA9D2985635F1161 /* IntegrationConnectionStore.swift */,
+				1FFF7B7B6E62B274D230C207 /* IntegrationServerAddress.swift */,
 			);
 			name = Connection;
 			path = Connection;
@@ -4936,6 +4942,7 @@
 				0199296D1E63EE13FC3558E6 /* WebAuthenticating.swift in Sources */,
 				0235B7EE8FA51C49AFBBBE71 /* IntegrationConnectionPayload.swift in Sources */,
 				843575DDF1CEEBC9A2EF015C /* IntegrationConnectionStore.swift in Sources */,
+				6DF751D96098B1A3224FDF43 /* IntegrationServerAddress.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4977,6 +4984,7 @@
 				F97E68221AB7CDFB93CC0AF7 /* AudiobookShelfConnectionViewModelTests.swift in Sources */,
 				ADBA6DD206F76CF92C0765A3 /* WebAuthenticatingTests.swift in Sources */,
 				E101E3603ACF4DB50AA0037B /* JellyfinQuickConnectTests.swift in Sources */,
+				5A9506FC8DAB858289E0EF89 /* IntegrationServerAddressTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -26,12 +26,11 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
   /// cannot possibly work.
   @Published private(set) var capabilities = AudiobookShelfConnectionService.ServerCapabilities()
 
-  var oidcSupported: Bool { capabilities.supportsOIDC && isPingedURLSecure }
-
-  var oidcButtonText: String? { capabilities.oidcButtonText }
-
-  var oidcBlockedByInsecureTransport: Bool {
-    capabilities.supportsOIDC && !isPingedURLSecure
+  var alternativeSignIn: AlternativeSignInState? {
+    guard capabilities.supportsOIDC else { return nil }
+    return isPingedURLSecure
+      ? .oidc(buttonText: capabilities.oidcButtonText)
+      : .oidcRequiresSecureTransport
   }
 
   /// SSO is refused over plaintext: the authorization code, the PKCE verifier and the returned token
@@ -295,7 +294,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
   /// drives the IdP handshake; on user cancellation the service throws `CancellationError`,
   /// which the shared view swallows.
   @MainActor
-  func handleStartOIDC() async throws {
+  func handleStartAlternativeSignIn() async throws {
     guard let serverUrl = pingedURL else {
       throw IntegrationError.urlMalformed(nil)
     }

--- a/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
+++ b/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
@@ -104,6 +104,12 @@ class AudiobookShelfConnectionService: BPLogger {
     /// The provider button label ABS's own web UI shows, e.g. "Login with OpenId". Preferring the
     /// server's wording means a user sees the same label here as in the browser.
     var oidcButtonText: String?
+    /// Whether the server accepts username/password sign-in at all. ABS admins can disable local
+    /// auth outright (SSO-only servers), and `authMethods` then omits `"local"` — a case the probe
+    /// used to ignore, leaving those users a password form that cannot possibly work. Defaults to
+    /// `true` because that is the failure-safe direction: when the probe can't answer, offering a
+    /// password form that might work beats hiding the only sign-in path a server may have.
+    var supportsLocal: Bool = true
   }
 
   /// Best-effort capability probe against `/status`.
@@ -137,7 +143,10 @@ class AudiobookShelfConnectionService: BPLogger {
 
     return ServerCapabilities(
       supportsOIDC: methods.contains("openid"),
-      oidcButtonText: buttonText?.isEmpty == false ? buttonText : nil
+      oidcButtonText: buttonText?.isEmpty == false ? buttonText : nil,
+      // An absent or empty `authMethods` means the server predates the field or answered something
+      // unexpected — treat local auth as available rather than locking the user out of the form.
+      supportsLocal: methods.isEmpty || methods.contains("local")
     )
   }
 

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -27,13 +27,13 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   /// awaiting-code overlay and react to failure/success.
   @Published var quickConnectStatus: QuickConnectStatus?
 
-  /// Whether the validated server actually has Quick Connect enabled.
+  /// `.quickConnect` when the validated server actually has it enabled, nil otherwise.
   ///
   /// Derived from the `/QuickConnect/Enabled` probe in `handleConnectAction`, not hardcoded: the
   /// feature ships with every modern Jellyfin build but admins can switch it off, and offering a button
   /// that can't work walks the user into a server error with no explanation. Mirrors how
-  /// `AudiobookShelfConnectionViewModel` derives `oidcSupported` from `/status`.
-  @Published private(set) var quickConnectSupported: Bool = false
+  /// `AudiobookShelfConnectionViewModel` derives its `alternativeSignIn` from `/status`.
+  @Published private(set) var alternativeSignIn: AlternativeSignInState?
 
   /// Active Quick Connect controller, retained so its polling task isn't deallocated and so
   /// cancel/cleanup can call `stop()`. Nil when no flow is in progress.
@@ -118,7 +118,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     )
     pendingServer = pending
     // Set before `signInFlow` so the credentials step renders with the right affordances on first pass.
-    quickConnectSupported = pending.quickConnectEnabled
+    alternativeSignIn = pending.quickConnectEnabled ? .quickConnect : nil
     signInFlow = .enteringCredentials
     form.serverName = pending.serverName
   }
@@ -144,7 +144,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
       // `signIn(pending:)` only reads `pending.client` and commits nothing on failure, so
       // the validated client is still good for another attempt.
       pendingServer = nil
-      quickConnectSupported = false
+      alternativeSignIn = nil
       isAddingServer = false
 
       if let data = connectionService.connection {
@@ -266,7 +266,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     // The transient client from any previous attempt is stale; Connect rebuilds it — and re-probes the
     // capability, so don't leave a stale `true` behind that would render a button we can't back up.
     pendingServer = nil
-    quickConnectSupported = false
+    alternativeSignIn = nil
     signInFlow = .enteringServerURL
   }
 
@@ -279,7 +279,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   /// only for setup failure (no validated server yet); mid-flight failures arrive async via
   /// the published state and surface as `quickConnectStatus = .failed(...)`.
   @MainActor
-  func handleStartQuickConnect() async throws {
+  func handleStartAlternativeSignIn() async throws {
     // Idempotent: ignore if a flow is already in progress.
     guard activeQuickConnect == nil else { return }
     guard let pending = pendingServer else {
@@ -305,7 +305,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   /// Cancels an in-flight Quick Connect flow and clears any pending status. Safe to call when
   /// no flow is running.
   @MainActor
-  func handleCancelQuickConnect() {
+  func handleCancelAlternativeSignIn() {
     // Cancelled here rather than in `teardownQuickConnect()`, which also runs *from inside* this task
     // on the success path — cancelling there would have the task cancel itself mid-persist.
     quickConnectSignInTask?.cancel()
@@ -331,7 +331,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
       // with an invisible poller still running for its full ~16-minute budget.
       //
       // Nothing is lost by ignoring it: the only other source of `.idle` is `stop()`, and
-      // `handleCancelQuickConnect` cancels this subscription on the very next line, so that emission
+      // `handleCancelAlternativeSignIn` cancels this subscription on the very next line, so that emission
       // is never delivered either.
       break
     case .retrievingCode:
@@ -371,7 +371,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
       )
       // Only drop the transient pending handle once the service has committed it.
       pendingServer = nil
-      quickConnectSupported = false
+      alternativeSignIn = nil
       isAddingServer = false
       if let data = connectionService.connection {
         form.setValues(
@@ -395,7 +395,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
       // as `CancellationError`: Get's `DataLoader` cancels through `onCancel: { task.cancel() }`, so the
       // URLSession task fails, the continuation resumes with `URLError(.cancelled)`, and `APIClient`
       // rethrows that raw `URLError`. Matching on `CancellationError` therefore missed the common window
-      // and set `.failed("cancelled")` *after* `handleCancelQuickConnect` had cleared the status —
+      // and set `.failed("cancelled")` *after* `handleCancelAlternativeSignIn` had cleared the status —
       // popping the dismissed sheet straight back up. `Task.isCancelled` covers both spellings.
       if Task.isCancelled { return }
       Self.logger.error("Quick Connect sign-in failed: \(String(describing: error))")
@@ -424,7 +424,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   /// Drops the active controller + state subscription. Leaves `quickConnectStatus` untouched so
   /// callers decide whether the sheet dismisses (status = nil) or shows a terminal error.
   ///
-  /// `stop()` is called unconditionally rather than only from `handleCancelQuickConnect`. Releasing our
+  /// `stop()` is called unconditionally rather than only from `handleCancelAlternativeSignIn`. Releasing our
   /// reference is NOT enough to end a poll: `QuickConnect` holds itself alive through
   /// `mainTask = Task { await run() }` and has no `deinit`, so an unstopped controller keeps polling for
   /// its full `maxPolls` budget (~16 minutes) with nobody listening. It happens to be harmless on the

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
@@ -34,7 +34,7 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
       get: { viewModel.quickConnectStatus != nil },
       set: { newValue in
         // The user dismissed the sheet by gesture — clean up the in-flight flow.
-        if !newValue { viewModel.handleCancelQuickConnect() }
+        if !newValue { viewModel.handleCancelAlternativeSignIn() }
       }
     )
   }
@@ -59,31 +59,34 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
           serverName: viewModel.form.serverName,
           serverUrl: viewModel.form.serverUrl
         )
-        // Alternative sign-in methods go ABOVE the username/password section.
+        // The alternative sign-in goes ABOVE the username/password section.
         // `IntegrationServerFoundView` auto-focuses the username field, so this step always arrives
         // with the keyboard up; below Login these rows start out hidden behind it on smaller devices —
-        // poor discoverability for what are meant to be peer paths to password sign-in, not footnotes.
-        // At most one of these renders: AudiobookShelf opts into OIDC, Jellyfin into Quick Connect,
-        // and each leaves the other at its protocol default of `false`.
-        if viewModel.oidcSupported {
+        // poor discoverability for what is meant to be a peer path to password sign-in, not a footnote.
+        // At most one renders — the slot is a single optional, so "both at once" cannot be expressed.
+        switch viewModel.alternativeSignIn {
+        case .oidc(let buttonText):
           IntegrationOIDCSectionView(
-            buttonText: viewModel.oidcButtonText,
+            buttonText: buttonText,
             isBusy: isLoading,
-            onStart: onStartOIDC
+            onStart: onStartAlternativeSignIn
           )
-        } else if viewModel.oidcBlockedByInsecureTransport {
+        case .oidcRequiresSecureTransport:
           // The server does offer SSO — say why we won't, rather than silently omitting it.
           IntegrationOIDCUnavailableSectionView()
-        }
-        if viewModel.quickConnectSupported {
-          IntegrationQuickConnectSectionView(onStart: onStartQuickConnect)
+        case .quickConnect:
+          IntegrationQuickConnectSectionView(onStart: onStartAlternativeSignIn)
+        case nil:
+          EmptyView()
         }
         IntegrationServerFoundView(
           username: $viewModel.form.username,
           password: $viewModel.form.password,
-          // Don't raise the keyboard when an alternative sign-in is on offer — it would cover the
-          // option above and presume the user came here to type a password.
-          autoFocusesUsername: !viewModel.oidcSupported && !viewModel.quickConnectSupported,
+          // Don't raise the keyboard when an alternative sign-in is actually on offer — it would cover
+          // the option above and presume the user came here to type a password. An explanation-only
+          // state (`.oidcRequiresSecureTransport`) is not an offer: typing is still the only way in,
+          // so the keyboard should come up exactly as it does with no alternative at all.
+          autoFocusesUsername: !(viewModel.alternativeSignIn?.isActionable ?? false),
           onCommit: onSignIn
         )
         IntegrationCustomHeadersSectionView(
@@ -113,7 +116,7 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
       IntegrationQuickConnectSheetView(
         status: viewModel.quickConnectStatus ?? .retrievingCode,
         serverUrl: viewModel.form.serverUrl,
-        onCancel: { viewModel.handleCancelQuickConnect() }
+        onCancel: { viewModel.handleCancelAlternativeSignIn() }
       )
       .environmentObject(theme)
     }
@@ -150,7 +153,7 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
             // Tear down any in-flight Quick Connect before leaving: its poller lives on the view model,
             // not in `actionTask`, so it would otherwise keep running — and could persist a connection
             // after the user explicitly backed out. No-op when no flow is running.
-            viewModel.handleCancelQuickConnect()
+            viewModel.handleCancelAlternativeSignIn()
             viewModel.handleCancelAddServerAction()
             dismiss()
           }
@@ -183,7 +186,7 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
       // this view model is a `@StateObject` on the presenting sheet, so it would deallocate, dropping
       // the state subscription while the SDK controller — which self-retains via `mainTask` and has no
       // `deinit` — kept polling for its full ~16-minute budget. No-op when no flow is running.
-      viewModel.handleCancelQuickConnect()
+      viewModel.handleCancelAlternativeSignIn()
     }
   }
 
@@ -233,15 +236,30 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
     }
   }
 
-  /// Starts the native SSO flow. The system web-auth sheet drives the IdP handshake; the
-  /// loading overlay covers the subsequent token exchange. User cancellation is swallowed.
-  func onStartOIDC() {
+  /// Starts whichever alternative flow the view model advertises.
+  ///
+  /// The loading overlay is OIDC-only: the system web-auth sheet drives the IdP handshake and the
+  /// overlay covers the subsequent token exchange, whereas Quick Connect presents a sheet with its own
+  /// progress UI the moment the flow starts — an overlay there would just stack spinners. Failures
+  /// mid-Quick-Connect surface inside that sheet via `quickConnectStatus`; only the synchronous setup
+  /// error lands in the alert.
+  func onStartAlternativeSignIn() {
+    guard let method = viewModel.alternativeSignIn, method.isActionable else { return }
+    let showsOverlay: Bool
+    switch method {
+    case .oidc:
+      showsOverlay = true
+    case .quickConnect, .oidcRequiresSecureTransport:
+      showsOverlay = false
+    }
+    // Routed through `actionTask` like every sibling handler — the property's own doc comment names
+    // alternative-sign-in start as one of the flows it tracks.
     actionTask?.cancel()
-    isLoading = true
+    if showsOverlay { isLoading = true }
     actionTask = Task { @MainActor in
-      defer { isLoading = false }
+      defer { if showsOverlay { isLoading = false } }
       do {
-        try await viewModel.handleStartOIDC()
+        try await viewModel.handleStartAlternativeSignIn()
         try Task.checkCancellation()
       } catch let error as URLError where error.code == .cancelled {
         // Same abort, different spelling. A cancelled `URLSession` task surfaces as
@@ -251,22 +269,6 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
         return
       } catch is CancellationError {
         return
-      } catch {
-        self.error = error
-      }
-    }
-  }
-
-  /// Starts the Quick Connect flow. Failures during the flow surface inside the sheet via the
-  /// view model's `quickConnectStatus`; this handler only catches the synchronous setup error.
-  /// No loading overlay — the sheet provides its own progress UI.
-  func onStartQuickConnect() {
-    // Routed through `actionTask` like every sibling handler — the property's own doc comment already
-    // names Quick-Connect-start as one of the flows it tracks.
-    actionTask?.cancel()
-    actionTask = Task { @MainActor in
-      do {
-        try await viewModel.handleStartQuickConnect()
       } catch {
         self.error = error
       }
@@ -316,7 +318,7 @@ private struct IntegrationOIDCSectionView: View {
   /// multi-second token exchange, and a second tap cancels the first attempt's task — surfacing an
   /// error alert on top of the flow the user just started.
   var isBusy: Bool
-  /// Tapped to begin the flow. The caller drives `viewModel.handleStartOIDC()` so loading-state
+  /// Tapped to begin the flow. The caller drives `handleStartAlternativeSignIn()` so loading-state
   /// plumbing stays in the host view.
   var onStart: () -> Void
 

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationQuickConnectViews.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationQuickConnectViews.swift
@@ -15,10 +15,10 @@ import UIKit
 /// In-form section that lets the user start a Quick Connect flow as an alternative to
 /// entering a username and password. Shown only in the `.foundServer` state of the shared
 /// `IntegrationConnectionView` for integrations whose view model opts in via
-/// `quickConnectSupported = true`.
+/// `alternativeSignIn == .quickConnect`.
 struct IntegrationQuickConnectSectionView: View {
   /// Tapped when the user wants to begin the flow. The caller drives the actual
-  /// `viewModel.handleStartQuickConnect()` call so loading-state plumbing stays in one place.
+  /// `viewModel.handleStartAlternativeSignIn()` call so loading-state plumbing stays in one place.
   var onStart: () -> Void
 
   @EnvironmentObject var theme: ThemeViewModel

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
@@ -151,6 +151,10 @@ struct IntegrationServerAddress: Equatable, Sendable {
     if URLComponents(string: "https://h" + path)?.percentEncodedPath == path {
       return path
     }
-    return path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+    // `?? ""`, not `?? path`: everything this function returns reaches the `percentEncodedPath`
+    // setter, which preconditions on valid encoding — an unvalidated fallback is a crash surface.
+    // `addingPercentEncoding` failing is practically unreachable for a Swift string, and if it ever
+    // happens, assembling without the subpath beats trapping the app over one.
+    return path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
   }
 }

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
@@ -38,6 +38,10 @@ struct IntegrationServerAddress: Equatable, Sendable {
   /// Normalized subpath: either empty or leading-slash with no trailing slash (`"/audiobookshelf"`).
   /// AudiobookShelf behind a reverse proxy on a subpath is common enough that dropping this would
   /// strand those installs.
+  ///
+  /// Stored **percent-encoded**. Reading the decoded `URLComponents.path` and re-encoding it cannot
+  /// tell an encoded slash from a segment separator, so `/a%2Fb` would silently round-trip to
+  /// `/a/b` — a different URL. Keeping the encoded bytes end-to-end makes parse → assemble faithful.
   var path: String
 
   /// Nil means "not specified" — never a default filled in on the user's behalf.
@@ -81,7 +85,10 @@ struct IntegrationServerAddress: Equatable, Sendable {
 
     self.scheme = scheme
     self.host = host
-    self.path = Self.normalizedPath(components.path)
+    // The *encoded* path, byte-for-byte. (The host, by contrast, is whatever `URLComponents` returns:
+    // the parser normalizes Unicode hosts to punycode, which is semantically identical under IDNA and
+    // matches what any fresh sign-in stores anyway.)
+    self.path = Self.normalizedPath(components.percentEncodedPath)
   }
 
   // MARK: - Assembly
@@ -96,7 +103,8 @@ struct IntegrationServerAddress: Equatable, Sendable {
     components.scheme = scheme.rawValue
     components.host = host
     components.port = port
-    components.path = path
+    // `path` is always valid percent-encoding — `normalizedPath` guarantees it — so this cannot trap.
+    components.percentEncodedPath = path
     return components.url
   }
 
@@ -131,11 +139,18 @@ struct IntegrationServerAddress: Equatable, Sendable {
   }
 
   /// Empty stays empty; anything else gains a leading slash and loses trailing ones, so
-  /// `"abs/"`, `"/abs"`, and `"/abs///"` all normalize to `"/abs"`.
+  /// `"abs/"`, `"/abs"`, and `"/abs///"` all normalize to `"/abs"`. The result is always valid
+  /// percent-encoding: input that already is (a parsed URL, a pasted `/audio%20books`) passes through
+  /// byte-for-byte; raw typed text that isn't (`/audio books`) gets encoded once. The distinction is
+  /// checked by re-parsing, not guessed at — guessing is how double-encoding bugs happen.
   private static func normalizedPath(_ raw: String) -> String {
     var path = raw
     while path.hasSuffix("/") { path.removeLast() }
     guard !path.isEmpty else { return "" }
-    return path.hasPrefix("/") ? path : "/" + path
+    if !path.hasPrefix("/") { path = "/" + path }
+    if URLComponents(string: "https://h" + path)?.percentEncodedPath == path {
+      return path
+    }
+    return path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
   }
 }

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
@@ -1,0 +1,141 @@
+//
+//  IntegrationServerAddress.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 8/8/26.
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+
+/// A media-server address as the connection form edits it: an explicit scheme choice, a host that may
+/// carry a reverse-proxy subpath, and an optional port.
+///
+/// This is a *form-level* model. Persistence is untouched — `JellyfinConnectionData` /
+/// `AudiobookShelfConnectionData` keep storing a single `URL`, and this type only parses that URL into
+/// editable fields and assembles the fields back. Changing the stored shape would sign users out;
+/// deriving instead is the same trick `IntegrationConnectionPayload.token` uses.
+///
+/// Two rules from the connection-screen design are load-bearing here:
+/// - **The URL is assembled strictly from typed input.** An empty port produces no port at all — the
+///   scheme's own default applies, exactly as in a browser. Nothing is substituted from a placeholder.
+/// - **Only `http` and `https` exist.** `init(parsing:)` rejects everything else, so a stored or pasted
+///   `javascript:`/`file:` address can never round-trip into a connectable value.
+struct IntegrationServerAddress: Equatable, Sendable {
+  enum Scheme: String, CaseIterable, Equatable, Sendable {
+    case http
+    case https
+  }
+
+  var scheme: Scheme
+
+  /// Hostname or IP literal, without port or path. IPv6 literals are stored *with* their brackets
+  /// (`"[::1]"`) — that is the form `URLComponents` both produces on parse and requires for assembly
+  /// on this Foundation, and it is how users type them anyway. May be empty while the user is typing;
+  /// `url` returns nil until it isn't.
+  var host: String
+
+  /// Normalized subpath: either empty or leading-slash with no trailing slash (`"/audiobookshelf"`).
+  /// AudiobookShelf behind a reverse proxy on a subpath is common enough that dropping this would
+  /// strand those installs.
+  var path: String
+
+  /// Nil means "not specified" — never a default filled in on the user's behalf.
+  var port: Int?
+
+  init(scheme: Scheme, host: String, path: String = "", port: Int? = nil) {
+    self.scheme = scheme
+    self.host = Self.normalizedHost(host)
+    self.path = Self.normalizedPath(path)
+    self.port = port
+  }
+
+  // MARK: - Parsing
+
+  /// Decomposes a full URL string — a stored connection URL, or a paste from a browser.
+  ///
+  /// Accepts only what the connection flow can use: an explicit `http`/`https` scheme and a host.
+  /// Userinfo, query, and fragment components mean the string is not a server base URL, so they are
+  /// rejected rather than silently dropped — a paste that loses pieces without saying so would
+  /// misconnect quietly.
+  init?(parsing string: String) {
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      let components = URLComponents(string: trimmed),
+      let rawScheme = components.scheme,
+      let scheme = Scheme(rawValue: rawScheme.lowercased()),
+      let host = components.host,
+      !host.isEmpty,
+      components.user == nil,
+      components.password == nil,
+      components.query == nil,
+      components.fragment == nil
+    else { return nil }
+
+    if let port = components.port {
+      guard (1...65535).contains(port) else { return nil }
+      self.port = port
+    } else {
+      self.port = nil
+    }
+
+    self.scheme = scheme
+    self.host = host
+    self.path = Self.normalizedPath(components.path)
+  }
+
+  // MARK: - Assembly
+
+  /// The address as a connectable URL, built strictly from the fields. Nil while the host is empty.
+  ///
+  /// Assembled through `URLComponents` rather than string concatenation so IPv6 literals get their
+  /// brackets back and a path that needs percent-encoding gets it.
+  var url: URL? {
+    guard !host.isEmpty else { return nil }
+    var components = URLComponents()
+    components.scheme = scheme.rawValue
+    components.host = host
+    components.port = port
+    components.path = path
+    return components.url
+  }
+
+  var urlString: String? { url?.absoluteString }
+
+  // MARK: - The combined host field
+
+  /// The host and subpath as one editable string — the design's screen 1 has a single Host row and the
+  /// subpath rides in it (`media.example.com/audiobookshelf`). The setter splits at the first slash;
+  /// IPv6 brackets are safe because they cannot contain one.
+  var hostField: String {
+    get { host + path }
+    set {
+      if let slash = newValue.firstIndex(of: "/") {
+        host = Self.normalizedHost(String(newValue[..<slash]))
+        path = Self.normalizedPath(String(newValue[slash...]))
+      } else {
+        host = Self.normalizedHost(newValue)
+        path = ""
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// A bare IPv6 literal gains its brackets: `URLComponents` refuses to assemble a host containing
+  /// a colon without them, so a bare `"::1"` would make `url` silently nil. No other legitimate host
+  /// contains a colon — ports live in their own field — so the wrap cannot misfire.
+  private static func normalizedHost(_ raw: String) -> String {
+    guard raw.contains(":"), !raw.hasPrefix("[") else { return raw }
+    return "[" + raw + "]"
+  }
+
+  /// Empty stays empty; anything else gains a leading slash and loses trailing ones, so
+  /// `"abs/"`, `"/abs"`, and `"/abs///"` all normalize to `"/abs"`.
+  private static func normalizedPath(_ raw: String) -> String {
+    var path = raw
+    while path.hasSuffix("/") { path.removeLast() }
+    guard !path.isEmpty else { return "" }
+    return path.hasPrefix("/") ? path : "/" + path
+  }
+}

--- a/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
+++ b/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
@@ -35,6 +35,38 @@ struct IntegrationServerInfo: Identifiable {
   let userName: String
 }
 
+/// What the alternative-sign-in slot on the credentials step renders, when the validated server
+/// offers a way in besides typing a password.
+///
+/// One value instead of parallel `oidcSupported`/`quickConnectSupported` booleans: the slot shows at
+/// most one thing, and a single optional makes the invalid "both at once" state unrepresentable. The
+/// upcoming method-choice screen consumes exactly this value to decide which buttons exist.
+enum AlternativeSignInState: Equatable {
+  /// Native SSO through the server's identity provider (AudiobookShelf OIDC). The associated text is
+  /// the provider's own button label when the server supplied one; nil falls back to a generic string.
+  case oidc(buttonText: String?)
+
+  /// The server advertises SSO but the connection is plaintext, so we refuse to run it — the
+  /// authorization code, PKCE verifier, and returned token all traverse the redirect chain
+  /// (RFC 6749 §10.9). Rendered as an explanation, not a button, so the absence isn't silent.
+  case oidcRequiresSecureTransport
+
+  /// Out-of-band code flow (Jellyfin Quick Connect).
+  case quickConnect
+
+  /// Whether the state offers something the user can actually start. Drives the username-field
+  /// autofocus: an explanation-only state must not suppress the keyboard the way a real
+  /// alternative does.
+  var isActionable: Bool {
+    switch self {
+    case .oidc, .quickConnect:
+      return true
+    case .oidcRequiresSecureTransport:
+      return false
+    }
+  }
+}
+
 /// Status of an out-of-band code-based authentication flow (Jellyfin Quick Connect).
 ///
 /// The device asks the server for a short user-facing code, then polls until the user enters
@@ -110,52 +142,32 @@ protocol IntegrationConnectionViewModelProtocol: ObservableObject {
   /// needs `/status`). Without that, an SSO-only user with no password has no way back in.
   func prepareReauth()
 
-  // MARK: - Alternative sign-in methods
-  //
-  // Two independent, mutually exclusive in practice: AudiobookShelf opts into OIDC, Jellyfin into
-  // Quick Connect, and each leaves the other at its default. The shared view renders whichever the
-  // concrete view model advertises.
+  // MARK: - Alternative sign-in
 
-  /// Whether SSO can actually be used with the server the user just validated — not merely whether
-  /// the integration speaks it. Default: `false`; concrete VMs opt in (AudiobookShelf).
-  var oidcSupported: Bool { get }
+  /// What the alternative-sign-in slot offers for the server the user just validated — not merely
+  /// what the integration speaks. Nil when password is the only way in. Default: nil; concrete VMs
+  /// opt in (AudiobookShelf → `.oidc`/`.oidcRequiresSecureTransport`, Jellyfin → `.quickConnect`).
+  var alternativeSignIn: AlternativeSignInState? { get }
 
-  /// The provider's own button label, when the server supplied one. Falls back to a generic string.
-  var oidcButtonText: String? { get }
-
-  /// Set when the server advertises SSO but we refuse it because the connection is plaintext, so the
-  /// UI can explain the absence rather than silently hiding an option the user may be expecting.
-  var oidcBlockedByInsecureTransport: Bool { get }
-
-  /// Begin the native SSO flow. Throws on setup failure; user cancellation surfaces as
-  /// `CancellationError` so the host view can stay quiet.
-  func handleStartOIDC() async throws
-
-  /// Whether this integration supports an out-of-band code-based sign-in flow
-  /// (Jellyfin's Quick Connect). Default: `false` — concrete VMs opt in.
-  var quickConnectSupported: Bool { get }
-
-  /// Current state of an in-flight Quick Connect flow, or `nil` if none is running.
+  /// Current state of an in-flight Quick Connect flow, or `nil` if none is running. Stays a separate
+  /// member rather than riding in `alternativeSignIn`: it is render state for the Quick Connect
+  /// sheet, mutating several times per flow, while `alternativeSignIn` is availability that holds
+  /// still once Connect has probed the server.
   var quickConnectStatus: QuickConnectStatus? { get }
 
-  /// Begin the Quick Connect flow. Throws if the underlying api-client cannot be reached.
-  func handleStartQuickConnect() async throws
+  /// Begin whichever flow `alternativeSignIn` advertises. Throws on setup failure; user cancellation
+  /// surfaces as `CancellationError` so the host view can stay quiet.
+  func handleStartAlternativeSignIn() async throws
 
-  /// Cancel an in-flight Quick Connect flow, dismiss any failure status, and free the
-  /// underlying poller. Safe to call when no flow is running.
-  func handleCancelQuickConnect()
+  /// Cancel an in-flight alternative sign-in, dismiss any failure status, and free any underlying
+  /// poller. Safe to call when no flow is running.
+  func handleCancelAlternativeSignIn()
 }
 
-/// No-op defaults for both alternative sign-in methods, so an integration only has to implement the
-/// one it actually speaks.
+/// No-op defaults, so an integration without an alternative sign-in implements none of it.
 extension IntegrationConnectionViewModelProtocol {
-  var oidcSupported: Bool { false }
-  var oidcButtonText: String? { nil }
-  var oidcBlockedByInsecureTransport: Bool { false }
-  func handleStartOIDC() async throws {}
-
-  var quickConnectSupported: Bool { false }
+  var alternativeSignIn: AlternativeSignInState? { nil }
   var quickConnectStatus: QuickConnectStatus? { nil }
-  func handleStartQuickConnect() async throws {}
-  func handleCancelQuickConnect() {}
+  func handleStartAlternativeSignIn() async throws {}
+  func handleCancelAlternativeSignIn() {}
 }

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -69,7 +69,7 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
 
     webAuth.code = "the-code"
     http.exchangePayload = Data(#"{"user":{"token":"t","id":"u1","username":"gianni"}}"#.utf8)
-    try await viewModel.handleStartOIDC()
+    try await viewModel.handleStartAlternativeSignIn()
 
     // Sign-in itself must persist them.
     XCTAssertEqual(try persistedHeaders(), ["CF-Access-Client-Id": "abc123"])
@@ -174,7 +174,7 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
 
     // Straight into the credentials step, SSO is not on offer: capabilities and the validated URL are
     // only established by Connect. An SSO-only user with no password would be stranded here.
-    XCTAssertFalse(viewModel.oidcSupported)
+    XCTAssertNil(viewModel.alternativeSignIn)
 
     viewModel.prepareReauth()
     http.statusPayload = Data(#"{"authMethods":["local","openid"]}"#.utf8)
@@ -182,7 +182,11 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     try await viewModel.handleConnectAction()
 
     XCTAssertEqual(viewModel.signInFlow, .enteringCredentials)
-    XCTAssertTrue(viewModel.oidcSupported, "SSO must be offered again when re-authenticating")
+    XCTAssertEqual(
+      viewModel.alternativeSignIn,
+      .oidc(buttonText: nil),
+      "SSO must be offered again when re-authenticating"
+    )
   }
 
   func testSSOStaysHiddenOverPlaintextEvenWhenTheServerSupportsIt() async throws {
@@ -193,8 +197,53 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     http.pingPayload = Data(#"{"success":true}"#.utf8)
     try await viewModel.handleConnectAction()
 
-    XCTAssertFalse(viewModel.oidcSupported)
-    XCTAssertTrue(viewModel.oidcBlockedByInsecureTransport, "the UI should explain the absence")
+    XCTAssertEqual(
+      viewModel.alternativeSignIn,
+      .oidcRequiresSecureTransport,
+      "the UI should explain the absence rather than silently hiding SSO"
+    )
+    XCTAssertFalse(
+      viewModel.alternativeSignIn?.isActionable ?? true,
+      "an explanation is not an offer — username autofocus must behave as if no alternative exists"
+    )
+  }
+
+  // MARK: - Capability probe
+
+  /// The case the probe used to miss entirely: an admin who disabled local auth. `authMethods` then
+  /// omits "local", and offering a password form anyway strands the user on a form that cannot work.
+  func testCapabilityProbeDetectsAnSSOOnlyServer() async {
+    http.statusPayload = Data(#"{"authMethods":["openid"]}"#.utf8)
+
+    let capabilities = await service.fetchCapabilities(at: serverURL)
+
+    XCTAssertTrue(capabilities.supportsOIDC)
+    XCTAssertFalse(capabilities.supportsLocal)
+  }
+
+  /// A server that predates `authMethods` (or answers something unrecognisable) must keep its
+  /// password form — hiding the only sign-in path a server may have is the unsafe direction.
+  func testCapabilityProbeFailsSafeTowardLocalAuth() async {
+    for payload in ["{}", #"{"authMethods":[]}"#, "not json at all"] {
+      http.statusPayload = Data(payload.utf8)
+
+      let capabilities = await service.fetchCapabilities(at: serverURL)
+
+      XCTAssertFalse(capabilities.supportsOIDC, "payload: \(payload)")
+      XCTAssertTrue(capabilities.supportsLocal, "payload: \(payload)")
+    }
+  }
+
+  func testCapabilityProbeReadsBothMethodsAndTheProviderLabel() async {
+    http.statusPayload = Data(
+      #"{"authMethods":["local","openid"],"authFormData":{"authOpenIDButtonText":"Login with Pocket ID"}}"#.utf8
+    )
+
+    let capabilities = await service.fetchCapabilities(at: serverURL)
+
+    XCTAssertTrue(capabilities.supportsLocal)
+    XCTAssertTrue(capabilities.supportsOIDC)
+    XCTAssertEqual(capabilities.oidcButtonText, "Login with Pocket ID")
   }
 }
 

--- a/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
@@ -1,0 +1,166 @@
+//
+//  IntegrationServerAddressTests.swift
+//  BookPlayerTests
+//
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+@testable import BookPlayer
+import XCTest
+
+/// The address model is the ground the new connection flow stands on: parsing prefills the form from a
+/// stored URL, assembly builds the URL the client actually connects to. A quiet mistake in either
+/// direction misconnects without an error, so both directions are pinned here.
+final class IntegrationServerAddressTests: XCTestCase {
+  // MARK: - Parsing
+
+  func testParsesADirectAddress() {
+    let address = IntegrationServerAddress(parsing: "https://ds224plus.example.ts.net")
+
+    XCTAssertEqual(address?.scheme, .https)
+    XCTAssertEqual(address?.host, "ds224plus.example.ts.net")
+    XCTAssertEqual(address?.path, "")
+    XCTAssertNil(address?.port)
+  }
+
+  func testParsesHostPortAndUppercaseScheme() {
+    let address = IntegrationServerAddress(parsing: "HTTP://192.168.1.5:8096")
+
+    XCTAssertEqual(address?.scheme, .http)
+    XCTAssertEqual(address?.host, "192.168.1.5")
+    XCTAssertEqual(address?.port, 8096)
+  }
+
+  /// The reverse-proxy case: the subpath must survive, or those installs cannot be represented.
+  func testParsesAReverseProxySubpath() {
+    let address = IntegrationServerAddress(parsing: "https://media.example.com/audiobookshelf")
+
+    XCTAssertEqual(address?.host, "media.example.com")
+    XCTAssertEqual(address?.path, "/audiobookshelf")
+    XCTAssertEqual(address?.hostField, "media.example.com/audiobookshelf")
+  }
+
+  func testTrailingSlashesNormalizeAway() {
+    XCTAssertEqual(IntegrationServerAddress(parsing: "https://example.com/")?.path, "")
+    XCTAssertEqual(IntegrationServerAddress(parsing: "https://example.com/abs///")?.path, "/abs")
+  }
+
+  func testWhitespaceAroundAPasteIsTrimmed() {
+    let address = IntegrationServerAddress(parsing: "  https://example.com:5006 \n")
+
+    XCTAssertEqual(address?.host, "example.com")
+    XCTAssertEqual(address?.port, 5006)
+  }
+
+  /// Only http/https can reach a media server; anything else parsing "successfully" would let a stored
+  /// or pasted `javascript:`/`file:` string round-trip into a connectable — and linkifiable — value.
+  func testRejectsNonWebSchemes() {
+    for bad in ["ftp://example.com", "javascript:alert(1)", "file:///etc/hosts", "ws://example.com"] {
+      XCTAssertNil(IntegrationServerAddress(parsing: bad), "should reject: \(bad)")
+    }
+  }
+
+  /// A server *base* URL has no userinfo, query, or fragment. Dropping them silently would connect
+  /// somewhere other than what the user pasted, so the parse refuses instead.
+  func testRejectsComponentsABaseURLCannotCarry() {
+    for bad in [
+      "https://user:pass@example.com",
+      "https://example.com?redirect=1",
+      "https://example.com/abs#section",
+    ] {
+      XCTAssertNil(IntegrationServerAddress(parsing: bad), "should reject: \(bad)")
+    }
+  }
+
+  func testRejectsSchemelessEmptyAndOutOfRangePorts() {
+    XCTAssertNil(IntegrationServerAddress(parsing: "example.com:8096"))
+    XCTAssertNil(IntegrationServerAddress(parsing: ""))
+    XCTAssertNil(IntegrationServerAddress(parsing: "https://"))
+    XCTAssertNil(IntegrationServerAddress(parsing: "http://example.com:0"))
+    XCTAssertNil(IntegrationServerAddress(parsing: "http://example.com:70000"))
+  }
+
+  // MARK: - Assembly
+
+  /// The rule the whole port UX hangs on: the placeholder is an example, never a substitute. Empty
+  /// port → no port in the URL.
+  func testEmptyPortProducesNoPort() {
+    let address = IntegrationServerAddress(scheme: .https, host: "media.example.com", path: "/audiobookshelf")
+
+    XCTAssertEqual(address.urlString, "https://media.example.com/audiobookshelf")
+  }
+
+  func testTypedPortIsIncludedVerbatim() {
+    let address = IntegrationServerAddress(scheme: .http, host: "100.81.227.12", port: 13378)
+
+    XCTAssertEqual(address.urlString, "http://100.81.227.12:13378")
+  }
+
+  /// A typed port equal to the scheme default still appears — assembly is strict, not canonicalizing.
+  func testSchemeDefaultPortIsNotStripped() {
+    let address = IntegrationServerAddress(scheme: .https, host: "example.com", port: 443)
+
+    XCTAssertEqual(address.urlString, "https://example.com:443")
+  }
+
+  func testEmptyHostAssemblesToNil() {
+    XCTAssertNil(IntegrationServerAddress(scheme: .https, host: "").url)
+  }
+
+  // MARK: - Round trips
+
+  /// parse → assemble must reproduce a canonical input byte-for-byte: this pair prefills the form from
+  /// the stored URL and then rebuilds it, and any drift here rewrites connections nobody touched.
+  func testCanonicalRoundTrips() {
+    for original in [
+      "https://ds224plus.example.ts.net:8096",
+      "http://192.168.1.5:13378",
+      "https://media.example.com/audiobookshelf",
+      "https://media.example.com:8443/abs",
+      "http://jellyfin.local",
+    ] {
+      XCTAssertEqual(IntegrationServerAddress(parsing: original)?.urlString, original)
+    }
+  }
+
+  /// `URLComponents.host` keeps IPv6 brackets on this Foundation, and assembly *requires* them — a
+  /// bare `::1` host assembles to nil. The model stores the bracketed form and normalizes a bare
+  /// literal on the way in, so neither construction path can produce a silently-nil URL.
+  func testIPv6LiteralRoundTripsWithBrackets() {
+    let address = IntegrationServerAddress(parsing: "http://[::1]:8096")
+
+    XCTAssertEqual(address?.host, "[::1]")
+    XCTAssertEqual(address?.port, 8096)
+    XCTAssertEqual(address?.urlString, "http://[::1]:8096")
+  }
+
+  func testBareIPv6LiteralGainsItsBrackets() {
+    let direct = IntegrationServerAddress(scheme: .http, host: "::1", port: 8096)
+    XCTAssertEqual(direct.urlString, "http://[::1]:8096")
+
+    var viaField = IntegrationServerAddress(scheme: .http, host: "")
+    viaField.hostField = "2001:db8::1/jellyfin"
+    XCTAssertEqual(viaField.host, "[2001:db8::1]")
+    XCTAssertEqual(viaField.path, "/jellyfin")
+  }
+
+  // MARK: - The combined host field
+
+  func testHostFieldSetterSplitsAtTheFirstSlash() {
+    var address = IntegrationServerAddress(scheme: .https, host: "old.example.com")
+
+    address.hostField = "media.example.com/audiobookshelf/"
+
+    XCTAssertEqual(address.host, "media.example.com")
+    XCTAssertEqual(address.path, "/audiobookshelf")
+  }
+
+  func testHostFieldSetterClearsAStalePath() {
+    var address = IntegrationServerAddress(scheme: .https, host: "media.example.com", path: "/abs")
+
+    address.hostField = "direct.example.com"
+
+    XCTAssertEqual(address.host, "direct.example.com")
+    XCTAssertEqual(address.path, "")
+  }
+}

--- a/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
@@ -126,6 +126,26 @@ final class IntegrationServerAddressTests: XCTestCase {
   /// `URLComponents.host` keeps IPv6 brackets on this Foundation, and assembly *requires* them — a
   /// bare `::1` host assembles to nil. The model stores the bracketed form and normalizes a bare
   /// literal on the way in, so neither construction path can produce a silently-nil URL.
+  /// The case a decoded-path implementation gets wrong: `%2F` inside a segment is indistinguishable
+  /// from a separator once decoded, so parse → assemble would rewrite the URL. Found by probing, not
+  /// by review — keep this pinned.
+  func testEncodedSlashInAPathSegmentRoundTrips() {
+    let address = IntegrationServerAddress(parsing: "https://media.example.com/a%2Fb")
+
+    XCTAssertEqual(address?.path, "/a%2Fb")
+    XCTAssertEqual(address?.urlString, "https://media.example.com/a%2Fb")
+  }
+
+  func testEncodedSpaceRoundTripsAndRawTypedSpaceEncodesOnce() {
+    let parsed = IntegrationServerAddress(parsing: "https://x.example/audio%20books")
+    XCTAssertEqual(parsed?.urlString, "https://x.example/audio%20books")
+
+    var typed = IntegrationServerAddress(scheme: .https, host: "")
+    typed.hostField = "x.example/audio books"
+    XCTAssertEqual(typed.path, "/audio%20books", "raw typed text encodes exactly once — no double-encoding")
+    XCTAssertEqual(typed.urlString, "https://x.example/audio%20books")
+  }
+
   func testIPv6LiteralRoundTripsWithBrackets() {
     let address = IntegrationServerAddress(parsing: "http://[::1]:8096")
 

--- a/BookPlayerTests/MediaServerIntegration/JellyfinQuickConnectTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/JellyfinQuickConnectTests.swift
@@ -115,10 +115,10 @@ final class JellyfinQuickConnectTests: XCTestCase {
     viewModel.handleQuickConnectStateChange(.authenticated(secret: "s3cr3t"))
     XCTAssertEqual(viewModel.quickConnectStatus, .authenticating)
 
-    // Captured before cancelling: `handleCancelQuickConnect` nils the handle, so reading it afterwards
-    // awaits nothing and the assertions race ahead of the task body.
+    // Captured before cancelling: `handleCancelAlternativeSignIn` nils the handle, so reading it
+    // afterwards awaits nothing and the assertions race ahead of the task body.
     let task = viewModel.quickConnectSignInTask
-    viewModel.handleCancelQuickConnect()
+    viewModel.handleCancelAlternativeSignIn()
     await task?.value
 
     XCTAssertNil(
@@ -136,7 +136,7 @@ final class JellyfinQuickConnectTests: XCTestCase {
     viewModel.handleQuickConnectStateChange(.authenticated(secret: "s3cr3t"))
 
     let task = viewModel.quickConnectSignInTask
-    viewModel.handleCancelQuickConnect()
+    viewModel.handleCancelAlternativeSignIn()
     await task?.value
 
     if case .failed(let message) = viewModel.quickConnectStatus {


### PR DESCRIPTION
Non-UI groundwork for reworking the add-server flow into pushed onboarding screens (design discussed separately). **No visible behavior change** — every screen renders and behaves exactly as on develop.

### What's in here

**`IntegrationServerAddress`** — a form-level model for server addresses: explicit `http`/`https` scheme, host (carrying any reverse-proxy subpath), optional port. Parsing decomposes a stored or pasted URL into fields; assembly builds the URL back strictly from typed input (empty port → no port; only http/https parse at all, so `javascript:`/`file:` strings can't round-trip into connectable values). The path stays percent-encoded end to end — reading the decoded path and re-encoding rewrites `/a%2Fb` into `/a/b`. Persistence untouched: connections keep storing a single `URL`.

**`AlternativeSignInState`** — collapses the 8 alternative-sign-in protocol members (`oidcSupported`, `oidcButtonText`, `oidcBlockedByInsecureTransport`, `handleStartOIDC`, `quickConnectSupported`, `quickConnectStatus`, `handleStartQuickConnect`, `handleCancelQuickConnect`) into one optional enum plus start/cancel handlers, making the invalid "both methods at once" state unrepresentable. This is the value the upcoming method-choice screen consumes. One subtlety preserved and now pinned by a test: the blocked-insecure state must keep auto-focusing the username field — an explanation is not an offer.

**`supportsLocal`** — the `/status` probe read `authMethods` for `"openid"` but never `"local"`, so an SSO-only ABS server (local auth disabled — a normal configuration) was indistinguishable from one that takes passwords. Detected now, consumed by the follow-up flow PR; defaults to `true` on every probe-failure path since hiding a server's only sign-in method is the unsafe direction.

### Tests

22 new (17 address model, 3 capability probe, 2 round-trip fidelity), 472 total green.