### PR TITLE
Rework the add-server flow into pushed onboarding screens

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		232F1DA50BB33EB5A629B8B7 /* PlayableChapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689E2BCD29DC1D9253949A53 /* PlayableChapterTests.swift */; };
 		2B283D695990DA665D1661CC /* mp3_NO_chapters.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 12EDB8401F38342155CBBC91 /* mp3_NO_chapters.mp3 */; };
 		2D7D5973F598D517CBCCE0ED /* PreferencesSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D25EF2A5FFF30CF12F2C21 /* PreferencesSyncService.swift */; };
+		39313742614BCCA918DA7C0E /* IntegrationConnectionFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA0C0229963991F8CE1E941 /* IntegrationConnectionFlowView.swift */; };
 		3F66408A2E162ABF00356522 /* AudioMetadataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6640892E162ABF00356522 /* AudioMetadataService.swift */; };
 		3F66408B2E162ABF00356522 /* AudioMetadataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6640892E162ABF00356522 /* AudioMetadataService.swift */; };
 		3F66408D2E172DF500356522 /* MappingModel_v9_to_v10.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 3F66408C2E172DF500356522 /* MappingModel_v9_to_v10.xcmappingmodel */; };
@@ -1660,6 +1661,7 @@
 		8AF18A3A2CF0E92800238F8D /* KeychainServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceMock.swift; sourceTree = "<group>"; };
 		8B8DAE18EF12485AD3509B2D /* JellyfinQuickConnectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JellyfinQuickConnectTests.swift; sourceTree = "<group>"; };
 		8D3EFD93E6D1E0366A3FD1E9 /* mp3_WITH_toc.mp3 */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = audio.mp3; path = mp3_WITH_toc.mp3; sourceTree = "<group>"; };
+		8DA0C0229963991F8CE1E941 /* IntegrationConnectionFlowView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationConnectionFlowView.swift; sourceTree = "<group>"; };
 		8FBF775DDE66D0AA08818D45 /* LibraryOptionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryOptionsView.swift; sourceTree = "<group>"; };
 		99329DB62F3AA8F6003F8E73 /* PlayControlsRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayControlsRowView.swift; sourceTree = "<group>"; };
 		99329DBA2F3AAA61003F8E73 /* ListeningProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningProgressView.swift; sourceTree = "<group>"; };
@@ -1962,6 +1964,7 @@
 				A5F919ABFCEF9B58EFE9D82E /* IntegrationServerInformationSectionView.swift */,
 				6FB91B577BC77F45EDB2AAAA /* IntegrationConnectionFormViewModel.swift */,
 				B14881000000000000000002 /* IntegrationCustomHeadersSectionView.swift */,
+				8DA0C0229963991F8CE1E941 /* IntegrationConnectionFlowView.swift */,
 			);
 			path = "Connection Screen";
 			sourceTree = "<group>";
@@ -4943,6 +4946,7 @@
 				0235B7EE8FA51C49AFBBBE71 /* IntegrationConnectionPayload.swift in Sources */,
 				843575DDF1CEEBC9A2EF015C /* IntegrationConnectionStore.swift in Sources */,
 				6DF751D96098B1A3224FDF43 /* IntegrationServerAddress.swift in Sources */,
+				39313742614BCCA918DA7C0E /* IntegrationConnectionFlowView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
+++ b/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
@@ -174,24 +174,10 @@ struct AudiobookShelfRootView: View {
       message: { Text(loadError?.localizedDescription ?? "") }
     )
     .sheet(isPresented: $showConnectionForm) {
-      NavigationStack {
-        IntegrationConnectionView(viewModel: connectionViewModel, integrationName: "AudiobookShelf")
-          .toolbar {
-            // Outer X only when we're NOT in Add Server mode — IntegrationConnectionView's
-            // own Cancel button handles that case (and just dismisses the form sheet).
-            if !connectionViewModel.isAddingServer {
-              ToolbarItemGroup(placement: .cancellationAction) {
-                Button { dismiss() } label: {
-                  Image(systemName: "xmark")
-                    .foregroundStyle(theme.linkColor)
-                }
-              }
-            }
-          }
-          .navigationBarTitleDisplayMode(.inline)
-      }
-      .tint(theme.linkColor)
-      .environmentObject(theme)
+      // The flow owns its NavigationStack and its own cancel affordances (Cancel for Add Server,
+      // an X otherwise) — no outer wrapping.
+      IntegrationConnectionFlowView(viewModel: connectionViewModel, integrationName: "AudiobookShelf")
+        .environmentObject(theme)
     }
     .sheet(isPresented: $showLibraryPicker) {
       libraryPickerSheet

--- a/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
+++ b/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
@@ -241,9 +241,16 @@ struct AudiobookShelfRootView: View {
             }
           }
         }
+        // The card fill every ThemedSection row gets; a bare List row renders the system fill,
+        // which is the one unthemed surface on this screen.
+        .listRowBackground(theme.tertiarySystemBackgroundColor)
       }
-      .scrollContentBackground(.hidden)
-      .background(theme.systemBackgroundColor)
+      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+      // Until a library is chosen there is nothing behind this sheet to land on — swiping it away
+      // would strand the user on an empty integration library. Cancel remains the way out, and it
+      // correctly backs out of the whole server. Once a library exists (reopening the picker to
+      // switch), swipe-to-dismiss behaves normally.
+      .interactiveDismissDisabled(resolvedLibrary == nil)
       .navigationTitle("library_title".localized)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
+++ b/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
@@ -176,7 +176,7 @@ struct AudiobookShelfRootView: View {
     .sheet(isPresented: $showConnectionForm) {
       // The flow owns its NavigationStack and its own cancel affordances (Cancel for Add Server,
       // an X otherwise) — no outer wrapping.
-      IntegrationConnectionFlowView(viewModel: connectionViewModel, integrationName: "AudiobookShelf")
+      IntegrationConnectionFlowView(viewModel: connectionViewModel, kind: .audiobookshelf, integrationName: "AudiobookShelf")
         .environmentObject(theme)
     }
     .sheet(isPresented: $showLibraryPicker) {

--- a/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
+++ b/BookPlayer/AudiobookShelf/AudiobookShelfRootView.swift
@@ -188,6 +188,11 @@ struct AudiobookShelfRootView: View {
         showLibraryPicker = true
       }
     }
+    .onChange(of: connectionService.connection?.id) { _, newValue in
+      // Same as JellyfinRootView: the active connection was deleted out from under this library;
+      // follow the deletion out instead of stranding a dead screen.
+      if newValue == nil { dismiss() }
+    }
     .onChange(of: connectionViewModel.signInCompletedAt) { _, newValue in
       guard newValue != nil else { return }
       showConnectionForm = false

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -133,6 +133,13 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
       at: normalizedURL,
       customHeaders: form.customHeadersDictionary()
     )
+    // A server that only offers SSO, reached over plaintext, has no usable sign-in method at all:
+    // we refuse SSO over http, and the password form cannot authenticate. Routing anywhere would be
+    // a silent dead-end — fail Connect instead, with the reason, while the user is still on the
+    // address screen where the https toggle that fixes it lives.
+    if !capabilities.supportsLocal, alternativeSignIn == nil, capabilities.supportsOIDC {
+      throw IntegrationError.insecureTransport
+    }
     signInFlow = .enteringCredentials
     flowPath = [stepAfterConnect]
     form.serverName = serverName

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -28,6 +28,11 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
 
   @Published var flowPath: [ConnectionFlowStep] = []
 
+  /// The connection a re-authentication started from, so a sign-in that lands on the same account at
+  /// an edited URL updates that row instead of orphaning it. Left in place after success on purpose:
+  /// the row it named was just replaced, so a stale value matches nothing.
+  private var reauthConnectionID: String?
+
   var supportsPasswordSignIn: Bool { capabilities.supportsLocal }
 
   /// SSO over plaintext is simply not offered — no explanatory state. The refusal reason (the
@@ -148,7 +153,8 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
         password: password,
         serverUrl: serverUrl,
         serverName: form.serverName,
-        customHeaders: form.customHeadersDictionary()
+        customHeaders: form.customHeadersDictionary(),
+        replacingID: reauthConnectionID
       )
 
       // Drop the captured URL only once the connection is persisted. Clearing it on every
@@ -186,6 +192,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     } ?? connectionService.connection
 
     if let data {
+      reauthConnectionID = data.id
       form.setValues(
         url: data.url.absoluteString,
         serverName: data.serverName,
@@ -313,7 +320,8 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     try await connectionService.signInWithOIDC(
       serverUrl: serverUrl,
       serverName: form.serverName,
-      customHeaders: form.customHeadersDictionary()
+      customHeaders: form.customHeadersDictionary(),
+      replacingID: reauthConnectionID
     )
     // Only drop the validated URL once sign-in succeeded.
     pingedURL = nil

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -26,6 +26,10 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
   /// cannot possibly work.
   @Published private(set) var capabilities = AudiobookShelfConnectionService.ServerCapabilities()
 
+  @Published var flowPath: [ConnectionFlowStep] = []
+
+  var supportsPasswordSignIn: Bool { capabilities.supportsLocal }
+
   /// SSO over plaintext is simply not offered — no explanatory state. The refusal reason (the
   /// authorization code, PKCE verifier, and returned token all traverse the redirect chain,
   /// RFC 6749 §10.9) lives in `isPingedURLSecure`'s doc; the scheme control on the address screen
@@ -125,6 +129,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
       customHeaders: form.customHeadersDictionary()
     )
     signInFlow = .enteringCredentials
+    flowPath = [stepAfterConnect]
     form.serverName = serverName
   }
 
@@ -165,6 +170,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
         )
       }
       signInFlow = nil
+      flowPath = []
       signInCompletedAt = Date()
     } catch let error as IntegrationError {
       throw error
@@ -191,6 +197,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     pingedURL = nil
     capabilities = .init()
     signInFlow = .enteringServerURL
+    flowPath = []
   }
 
   /// Normalize the user-typed server URL before we send a request:
@@ -234,6 +241,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     if connectionService.connections.isEmpty {
       form = IntegrationConnectionFormViewModel()
       signInFlow = .enteringServerURL
+      flowPath = []
     } else if let data = connectionService.connection {
       form.setValues(
         url: data.url.absoluteString,
@@ -259,12 +267,14 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
   func handleAddServerAction() {
     isAddingServer = true
     signInFlow = .enteringServerURL
+    flowPath = []
     form = IntegrationConnectionFormViewModel()
   }
 
   func handleCancelAddServerAction() {
     isAddingServer = false
     signInFlow = nil
+    flowPath = []
     // Drop any URL captured from a half-finished Connect → Sign In flow so a stale
     // value can't get reused by a later sign-in attempt.
     pingedURL = nil
@@ -318,6 +328,7 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
       )
     }
     signInFlow = nil
+    flowPath = []
     signInCompletedAt = Date()
   }
 }

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -26,11 +26,13 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
   /// cannot possibly work.
   @Published private(set) var capabilities = AudiobookShelfConnectionService.ServerCapabilities()
 
+  /// SSO over plaintext is simply not offered — no explanatory state. The refusal reason (the
+  /// authorization code, PKCE verifier, and returned token all traverse the redirect chain,
+  /// RFC 6749 §10.9) lives in `isPingedURLSecure`'s doc; the scheme control on the address screen
+  /// makes the `http` choice visible enough to act on.
   var alternativeSignIn: AlternativeSignInState? {
-    guard capabilities.supportsOIDC else { return nil }
-    return isPingedURLSecure
-      ? .oidc(buttonText: capabilities.oidcButtonText)
-      : .oidcRequiresSecureTransport
+    guard capabilities.supportsOIDC, isPingedURLSecure else { return nil }
+    return .oidc(buttonText: capabilities.oidcButtonText)
   }
 
   /// SSO is refused over plaintext: the authorization code, the PKCE verifier and the returned token

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -232,7 +232,10 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
       connectionService.deleteConnection()
     }
     form = IntegrationConnectionFormViewModel()
-    signInFlow = connectionService.connections.isEmpty ? .enteringServerURL : nil
+    // Signing out never redraws a sign-in form in place — the presenting details screen dismisses,
+    // and reconnecting happens through Add Server.
+    signInFlow = nil
+    flowPath = []
     if let data = connectionService.connection {
       form.setValues(
         url: data.url.absoluteString,
@@ -247,7 +250,8 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     connectionService.deleteConnection(id: id)
     if connectionService.connections.isEmpty {
       form = IntegrationConnectionFormViewModel()
-      signInFlow = .enteringServerURL
+      // Same rule as above: no in-place redraw; the presenter dismisses.
+      signInFlow = nil
       flowPath = []
     } else if let data = connectionService.connection {
       form.setValues(

--- a/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
+++ b/BookPlayer/AudiobookShelf/Connection Screen/AudiobookShelfConnectionViewModel.swift
@@ -300,15 +300,6 @@ final class AudiobookShelfConnectionViewModel: IntegrationConnectionViewModelPro
     }
   }
 
-  @MainActor
-  func handleCustomHeadersUpdate() {
-    let headers = form.customHeadersDictionary()
-    if let targetId = targetConnectionId {
-      connectionService.updateCustomHeaders(id: targetId, headers)
-    } else {
-      connectionService.updateCustomHeaders(headers)
-    }
-  }
 
   // MARK: - SSO (OpenID Connect)
 

--- a/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
+++ b/BookPlayer/AudiobookShelf/Network/AudiobookShelfConnectionService.swift
@@ -156,7 +156,8 @@ class AudiobookShelfConnectionService: BPLogger {
     password: String,
     serverUrl: String,
     serverName: String,
-    customHeaders: [String: String] = [:]
+    customHeaders: [String: String] = [:],
+    replacingID: String? = nil
   ) async throws {
     guard let url = URL(string: serverUrl) else {
       throw IntegrationError.urlMalformed(nil)
@@ -171,15 +172,14 @@ class AudiobookShelfConnectionService: BPLogger {
     let credentials = ["username": username, "password": password]
     request.httpBody = try JSONSerialization.data(withJSONObject: credentials)
 
-    let (data, response) = try await urlSession.data(for: request)
+    // Through the injected client, like the OIDC exchange — the one path that still used the
+    // service's private URLSession couldn't be exercised by tests at all, which is how the
+    // moved-server re-auth behavior went unpinned.
+    let (data, httpResponse) = try await httpClient.data(for: request)
     // Bail out before persisting if the caller cancelled while the auth round-trip was
     // in flight (e.g. the user swiped the sheet down). Otherwise the cancelled sign-in
     // still ends up saved.
     try Task.checkCancellation()
-
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw IntegrationError.unexpectedResponse(code: nil)
-    }
 
     guard (200...299).contains(httpResponse.statusCode) else {
       if httpResponse.statusCode == 401 {
@@ -203,7 +203,8 @@ class AudiobookShelfConnectionService: BPLogger {
       userID: userID,
       userName: username,
       apiToken: apiToken,
-      customHeaders: customHeaders
+      customHeaders: customHeaders,
+      replacingID: replacingID
     )
   }
 
@@ -220,9 +221,10 @@ class AudiobookShelfConnectionService: BPLogger {
     userID: String,
     userName: String,
     apiToken: String,
-    customHeaders: [String: String]
+    customHeaders: [String: String],
+    replacingID: String? = nil
   ) {
-    let result = store.upsert(url: url, userID: userID) { existing in
+    let result = store.upsert(url: url, userID: userID, replacingID: replacingID) { existing in
       AudiobookShelfConnectionData(
         id: existing?.id ?? UUID().uuidString,
         url: url,
@@ -251,7 +253,8 @@ class AudiobookShelfConnectionService: BPLogger {
   public func signInWithOIDC(
     serverUrl: String,
     serverName: String,
-    customHeaders: [String: String] = [:]
+    customHeaders: [String: String] = [:],
+    replacingID: String? = nil
   ) async throws {
     guard let baseURL = URL(string: serverUrl) else {
       throw IntegrationError.urlMalformed(nil)
@@ -279,7 +282,8 @@ class AudiobookShelfConnectionService: BPLogger {
       userID: credentials.userID,
       userName: credentials.userName,
       apiToken: credentials.apiToken,
-      customHeaders: customHeaders
+      customHeaders: customHeaders,
+      replacingID: replacingID
     )
   }
 

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sort Items by";
 "cancel_button" = "Cancel";
 "copy_button" = "Copy";
+"clear_text_button" = "Clear text";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Shortcuts are available on iOS 12 and above";

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -379,6 +379,12 @@ We're working hard on providing a seamless experience, if possible, please conta
 "integration_custom_headers_key_placeholder" = "Header name";
 "integration_custom_headers_value_placeholder" = "Header value";
 "integration_custom_headers_add_button" = "Add Header";
+"integration_address_scheme_label" = "Connection type";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Username & Password";
+"integration_headers_detail_footer" = "These headers are attached to every request sent to this server. They can be edited from the server address screen.";
 "settings_integration_manage_connection_title" = "Manage Connection";
 "integration_internal_error_invalid_url" = "Internal error: Request URL is invalid: %@";
 "integration_internal_error_build_url" = "Internal error: Failed to build request URL";

--- a/BookPlayer/Base.lproj/Localizable.strings
+++ b/BookPlayer/Base.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sort Items by";
 "cancel_button" = "Cancel";
 "copy_button" = "Copy";
-"clear_text_button" = "Clear text";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Shortcuts are available on iOS 12 and above";

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -37,6 +37,11 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
 
   @Published var flowPath: [ConnectionFlowStep] = []
 
+  /// The connection a re-authentication started from, so a sign-in that lands on the same account at
+  /// an edited URL updates that row instead of orphaning it. Left in place after success on purpose:
+  /// the row it named was just replaced, so a stale value matches nothing.
+  private var reauthConnectionID: String?
+
   /// Active Quick Connect controller, retained so its polling task isn't deallocated and so
   /// cancel/cleanup can call `stop()`. Nil when no flow is in progress.
   private var activeQuickConnect: JellyfinAPI.QuickConnect?
@@ -137,7 +142,8 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
         username: form.username,
         password: form.password,
         serverName: form.serverName,
-        customHeaders: form.customHeadersDictionary()
+        customHeaders: form.customHeadersDictionary(),
+        replacingID: reauthConnectionID
       )
 
       // Drop the transient `pending` only once the service has committed it as
@@ -263,6 +269,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     } ?? connectionService.connection
 
     if let data {
+      reauthConnectionID = data.id
       form.setValues(
         url: data.url.absoluteString,
         serverName: data.serverName,
@@ -375,7 +382,8 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
         pending: pending,
         secret: secret,
         serverName: form.serverName,
-        customHeaders: form.customHeadersDictionary()
+        customHeaders: form.customHeadersDictionary(),
+        replacingID: reauthConnectionID
       )
       // Only drop the transient pending handle once the service has committed it.
       pendingServer = nil

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -257,15 +257,6 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     }
   }
 
-  @MainActor
-  func handleCustomHeadersUpdate() {
-    let headers = form.customHeadersDictionary()
-    if let targetId = targetConnectionId {
-      connectionService.updateCustomHeaders(id: targetId, headers)
-    } else {
-      connectionService.updateCustomHeaders(headers)
-    }
-  }
 
   @MainActor
   func prepareReauth() {

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -189,7 +189,11 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
       connectionService.deleteConnection()
     }
     form = IntegrationConnectionFormViewModel()
-    signInFlow = connectionService.connections.isEmpty ? .enteringServerURL : nil
+    // Signing out never redraws a sign-in form in place — the presenting details screen dismisses,
+    // and reconnecting happens through Add Server. Redrawing left the details sheet showing the old
+    // URL form with two competing toolbars.
+    signInFlow = nil
+    flowPath = []
     if let data = connectionService.connection {
       form.setValues(
         url: data.url.absoluteString,
@@ -204,7 +208,8 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     connectionService.deleteConnection(id: id)
     if connectionService.connections.isEmpty {
       form = IntegrationConnectionFormViewModel()
-      signInFlow = .enteringServerURL
+      // Same rule as above: no in-place redraw; the presenter dismisses.
+      signInFlow = nil
       flowPath = []
     } else if let data = connectionService.connection {
       form.setValues(

--- a/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
+++ b/BookPlayer/Jellyfin/Connection Screen/JellyfinConnectionViewModel.swift
@@ -35,6 +35,8 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   /// `AudiobookShelfConnectionViewModel` derives its `alternativeSignIn` from `/status`.
   @Published private(set) var alternativeSignIn: AlternativeSignInState?
 
+  @Published var flowPath: [ConnectionFlowStep] = []
+
   /// Active Quick Connect controller, retained so its polling task isn't deallocated and so
   /// cancel/cleanup can call `stop()`. Nil when no flow is in progress.
   private var activeQuickConnect: JellyfinAPI.QuickConnect?
@@ -120,6 +122,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     // Set before `signInFlow` so the credentials step renders with the right affordances on first pass.
     alternativeSignIn = pending.quickConnectEnabled ? .quickConnect : nil
     signInFlow = .enteringCredentials
+    flowPath = [stepAfterConnect]
     form.serverName = pending.serverName
   }
 
@@ -156,6 +159,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
         )
       }
       signInFlow = nil
+      flowPath = []
       signInCompletedAt = Date()
     } catch APIError.unacceptableStatusCode(let statusCode) {
       switch statusCode {
@@ -195,6 +199,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     if connectionService.connections.isEmpty {
       form = IntegrationConnectionFormViewModel()
       signInFlow = .enteringServerURL
+      flowPath = []
     } else if let data = connectionService.connection {
       form.setValues(
         url: data.url.absoluteString,
@@ -220,12 +225,14 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
   func handleAddServerAction() {
     isAddingServer = true
     signInFlow = .enteringServerURL
+    flowPath = []
     form = IntegrationConnectionFormViewModel()
   }
 
   func handleCancelAddServerAction() {
     isAddingServer = false
     signInFlow = nil
+    flowPath = []
     // Drop any transient `pending` from a half-finished Connect → Sign In flow,
     // so a stale `JellyfinClient` can't get reused by a later sign-in attempt.
     pendingServer = nil
@@ -268,6 +275,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
     pendingServer = nil
     alternativeSignIn = nil
     signInFlow = .enteringServerURL
+    flowPath = []
   }
 
   // MARK: - Quick Connect
@@ -387,6 +395,7 @@ final class JellyfinConnectionViewModel: IntegrationConnectionViewModelProtocol,
         form.username = userName
       }
       signInFlow = nil
+      flowPath = []
       signInCompletedAt = Date()
       quickConnectStatus = nil
       teardownQuickConnect()

--- a/BookPlayer/Jellyfin/JellyfinRootView.swift
+++ b/BookPlayer/Jellyfin/JellyfinRootView.swift
@@ -146,6 +146,12 @@ struct JellyfinRootView: View {
         showLibraryPicker = true
       }
     }
+    .onChange(of: connectionService.connection?.id) { _, newValue in
+      // The active connection was deleted out from under this library — signing out from the
+      // details screen inside it, or from Media Servers. A library for a connection that no longer
+      // exists has nothing left to show; follow the deletion out instead of stranding a dead screen.
+      if newValue == nil { dismiss() }
+    }
     .onChange(of: connectionViewModel.signInCompletedAt) { _, newValue in
       guard newValue != nil else { return }
       showConnectionForm = false

--- a/BookPlayer/Jellyfin/JellyfinRootView.swift
+++ b/BookPlayer/Jellyfin/JellyfinRootView.swift
@@ -132,24 +132,10 @@ struct JellyfinRootView: View {
       message: { Text(loadError?.localizedDescription ?? "") }
     )
     .sheet(isPresented: $showConnectionForm) {
-      NavigationStack {
-        IntegrationConnectionView(viewModel: connectionViewModel, integrationName: "Jellyfin")
-          .toolbar {
-            // Outer X only when we're NOT in Add Server mode — IntegrationConnectionView's
-            // own Cancel button handles that case (and just dismisses the form sheet).
-            if !connectionViewModel.isAddingServer {
-              ToolbarItemGroup(placement: .cancellationAction) {
-                Button { dismiss() } label: {
-                  Image(systemName: "xmark")
-                    .foregroundStyle(theme.linkColor)
-                }
-              }
-            }
-          }
-          .navigationBarTitleDisplayMode(.inline)
-      }
-      .tint(theme.linkColor)
-      .environmentObject(theme)
+      // The flow owns its NavigationStack and its own cancel affordances (Cancel for Add Server,
+      // an X otherwise) — no outer wrapping.
+      IntegrationConnectionFlowView(viewModel: connectionViewModel, integrationName: "Jellyfin")
+        .environmentObject(theme)
     }
     .sheet(isPresented: $showLibraryPicker) {
       libraryPickerSheet

--- a/BookPlayer/Jellyfin/JellyfinRootView.swift
+++ b/BookPlayer/Jellyfin/JellyfinRootView.swift
@@ -193,9 +193,16 @@ struct JellyfinRootView: View {
             }
           }
         }
+        // The card fill every ThemedSection row gets; a bare List row renders the system fill,
+        // which is the one unthemed surface on this screen.
+        .listRowBackground(theme.tertiarySystemBackgroundColor)
       }
-      .scrollContentBackground(.hidden)
-      .background(theme.systemBackgroundColor)
+      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+      // Until a library is chosen there is nothing behind this sheet to land on — swiping it away
+      // would strand the user on an empty integration library. Cancel remains the way out, and it
+      // correctly backs out of the whole server. Once a library exists (reopening the picker to
+      // switch), swipe-to-dismiss behaves normally.
+      .interactiveDismissDisabled(resolvedLibrary == nil)
       .navigationTitle("library_title".localized)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {

--- a/BookPlayer/Jellyfin/JellyfinRootView.swift
+++ b/BookPlayer/Jellyfin/JellyfinRootView.swift
@@ -134,7 +134,7 @@ struct JellyfinRootView: View {
     .sheet(isPresented: $showConnectionForm) {
       // The flow owns its NavigationStack and its own cancel affordances (Cancel for Add Server,
       // an X otherwise) — no outer wrapping.
-      IntegrationConnectionFlowView(viewModel: connectionViewModel, integrationName: "Jellyfin")
+      IntegrationConnectionFlowView(viewModel: connectionViewModel, kind: .jellyfin, integrationName: "Jellyfin")
         .environmentObject(theme)
     }
     .sheet(isPresented: $showLibraryPicker) {

--- a/BookPlayer/Jellyfin/Network/JellyfinConnectionService.swift
+++ b/BookPlayer/Jellyfin/Network/JellyfinConnectionService.swift
@@ -149,7 +149,8 @@ class JellyfinConnectionService: BPLogger {
     username: String,
     password: String,
     serverName: String,
-    customHeaders: [String: String] = [:]
+    customHeaders: [String: String] = [:],
+    replacingID: String? = nil
   ) async throws {
     let result = try await pending.client.signIn(username: username, password: password)
     // Bail out before persisting if the caller cancelled while the auth round-trip was
@@ -169,7 +170,7 @@ class JellyfinConnectionService: BPLogger {
     // off (same library context, same outbound references) rather than on a fresh record they have
     // to re-configure.
     let serverURL = pending.client.configuration.url
-    store.upsert(url: serverURL, userID: userID) { existing in
+    store.upsert(url: serverURL, userID: userID, replacingID: replacingID) { existing in
       JellyfinConnectionData(
         id: existing?.id ?? UUID().uuidString,
         url: serverURL,
@@ -214,7 +215,8 @@ class JellyfinConnectionService: BPLogger {
     pending: PendingServer,
     secret: String,
     serverName: String,
-    customHeaders: [String: String] = [:]
+    customHeaders: [String: String] = [:],
+    replacingID: String? = nil
   ) async throws -> String {
     let result = try await pending.client.signIn(quickConnectSecret: secret)
     // Bail out before persisting if the caller cancelled while the exchange was in flight.
@@ -232,7 +234,7 @@ class JellyfinConnectionService: BPLogger {
     // and carries the existing connection's id and selectedLibraryId forward on a re-auth, so the
     // user lands back in the same library context with the same outbound references.
     let serverURL = pending.client.configuration.url
-    store.upsert(url: serverURL, userID: userID) { existing in
+    store.upsert(url: serverURL, userID: userID, replacingID: replacingID) { existing in
       JellyfinConnectionData(
         id: existing?.id ?? UUID().uuidString,
         url: serverURL,

--- a/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
+++ b/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
@@ -30,13 +30,22 @@ struct ClearableTextField: View {
     HStack {
       TextField(placeholder, text: $text, onCommit: onCommit)
         .foregroundStyle(themeViewModel.primaryColor)
-      Image(systemName: "clear.fill")
-        .foregroundStyle(themeViewModel.secondaryColor)
-        .onTapGesture {
+      // Shown only when there is something to clear, like the system clear button — an X that clears
+      // an empty field is a pointless VoiceOver stop.
+      if !text.isEmpty {
+        Button {
           text = ""
+        } label: {
+          Image(systemName: "clear.fill")
+            .foregroundStyle(themeViewModel.secondaryColor)
         }
-        .accessibilityAddTraits(.isButton)
-        .accessibilityRemoveTraits(.isImage)
+        // `.borderless`, because these fields sit in Form rows: a default-styled button there is
+        // fired by the List's row-tap forwarding, so tapping anywhere in the row would clear the
+        // text. A real Button (not the old tap gesture on the Image) is what gives VoiceOver proper
+        // activation; the label is what it announces — the bare symbol read as its inferred name.
+        .buttonStyle(.borderless)
+        .accessibilityLabel(Text("clear_text_button".localized))
+      }
     }
   }
 }

--- a/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
+++ b/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
@@ -55,9 +55,14 @@ struct ClearableTextField: View {
         // `.borderless`, because these fields sit in Form rows: a default-styled button there is
         // fired by the List's row-tap forwarding, so tapping anywhere in the row would clear the
         // text. A real Button (not the old tap gesture on the Image) is what gives VoiceOver proper
-        // activation; the label is what it announces — the bare symbol read as its inferred name.
+        // activation.
+        //
+        // Deliberately NO explicit accessibility label: `clear.fill` ships with Apple's own localized
+        // description ("Clear"), which is device-verified to announce correctly — and it only worked
+        // wrong before because a label applied to the compound propagated in over it, which the
+        // scoped `accessibilityLabel` parameter now makes impossible. Don't add a custom string here;
+        // it would re-own 26 translations Apple already maintains.
         .buttonStyle(.borderless)
-        .accessibilityLabel(Text("clear_text_button".localized))
       }
     }
   }

--- a/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
+++ b/BookPlayer/Library/ItemDetails/Views/ClearableTextField.swift
@@ -17,12 +17,24 @@ struct ClearableTextField: View {
   /// An action to perform when the user performs an action (for example, when the user presses the Return key) while the text field has focus.
   var onCommit: () -> Void
 
+  /// VoiceOver label for the text field itself. Pass it here rather than applying
+  /// `.accessibilityLabel` to this view from outside: this is a compound of two elements, and a
+  /// label on the container propagates into the clear button too — which is exactly how the flow's
+  /// clear button ended up announcing as "Host".
+  var accessibilityLabel: String?
+
   /// Current theme
   @EnvironmentObject var themeViewModel: ThemeViewModel
 
-  init(_ placeholder: String, text: Binding<String>, onCommit: @escaping () -> Void = {}) {
+  init(
+    _ placeholder: String,
+    text: Binding<String>,
+    accessibilityLabel: String? = nil,
+    onCommit: @escaping () -> Void = {}
+  ) {
     self.placeholder = placeholder
     _text = text
+    self.accessibilityLabel = accessibilityLabel
     self.onCommit = onCommit
   }
 
@@ -30,6 +42,7 @@ struct ClearableTextField: View {
     HStack {
       TextField(placeholder, text: $text, onCommit: onCommit)
         .foregroundStyle(themeViewModel.primaryColor)
+        .accessibilityLabel(Text(accessibilityLabel ?? placeholder))
       // Shown only when there is something to clear, like the system clear button — an X that clears
       // an empty field is a pointless VoiceOver stop.
       if !text.isEmpty {

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectedView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectedView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct IntegrationConnectedView<VM: IntegrationConnectionViewModelProtocol>: View {
   @ObservedObject var viewModel: VM
   @EnvironmentObject var theme: ThemeViewModel
+  @Environment(\.dismiss) private var dismiss
 
   var body: some View {
     ThemedSection {
@@ -31,6 +32,10 @@ struct IntegrationConnectedView<VM: IntegrationConnectionViewModelProtocol>: Vie
     ThemedSection {
       Button("logout_title".localized, role: .destructive) {
         viewModel.handleSignOutAction()
+        // Signing out is deletion: the connection this screen describes no longer exists, so the
+        // screen leaves with it — back to Media Servers (sheet) or the presenting stack (push).
+        // The old behavior redrew the details sheet into the sign-in form in place.
+        dismiss()
       }
       .frame(maxWidth: .infinity)
       .foregroundStyle(.red)

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -143,8 +143,8 @@ struct IntegrationConnectionFlowView<VM: IntegrationConnectionViewModelProtocol>
 // MARK: - Screen 1 · Address
 
 /// Server address as explicit fields — scheme, host (carrying any reverse-proxy subpath), port — plus
-/// the custom headers, which are editable here and only here. Connect is pinned at the bottom, the
-/// `LoginView` pattern, so the primary action sits in the same place on every screen of the flow.
+/// the custom headers, which are editable here and only here. Connect flows after the content as the
+/// form's final section, like every action button in this flow.
 struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: View {
   @ObservedObject var viewModel: VM
 
@@ -270,7 +270,6 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
         }
     }
     .scrollDismissesKeyboard(.immediately)
-    .onTapGesture { hideKeyboard() }
     .applyListStyle(with: theme, background: theme.systemBackgroundColor)
     .navigationTitle(integrationName)
     .navigationBarTitleDisplayMode(.inline)
@@ -411,7 +410,6 @@ struct IntegrationPasswordScreen<VM: IntegrationConnectionViewModelProtocol>: Vi
       }
     }
     .scrollDismissesKeyboard(.immediately)
-    .onTapGesture { hideKeyboard() }
     .applyListStyle(with: theme, background: theme.systemBackgroundColor)
     .navigationTitle("integration_sign_in_button".localized)
     .navigationBarTitleDisplayMode(.inline)
@@ -477,8 +475,9 @@ struct IntegrationHeadersReadOnlySection: View {
 ///
 /// Called before pushing off the address screen: if the keyboard rides through the push, popping back
 /// can leave the bottom button behind it — keyboard safe-area avoidance doesn't reliably re-apply
-/// after a pop. Dismissing before navigating sidesteps the glitch instead of fighting it. Also wired
-/// to background taps and scroll drags, so the keyboard never has to be typed away.
+/// after a pop. Dismissing before navigating sidesteps the glitch instead of fighting it. Scroll
+/// drags also dismiss (`scrollDismissesKeyboard`); a Form-wide tap gesture was tried and reverted —
+/// it stole taps from the buttons inside the list rows.
 private func hideKeyboard() {
   UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 }
@@ -486,16 +485,23 @@ private func hideKeyboard() {
 /// Hosts a screen's action buttons as the form's final section, flowing after the content rather
 /// than pinned to the bottom edge — short screens (the method chooser) otherwise strand the buttons
 /// across a gulf of empty space, and in-flow buttons ride the scroll view's native keyboard avoidance.
+///
+/// Three List behaviors this exists to defuse, all found on device:
+/// - Each button must be its OWN row. Default-styled buttons sharing one row fire *together* on a
+///   row tap — choosing "Username & Password" also launched Quick Connect.
+/// - `.borderless`, so the button itself is the hit target instead of the List's row-tap forwarding.
+/// - Clear row background with no card: the section card's rounded clipping otherwise cuts into the
+///   button's own shape.
 struct IntegrationFlowButtonsSection<Content: View>: View {
   @ViewBuilder var content: Content
 
   var body: some View {
     Section {
-      VStack(spacing: Spacing.S) {
-        content
-      }
+      content
     }
+    .buttonStyle(.borderless)
     .listRowBackground(Color.clear)
+    .listRowSeparator(.hidden)
     .listRowInsets(EdgeInsets())
   }
 }

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -253,6 +253,8 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
 
         IntegrationCustomHeadersSectionView(customHeaders: $viewModel.form.customHeaders)
       }
+      .scrollDismissesKeyboard(.immediately)
+      .onTapGesture { hideKeyboard() }
       .applyListStyle(with: theme, background: theme.systemBackgroundColor)
       .safeAreaInset(edge: .bottom) { Color.clear.frame(height: Self.footerClearance) }
 
@@ -266,6 +268,7 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
           address = pasted
           portText = pasted.port.map(String.init) ?? ""
         }
+        hideKeyboard()
         viewModel.form.serverUrl = address.urlString ?? ""
         onConnect()
       }
@@ -403,6 +406,8 @@ struct IntegrationPasswordScreen<VM: IntegrationConnectionViewModelProtocol>: Vi
           onCommit: onSignIn
         )
       }
+      .scrollDismissesKeyboard(.immediately)
+      .onTapGesture { hideKeyboard() }
       .applyListStyle(with: theme, background: theme.systemBackgroundColor)
       .safeAreaInset(edge: .bottom) {
         Color.clear.frame(height: IntegrationAddressScreen<VM>.footerClearance)
@@ -473,6 +478,16 @@ struct IntegrationHeadersReadOnlySection: View {
 }
 
 // MARK: - Shared chrome
+
+/// Drops the keyboard by resigning whatever holds first-responder status.
+///
+/// Called before pushing off the address screen: if the keyboard rides through the push, popping back
+/// can leave the bottom button behind it — keyboard safe-area avoidance doesn't reliably re-apply
+/// after a pop. Dismissing before navigating sidesteps the glitch instead of fighting it. Also wired
+/// to background taps and scroll drags, so the keyboard never has to be typed away.
+private func hideKeyboard() {
+  UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+}
 
 /// The flow's pinned primary action — filled, full width, bottom of every screen, so the way forward
 /// never moves and never vanishes.

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -486,23 +486,27 @@ private func hideKeyboard() {
 /// than pinned to the bottom edge — short screens (the method chooser) otherwise strand the buttons
 /// across a gulf of empty space, and in-flow buttons ride the scroll view's native keyboard avoidance.
 ///
-/// Three List behaviors this exists to defuse, all found on device:
-/// - Each button must be its OWN row. Default-styled buttons sharing one row fire *together* on a
-///   row tap — choosing "Username & Password" also launched Quick Connect.
-/// - `.borderless`, so the button itself is the hit target instead of the List's row-tap forwarding.
-/// - Clear row background with no card: the section card's rounded clipping otherwise cuts into the
-///   button's own shape.
+/// The buttons live in a section FOOTER, not in rows — the third shape this view has taken, each
+/// retreating further from List's row machinery after a device finding:
+/// - Buttons sharing one row fire *together* on a row tap (choosing "Username & Password" also
+///   launched Quick Connect), and row-tap forwarding swallows direct hits.
+/// - Rows are clipped to the section container's shape. Clear backgrounds and zero insets don't
+///   escape it: the container's corner radius (large, on current list styling) shears the button's
+///   own corners — square-cut tops on an otherwise rounded button.
+/// Footers render outside the card container: never clipped, no row-tap semantics, plainly hit-tested.
 struct IntegrationFlowButtonsSection<Content: View>: View {
   @ViewBuilder var content: Content
 
   var body: some View {
     Section {
-      content
+      EmptyView()
+    } footer: {
+      VStack(spacing: Spacing.S) {
+        content
+      }
+      .frame(maxWidth: .infinity)
+      .listRowInsets(EdgeInsets())
     }
-    .buttonStyle(.borderless)
-    .listRowBackground(Color.clear)
-    .listRowSeparator(.hidden)
-    .listRowInsets(EdgeInsets())
   }
 }
 

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -160,6 +160,12 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
   /// The port as typed. Kept as text so emptying the field is representable; parsed on change.
   @State private var portText: String
 
+  /// The host field's display text, mirrored from `address.hostField` rather than bound to it
+  /// directly. A focused `TextField` shows its live edit buffer and won't re-read a computed
+  /// binding whose setter changed the value — so a decomposed paste kept displaying the full URL
+  /// until focus left. A plain `@State` is something the field does refresh from immediately.
+  @State private var hostText: String
+
   @EnvironmentObject var theme: ThemeViewModel
   @Environment(\.dismiss) private var dismiss
 
@@ -179,6 +185,7 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
       ?? IntegrationServerAddress(scheme: .https, host: "")
     self._address = State(initialValue: parsed)
     self._portText = State(initialValue: parsed.port.map(String.init) ?? "")
+    self._hostText = State(initialValue: parsed.hostField)
   }
 
   /// The usual port for this integration, shown as a placeholder example — never substituted.
@@ -216,13 +223,22 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             // compound from out here propagated "Host" into the clear button as well.
             ClearableTextField(
               hostPlaceholder,
-              text: $address.hostField,
+              text: $hostText,
               accessibilityLabel: "integration_address_host_label".localized
             )
             .multilineTextAlignment(.trailing)
             .keyboardType(.URL)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
+            .onChange(of: hostText) { _, newValue in
+              address.hostField = newValue
+              // The setter normalizes — a pasted URL decomposes, IPv6 gains brackets. Reflect that
+              // in the visible text at once instead of on focus loss. Settles in one extra pass:
+              // re-setting an already-normalized value changes nothing.
+              if address.hostField != newValue {
+                hostText = address.hostField
+              }
+            }
           }
 
           HStack {

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -315,15 +315,14 @@ struct IntegrationMethodScreen<VM: IntegrationConnectionViewModelProtocol>: View
     ZStack(alignment: .bottom) {
       Form {
         ThemedSection {
-          HStack {
-            Text("integration_server_url_label".localized)
-              .foregroundStyle(theme.primaryColor)
-            Spacer()
-            Text(viewModel.form.serverUrl)
-              .foregroundStyle(theme.secondaryColor)
-              .lineLimit(1)
-              .truncationMode(.middle)
-          }
+          // Just the URL, no "URL" label: a key/value pair in a grouped list reads as a tappable
+          // row, and this one is purely informational. The bare value gets the full width — these
+          // are often long self-hosted hostnames — and wraps rather than truncating.
+          Text(viewModel.form.serverUrl)
+            .bpFont(.footnote)
+            .foregroundStyle(theme.secondaryColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
           if !viewModel.form.customHeaders.isEmpty {
             NavigationLink(value: ConnectionFlowStep.headersDetail) {
               HStack {

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -404,6 +404,23 @@ struct IntegrationHeadersDetailScreen: View {
 
   var body: some View {
     Form {
+      IntegrationHeadersReadOnlySection(headers: headers)
+    }
+    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+    .navigationTitle("integration_custom_headers_title".localized)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}
+
+/// Read-only rendering of a connection's custom headers — shared by the flow's pushed detail and the
+/// connection-details screen, whose editor is gone (edits happen on the flow's address screen).
+struct IntegrationHeadersReadOnlySection: View {
+  let headers: [CustomHeaderEntry]
+
+  @EnvironmentObject var theme: ThemeViewModel
+
+  var body: some View {
+    if !headers.isEmpty {
       ThemedSection {
         ForEach(headers) { header in
           VStack(alignment: .leading, spacing: 4) {
@@ -416,14 +433,14 @@ struct IntegrationHeadersDetailScreen: View {
               .textSelection(.enabled)
           }
         }
+      } header: {
+        Text("integration_custom_headers_title".localized)
+          .foregroundStyle(theme.secondaryColor)
       } footer: {
         Text("integration_headers_detail_footer".localized)
           .foregroundStyle(theme.secondaryColor)
       }
     }
-    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
-    .navigationTitle("integration_custom_headers_title".localized)
-    .navigationBarTitleDisplayMode(.inline)
   }
 }
 

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -237,6 +237,12 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
               .onChange(of: portText) { _, newValue in
                 address.port = Int(newValue).flatMap { (1...65535).contains($0) ? $0 : nil }
               }
+              // A pasted URL decomposes inside the host binding and can carry a port; the text this
+              // field displays has to follow. Keyed on the host so ordinary port typing (including
+              // an invalid value mid-edit, which maps to nil) never rewrites the user's text.
+              .onChange(of: address.host) { _, _ in
+                portText = address.port.map(String.init) ?? ""
+              }
           }
         } header: {
           Text("integration_server_section_header".localized)
@@ -257,12 +263,6 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             title: "integration_connect_button".localized,
             isDisabled: address.url == nil || isLoading
           ) {
-            // A paste of a full URL into the host field carries the whole address; decompose it into
-            // the fields rather than sending a host that contains a scheme.
-            if let pasted = IntegrationServerAddress(parsing: address.hostField) {
-              address = pasted
-              portText = pasted.port.map(String.init) ?? ""
-            }
             hideKeyboard()
             viewModel.form.serverUrl = address.urlString ?? ""
             onConnect()

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -244,13 +244,24 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
     .navigationTitle(integrationName)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
-      if viewModel.isAddingServer {
-        ToolbarItem(placement: .cancellationAction) {
+      ToolbarItem(placement: .cancellationAction) {
+        // Add Server gets a worded Cancel that also tears down the in-flight VM state; the
+        // initial-connect and re-auth presentations get the X the old sheet wrappers injected —
+        // the flow owns its NavigationStack now, so the affordance has to live here.
+        if viewModel.isAddingServer {
           Button("cancel_button".localized) {
             viewModel.handleCancelAddServerAction()
             dismiss()
           }
           .foregroundStyle(theme.linkColor)
+        } else {
+          Button {
+            dismiss()
+          } label: {
+            Image(systemName: "xmark")
+              .foregroundStyle(theme.linkColor)
+          }
+          .accessibilityLabel(Text("cancel_button".localized))
         }
       }
     }

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -198,8 +198,7 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
   }
 
   var body: some View {
-    ZStack(alignment: .bottom) {
-      Form {
+    Form {
         ThemedSection {
           Picker("", selection: $address.scheme) {
             // Protocol identifiers, not words — deliberately unlocalized.
@@ -252,27 +251,27 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
         }
 
         IntegrationCustomHeadersSectionView(customHeaders: $viewModel.form.customHeaders)
-      }
-      .scrollDismissesKeyboard(.immediately)
-      .onTapGesture { hideKeyboard() }
-      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
-      .safeAreaInset(edge: .bottom) { Color.clear.frame(height: Self.footerClearance) }
 
-      IntegrationFlowPrimaryButton(
-        title: "integration_connect_button".localized,
-        isDisabled: address.url == nil || isLoading
-      ) {
-        // A paste of a full URL into the host field carries the whole address; decompose it into
-        // the fields rather than sending a host that contains a scheme.
-        if let pasted = IntegrationServerAddress(parsing: address.hostField) {
-          address = pasted
-          portText = pasted.port.map(String.init) ?? ""
+        IntegrationFlowButtonsSection {
+          IntegrationFlowPrimaryButton(
+            title: "integration_connect_button".localized,
+            isDisabled: address.url == nil || isLoading
+          ) {
+            // A paste of a full URL into the host field carries the whole address; decompose it into
+            // the fields rather than sending a host that contains a scheme.
+            if let pasted = IntegrationServerAddress(parsing: address.hostField) {
+              address = pasted
+              portText = pasted.port.map(String.init) ?? ""
+            }
+            hideKeyboard()
+            viewModel.form.serverUrl = address.urlString ?? ""
+            onConnect()
+          }
         }
-        hideKeyboard()
-        viewModel.form.serverUrl = address.urlString ?? ""
-        onConnect()
-      }
     }
+    .scrollDismissesKeyboard(.immediately)
+    .onTapGesture { hideKeyboard() }
+    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
     .navigationTitle(integrationName)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
@@ -299,7 +298,6 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
     }
   }
 
-  static var footerClearance: CGFloat { 88 }
 }
 
 // MARK: - Screen 2 · Method
@@ -315,36 +313,33 @@ struct IntegrationMethodScreen<VM: IntegrationConnectionViewModelProtocol>: View
   @EnvironmentObject var theme: ThemeViewModel
 
   var body: some View {
-    ZStack(alignment: .bottom) {
-      Form {
+    Form {
+      // The server-reported name, under its own header — the address identifies the server in the
+      // title, the name is a fact the server told us. Hidden when the admin never set one.
+      if !viewModel.form.serverName.isEmpty {
         ThemedSection {
-          // Just the URL, no "URL" label: a key/value pair in a grouped list reads as a tappable
-          // row, and this one is purely informational. The bare value gets the full width — these
-          // are often long self-hosted hostnames — and wraps rather than truncating.
-          Text(viewModel.form.serverUrl)
-            .bpFont(.footnote)
+          Text(viewModel.form.serverName)
+            .bpFont(.body)
+            .foregroundStyle(theme.primaryColor)
+        } header: {
+          Text("integration_server_name_label".localized)
             .foregroundStyle(theme.secondaryColor)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .fixedSize(horizontal: false, vertical: true)
-          if !viewModel.form.customHeaders.isEmpty {
-            NavigationLink(value: ConnectionFlowStep.headersDetail) {
-              HStack {
-                Text("integration_custom_headers_title".localized)
-                  .foregroundStyle(theme.primaryColor)
-                Spacer()
-                Text("\(viewModel.form.customHeaders.count)")
-                  .foregroundStyle(theme.secondaryColor)
-              }
+        }
+      }
+      if !viewModel.form.customHeaders.isEmpty {
+        ThemedSection {
+          NavigationLink(value: ConnectionFlowStep.headersDetail) {
+            HStack {
+              Text("integration_custom_headers_title".localized)
+                .foregroundStyle(theme.primaryColor)
+              Spacer()
+              Text("\(viewModel.form.customHeaders.count)")
+                .foregroundStyle(theme.secondaryColor)
             }
           }
         }
       }
-      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
-      .safeAreaInset(edge: .bottom) {
-        Color.clear.frame(height: IntegrationAddressScreen<VM>.footerClearance)
-      }
-
-      VStack(spacing: Spacing.S) {
+      IntegrationFlowButtonsSection {
         IntegrationFlowPrimaryButton(title: primaryTitle, isDisabled: isLoading) {
           onStartAlternative()
         }
@@ -357,19 +352,22 @@ struct IntegrationMethodScreen<VM: IntegrationConnectionViewModelProtocol>: View
               .frame(maxWidth: .infinity)
               .foregroundColor(theme.linkColor)
           }
-          .padding(.bottom, Spacing.S)
         }
       }
     }
+    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
     .navigationTitle(navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
   }
 
-  /// The server's own name when the admin set one; the host otherwise — a blank title helps nobody.
+  /// The address, scheme stripped — it identifies which server this is, while the name the server
+  /// reports is data about it, shown in the body. A title has no room for "https://".
   private var navigationTitle: String {
-    if !viewModel.form.serverName.isEmpty { return viewModel.form.serverName }
-    return IntegrationServerAddress(parsing: viewModel.form.serverUrl)?.hostField
-      ?? viewModel.form.serverUrl
+    guard let address = IntegrationServerAddress(parsing: viewModel.form.serverUrl) else {
+      return viewModel.form.serverUrl
+    }
+    let port = address.port.map { ":\($0)" } ?? ""
+    return address.host + port + address.path
   }
 
   private var primaryTitle: String {
@@ -396,29 +394,25 @@ struct IntegrationPasswordScreen<VM: IntegrationConnectionViewModelProtocol>: Vi
   @EnvironmentObject var theme: ThemeViewModel
 
   var body: some View {
-    ZStack(alignment: .bottom) {
-      Form {
-        // Typing is the only thing this screen does, so the username field always auto-focuses.
-        IntegrationServerFoundView(
-          username: $viewModel.form.username,
-          password: $viewModel.form.password,
-          autoFocusesUsername: true,
-          onCommit: onSignIn
+    Form {
+      // Typing is the only thing this screen does, so the username field always auto-focuses.
+      IntegrationServerFoundView(
+        username: $viewModel.form.username,
+        password: $viewModel.form.password,
+        autoFocusesUsername: true,
+        onCommit: onSignIn
+      )
+      IntegrationFlowButtonsSection {
+        IntegrationFlowPrimaryButton(
+          title: "integration_sign_in_button".localized,
+          isDisabled: viewModel.form.username.isEmpty || viewModel.form.password.isEmpty || isLoading,
+          action: onSignIn
         )
       }
-      .scrollDismissesKeyboard(.immediately)
-      .onTapGesture { hideKeyboard() }
-      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
-      .safeAreaInset(edge: .bottom) {
-        Color.clear.frame(height: IntegrationAddressScreen<VM>.footerClearance)
-      }
-
-      IntegrationFlowPrimaryButton(
-        title: "integration_sign_in_button".localized,
-        isDisabled: viewModel.form.username.isEmpty || viewModel.form.password.isEmpty || isLoading,
-        action: onSignIn
-      )
     }
+    .scrollDismissesKeyboard(.immediately)
+    .onTapGesture { hideKeyboard() }
+    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
     .navigationTitle("integration_sign_in_button".localized)
     .navigationBarTitleDisplayMode(.inline)
   }
@@ -489,8 +483,24 @@ private func hideKeyboard() {
   UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
 }
 
-/// The flow's pinned primary action — filled, full width, bottom of every screen, so the way forward
-/// never moves and never vanishes.
+/// Hosts a screen's action buttons as the form's final section, flowing after the content rather
+/// than pinned to the bottom edge — short screens (the method chooser) otherwise strand the buttons
+/// across a gulf of empty space, and in-flow buttons ride the scroll view's native keyboard avoidance.
+struct IntegrationFlowButtonsSection<Content: View>: View {
+  @ViewBuilder var content: Content
+
+  var body: some View {
+    Section {
+      VStack(spacing: Spacing.S) {
+        content
+      }
+    }
+    .listRowBackground(Color.clear)
+    .listRowInsets(EdgeInsets())
+  }
+}
+
+/// The flow's primary action — filled, full width, directly after the screen's content.
 struct IntegrationFlowPrimaryButton: View {
   let title: String
   var isDisabled: Bool = false
@@ -509,7 +519,5 @@ struct IntegrationFlowPrimaryButton: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
     .disabledWithOpacity(isDisabled)
-    .padding(.horizontal, Spacing.M)
-    .padding(.bottom, Spacing.S)
   }
 }

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -21,6 +21,10 @@ import SwiftUI
 struct IntegrationConnectionFlowView<VM: IntegrationConnectionViewModelProtocol>: View {
   @ObservedObject var viewModel: VM
 
+  /// Which integration this flow signs into. Placeholders and defaults key off this, not off the
+  /// display string — a renamed `integrationName` must never silently flip them.
+  let kind: IntegrationKind
+
   let integrationName: String
 
   @State private var isLoading = false
@@ -44,6 +48,7 @@ struct IntegrationConnectionFlowView<VM: IntegrationConnectionViewModelProtocol>
     NavigationStack(path: $viewModel.flowPath) {
       IntegrationAddressScreen(
         viewModel: viewModel,
+        kind: kind,
         integrationName: integrationName,
         isLoading: isLoading,
         onConnect: onConnect
@@ -143,6 +148,7 @@ struct IntegrationConnectionFlowView<VM: IntegrationConnectionViewModelProtocol>
 struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: View {
   @ObservedObject var viewModel: VM
 
+  let kind: IntegrationKind
   let integrationName: String
   let isLoading: Bool
   var onConnect: () -> Void
@@ -157,8 +163,15 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
   @EnvironmentObject var theme: ThemeViewModel
   @Environment(\.dismiss) private var dismiss
 
-  init(viewModel: VM, integrationName: String, isLoading: Bool, onConnect: @escaping () -> Void) {
+  init(
+    viewModel: VM,
+    kind: IntegrationKind,
+    integrationName: String,
+    isLoading: Bool,
+    onConnect: @escaping () -> Void
+  ) {
     self.viewModel = viewModel
+    self.kind = kind
     self.integrationName = integrationName
     self.isLoading = isLoading
     self.onConnect = onConnect
@@ -171,7 +184,17 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
   /// The usual port for this integration, shown as a placeholder example — never substituted.
   /// An empty field means no port, exactly as in a browser.
   private var usualPort: String {
-    integrationName == "Jellyfin" ? "8096" : "13378"
+    switch kind {
+    case .jellyfin: return "8096"
+    case .audiobookshelf: return "13378"
+    }
+  }
+
+  private var hostPlaceholder: String {
+    switch kind {
+    case .jellyfin: return "jellyfin.example.com"
+    case .audiobookshelf: return "audiobookshelf.example.com"
+    }
   }
 
   var body: some View {
@@ -191,7 +214,7 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             Text("integration_address_host_label".localized)
               .foregroundStyle(theme.primaryColor)
             ClearableTextField(
-              integrationName == "Jellyfin" ? "jellyfin.example.com" : "audiobookshelf.example.com",
+              hostPlaceholder,
               text: $address.hostField
             )
             .multilineTextAlignment(.trailing)

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -198,6 +198,9 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             .keyboardType(.URL)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
+            // The row's Text label isn't associated with the field — without this VoiceOver reads
+            // the placeholder hostname as if it were the field's name.
+            .accessibilityLabel(Text("integration_address_host_label".localized))
           }
 
           HStack {
@@ -206,6 +209,9 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             TextField(usualPort, text: $portText)
               .multilineTextAlignment(.trailing)
               .keyboardType(.numberPad)
+              // Same association gap — and here the placeholder is a bare number, so an unlabelled
+              // field announces as "8096", which is meaningless.
+              .accessibilityLabel(Text("integration_address_port_label".localized))
               .onChange(of: portText) { _, newValue in
                 address.port = Int(newValue).flatMap { (1...65535).contains($0) ? $0 : nil }
               }

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -1,0 +1,444 @@
+//
+//  IntegrationConnectionFlowView.swift
+//  BookPlayer
+//
+//  Created by Gianni Carlo on 8/8/26.
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import BookPlayerKit
+import SwiftUI
+
+/// The redesigned add-server flow: one pushed screen per decision.
+///
+/// Address (root) → method chooser (only when the server offers an alternative to the password) →
+/// password form. Quick Connect and SSO present modally from wherever they're started — they hand off
+/// to an external authority and come back, which is what a modal says and a push doesn't.
+///
+/// Owns its `NavigationStack`, with the path living on the view model — the routing decision (what
+/// Connect lands on) is view-model logic under test, and success/cancel clear the path there so no
+/// pushed screen can outlive the flow. Presenters therefore must NOT wrap this in another stack.
+struct IntegrationConnectionFlowView<VM: IntegrationConnectionViewModelProtocol>: View {
+  @ObservedObject var viewModel: VM
+
+  let integrationName: String
+
+  @State private var isLoading = false
+  @State private var error: Error?
+
+  /// In-flight connect/sign-in/alternative task, cancelled when the flow disappears so dismissing
+  /// the sheet can't let a stale attempt persist a connection the user gave up on.
+  @State private var actionTask: Task<Void, Never>?
+
+  @EnvironmentObject var theme: ThemeViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  private var isQuickConnectSheetPresented: Binding<Bool> {
+    Binding(
+      get: { viewModel.quickConnectStatus != nil },
+      set: { if !$0 { viewModel.handleCancelAlternativeSignIn() } }
+    )
+  }
+
+  var body: some View {
+    NavigationStack(path: $viewModel.flowPath) {
+      IntegrationAddressScreen(
+        viewModel: viewModel,
+        integrationName: integrationName,
+        isLoading: isLoading,
+        onConnect: onConnect
+      )
+      .navigationDestination(for: ConnectionFlowStep.self) { step in
+        switch step {
+        case .method:
+          IntegrationMethodScreen(
+            viewModel: viewModel,
+            isLoading: isLoading,
+            onStartAlternative: onStartAlternativeSignIn
+          )
+        case .password:
+          IntegrationPasswordScreen(
+            viewModel: viewModel,
+            isLoading: isLoading,
+            onSignIn: onSignIn
+          )
+        case .headersDetail:
+          IntegrationHeadersDetailScreen(headers: viewModel.form.customHeaders)
+        }
+      }
+    }
+    .tint(theme.linkColor)
+    .errorAlert(error: $error)
+    .sheet(isPresented: isQuickConnectSheetPresented) {
+      IntegrationQuickConnectSheetView(
+        status: viewModel.quickConnectStatus ?? .retrievingCode,
+        serverUrl: viewModel.form.serverUrl,
+        onCancel: { viewModel.handleCancelAlternativeSignIn() }
+      )
+      .environmentObject(theme)
+    }
+    .overlay {
+      if isLoading {
+        ProgressView()
+          .tint(.white)
+          .padding()
+          .background(Color.black.opacity(0.9).clipShape(RoundedRectangle(cornerRadius: 10)))
+      }
+    }
+    .onDisappear {
+      actionTask?.cancel()
+      actionTask = nil
+      viewModel.handleCancelAlternativeSignIn()
+    }
+  }
+
+  // MARK: - Actions
+
+  /// Runs `work` in the tracked task with the shared cancellation treatment: a cancelled attempt —
+  /// whichever spelling it surfaces as — stays silent instead of popping an alert over its successor.
+  private func run(showsOverlay: Bool, _ work: @escaping () async throws -> Void) {
+    actionTask?.cancel()
+    if showsOverlay { isLoading = true }
+    actionTask = Task { @MainActor in
+      defer { if showsOverlay { isLoading = false } }
+      do {
+        try await work()
+        try Task.checkCancellation()
+      } catch let error as URLError where error.code == .cancelled {
+        return
+      } catch is CancellationError {
+        return
+      } catch {
+        self.error = error
+      }
+    }
+  }
+
+  private func onConnect() {
+    run(showsOverlay: true) { try await viewModel.handleConnectAction() }
+  }
+
+  private func onSignIn() {
+    run(showsOverlay: true) { try await viewModel.handleSignInAction() }
+  }
+
+  private func onStartAlternativeSignIn() {
+    guard let method = viewModel.alternativeSignIn else { return }
+    // OIDC's token exchange hides behind the system browser sheet, so the overlay covers it.
+    // Quick Connect presents a sheet with its own progress UI — an overlay would stack spinners.
+    let showsOverlay: Bool
+    switch method {
+    case .oidc: showsOverlay = true
+    case .quickConnect: showsOverlay = false
+    }
+    run(showsOverlay: showsOverlay) { try await viewModel.handleStartAlternativeSignIn() }
+  }
+}
+
+// MARK: - Screen 1 · Address
+
+/// Server address as explicit fields — scheme, host (carrying any reverse-proxy subpath), port — plus
+/// the custom headers, which are editable here and only here. Connect is pinned at the bottom, the
+/// `LoginView` pattern, so the primary action sits in the same place on every screen of the flow.
+struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: View {
+  @ObservedObject var viewModel: VM
+
+  let integrationName: String
+  let isLoading: Bool
+  var onConnect: () -> Void
+
+  /// The fields, seeded from the form's URL so re-auth and edit-connection arrive prefilled. Written
+  /// back as an assembled string only on Connect — the form stays the single source the services read.
+  @State private var address: IntegrationServerAddress
+
+  /// The port as typed. Kept as text so emptying the field is representable; parsed on change.
+  @State private var portText: String
+
+  @EnvironmentObject var theme: ThemeViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  init(viewModel: VM, integrationName: String, isLoading: Bool, onConnect: @escaping () -> Void) {
+    self.viewModel = viewModel
+    self.integrationName = integrationName
+    self.isLoading = isLoading
+    self.onConnect = onConnect
+    let parsed = IntegrationServerAddress(parsing: viewModel.form.serverUrl)
+      ?? IntegrationServerAddress(scheme: .https, host: "")
+    self._address = State(initialValue: parsed)
+    self._portText = State(initialValue: parsed.port.map(String.init) ?? "")
+  }
+
+  /// The usual port for this integration, shown as a placeholder example — never substituted.
+  /// An empty field means no port, exactly as in a browser.
+  private var usualPort: String {
+    integrationName == "Jellyfin" ? "8096" : "13378"
+  }
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      Form {
+        ThemedSection {
+          Picker("", selection: $address.scheme) {
+            // Protocol identifiers, not words — deliberately unlocalized.
+            ForEach(IntegrationServerAddress.Scheme.allCases, id: \.self) {
+              Text($0.rawValue).tag($0)
+            }
+          }
+          .pickerStyle(.segmented)
+          .accessibilityLabel(Text("integration_address_scheme_label".localized))
+
+          HStack {
+            Text("integration_address_host_label".localized)
+              .foregroundStyle(theme.primaryColor)
+            ClearableTextField(
+              integrationName == "Jellyfin" ? "jellyfin.example.com" : "audiobookshelf.example.com",
+              text: $address.hostField
+            )
+            .multilineTextAlignment(.trailing)
+            .keyboardType(.URL)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+          }
+
+          HStack {
+            Text("integration_address_port_label".localized)
+              .foregroundStyle(theme.primaryColor)
+            TextField(usualPort, text: $portText)
+              .multilineTextAlignment(.trailing)
+              .keyboardType(.numberPad)
+              .onChange(of: portText) { _, newValue in
+                address.port = Int(newValue).flatMap { (1...65535).contains($0) ? $0 : nil }
+              }
+          }
+        } header: {
+          Text("integration_server_section_header".localized)
+            .foregroundStyle(theme.secondaryColor)
+        } footer: {
+          // The assembled URL, so what Connect will actually dial is visible before tapping it —
+          // the part that makes a split address field trustworthy.
+          if let urlString = address.urlString {
+            Text(verbatim: urlString)
+              .foregroundStyle(theme.secondaryColor)
+          }
+        }
+
+        IntegrationCustomHeadersSectionView(customHeaders: $viewModel.form.customHeaders)
+      }
+      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+      .safeAreaInset(edge: .bottom) { Color.clear.frame(height: Self.footerClearance) }
+
+      IntegrationFlowPrimaryButton(
+        title: "integration_connect_button".localized,
+        isDisabled: address.url == nil || isLoading
+      ) {
+        // A paste of a full URL into the host field carries the whole address; decompose it into
+        // the fields rather than sending a host that contains a scheme.
+        if let pasted = IntegrationServerAddress(parsing: address.hostField) {
+          address = pasted
+          portText = pasted.port.map(String.init) ?? ""
+        }
+        viewModel.form.serverUrl = address.urlString ?? ""
+        onConnect()
+      }
+    }
+    .navigationTitle(integrationName)
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      if viewModel.isAddingServer {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("cancel_button".localized) {
+            viewModel.handleCancelAddServerAction()
+            dismiss()
+          }
+          .foregroundStyle(theme.linkColor)
+        }
+      }
+    }
+  }
+
+  static var footerClearance: CGFloat { 88 }
+}
+
+// MARK: - Screen 2 · Method
+
+/// "How do you want to sign in?" — rendered only when the server offers an alternative. The
+/// alternative is primary; the password path, when the server accepts one at all, is secondary.
+struct IntegrationMethodScreen<VM: IntegrationConnectionViewModelProtocol>: View {
+  @ObservedObject var viewModel: VM
+
+  let isLoading: Bool
+  var onStartAlternative: () -> Void
+
+  @EnvironmentObject var theme: ThemeViewModel
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      Form {
+        ThemedSection {
+          HStack {
+            Text("integration_server_url_label".localized)
+              .foregroundStyle(theme.primaryColor)
+            Spacer()
+            Text(viewModel.form.serverUrl)
+              .foregroundStyle(theme.secondaryColor)
+              .lineLimit(1)
+              .truncationMode(.middle)
+          }
+          if !viewModel.form.customHeaders.isEmpty {
+            NavigationLink(value: ConnectionFlowStep.headersDetail) {
+              HStack {
+                Text("integration_custom_headers_title".localized)
+                  .foregroundStyle(theme.primaryColor)
+                Spacer()
+                Text("\(viewModel.form.customHeaders.count)")
+                  .foregroundStyle(theme.secondaryColor)
+              }
+            }
+          }
+        }
+      }
+      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+      .safeAreaInset(edge: .bottom) {
+        Color.clear.frame(height: IntegrationAddressScreen<VM>.footerClearance)
+      }
+
+      VStack(spacing: Spacing.S) {
+        IntegrationFlowPrimaryButton(title: primaryTitle, isDisabled: isLoading) {
+          onStartAlternative()
+        }
+        if viewModel.supportsPasswordSignIn {
+          Button {
+            viewModel.flowPath.append(.password)
+          } label: {
+            Text("integration_password_signin_button".localized)
+              .bpFont(.body)
+              .frame(maxWidth: .infinity)
+              .foregroundColor(theme.linkColor)
+          }
+          .padding(.bottom, Spacing.S)
+        }
+      }
+    }
+    .navigationTitle(navigationTitle)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+
+  /// The server's own name when the admin set one; the host otherwise — a blank title helps nobody.
+  private var navigationTitle: String {
+    if !viewModel.form.serverName.isEmpty { return viewModel.form.serverName }
+    return IntegrationServerAddress(parsing: viewModel.form.serverUrl)?.hostField
+      ?? viewModel.form.serverUrl
+  }
+
+  private var primaryTitle: String {
+    switch viewModel.alternativeSignIn {
+    case .oidc(let buttonText):
+      return buttonText ?? "integration_sso_button".localized
+    case .quickConnect:
+      return "integration_quick_connect_button".localized
+    case nil:
+      // Unreachable by routing: `.method` is only pushed when an alternative exists.
+      return "integration_sign_in_button".localized
+    }
+  }
+}
+
+// MARK: - Screen 3 · Password
+
+struct IntegrationPasswordScreen<VM: IntegrationConnectionViewModelProtocol>: View {
+  @ObservedObject var viewModel: VM
+
+  let isLoading: Bool
+  var onSignIn: () -> Void
+
+  @EnvironmentObject var theme: ThemeViewModel
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      Form {
+        // Typing is the only thing this screen does, so the username field always auto-focuses.
+        IntegrationServerFoundView(
+          username: $viewModel.form.username,
+          password: $viewModel.form.password,
+          autoFocusesUsername: true,
+          onCommit: onSignIn
+        )
+      }
+      .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+      .safeAreaInset(edge: .bottom) {
+        Color.clear.frame(height: IntegrationAddressScreen<VM>.footerClearance)
+      }
+
+      IntegrationFlowPrimaryButton(
+        title: "integration_sign_in_button".localized,
+        isDisabled: viewModel.form.username.isEmpty || viewModel.form.password.isEmpty || isLoading,
+        action: onSignIn
+      )
+    }
+    .navigationTitle("integration_sign_in_button".localized)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}
+
+// MARK: - Headers detail
+
+/// Read-only view of the headers the connection carries. A pushed screen rather than an alert:
+/// alerts don't scroll, truncate long values, and can't be copied — and these are frequently secrets,
+/// which is the whole reason custom headers exist. Values render in full; nothing in a
+/// `[String: String]` says which value is a credential, so any masking rule would be guesswork.
+struct IntegrationHeadersDetailScreen: View {
+  let headers: [CustomHeaderEntry]
+
+  @EnvironmentObject var theme: ThemeViewModel
+
+  var body: some View {
+    Form {
+      ThemedSection {
+        ForEach(headers) { header in
+          VStack(alignment: .leading, spacing: 4) {
+            Text(header.key)
+              .bpFont(.footnote)
+              .foregroundStyle(theme.secondaryColor)
+            Text(header.value)
+              .bpFont(.body)
+              .foregroundStyle(theme.primaryColor)
+              .textSelection(.enabled)
+          }
+        }
+      } footer: {
+        Text("integration_headers_detail_footer".localized)
+          .foregroundStyle(theme.secondaryColor)
+      }
+    }
+    .applyListStyle(with: theme, background: theme.systemBackgroundColor)
+    .navigationTitle("integration_custom_headers_title".localized)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}
+
+// MARK: - Shared chrome
+
+/// The flow's pinned primary action — filled, full width, bottom of every screen, so the way forward
+/// never moves and never vanishes.
+struct IntegrationFlowPrimaryButton: View {
+  let title: String
+  var isDisabled: Bool = false
+  var action: () -> Void
+
+  @EnvironmentObject var theme: ThemeViewModel
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .bpFont(.headline)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(theme.linkColor)
+        .foregroundColor(.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    .disabledWithOpacity(isDisabled)
+    .padding(.horizontal, Spacing.M)
+    .padding(.bottom, Spacing.S)
+  }
+}

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -212,17 +212,17 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
           HStack {
             Text("integration_address_host_label".localized)
               .foregroundStyle(theme.primaryColor)
+            // The label rides INSIDE the component, scoped to the text field alone. Labelling the
+            // compound from out here propagated "Host" into the clear button as well.
             ClearableTextField(
               hostPlaceholder,
-              text: $address.hostField
+              text: $address.hostField,
+              accessibilityLabel: "integration_address_host_label".localized
             )
             .multilineTextAlignment(.trailing)
             .keyboardType(.URL)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
-            // The row's Text label isn't associated with the field — without this VoiceOver reads
-            // the placeholder hostname as if it were the field's name.
-            .accessibilityLabel(Text("integration_address_host_label".localized))
           }
 
           HStack {

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
@@ -95,10 +95,11 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
           serverName: viewModel.form.serverName,
           serverUrl: viewModel.form.serverUrl
         )
-        IntegrationCustomHeadersSectionView(
-          customHeaders: $viewModel.form.customHeaders,
-          onCommit: { viewModel.handleCustomHeadersUpdate() }
-        )
+        // Read-only: editing lives on the flow's address screen, reached via re-auth or Add Server.
+        // The editable section committed on `onDisappear`, so a form left showing an empty list wrote
+        // that emptiness over the saved connection when the sheet closed — removing the editor deletes
+        // the hazard instead of guarding it.
+        IntegrationHeadersReadOnlySection(headers: viewModel.form.customHeaders)
         IntegrationConnectedView(viewModel: viewModel)
       }
     }

--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionView.swift
@@ -71,9 +71,6 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
             isBusy: isLoading,
             onStart: onStartAlternativeSignIn
           )
-        case .oidcRequiresSecureTransport:
-          // The server does offer SSO — say why we won't, rather than silently omitting it.
-          IntegrationOIDCUnavailableSectionView()
         case .quickConnect:
           IntegrationQuickConnectSectionView(onStart: onStartAlternativeSignIn)
         case nil:
@@ -82,11 +79,9 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
         IntegrationServerFoundView(
           username: $viewModel.form.username,
           password: $viewModel.form.password,
-          // Don't raise the keyboard when an alternative sign-in is actually on offer — it would cover
-          // the option above and presume the user came here to type a password. An explanation-only
-          // state (`.oidcRequiresSecureTransport`) is not an offer: typing is still the only way in,
-          // so the keyboard should come up exactly as it does with no alternative at all.
-          autoFocusesUsername: !(viewModel.alternativeSignIn?.isActionable ?? false),
+          // Don't raise the keyboard when an alternative sign-in is on offer — it would cover the
+          // option above and presume the user came here to type a password.
+          autoFocusesUsername: viewModel.alternativeSignIn == nil,
           onCommit: onSignIn
         )
         IntegrationCustomHeadersSectionView(
@@ -244,12 +239,12 @@ struct IntegrationConnectionView<VM: IntegrationConnectionViewModelProtocol>: Vi
   /// mid-Quick-Connect surface inside that sheet via `quickConnectStatus`; only the synchronous setup
   /// error lands in the alert.
   func onStartAlternativeSignIn() {
-    guard let method = viewModel.alternativeSignIn, method.isActionable else { return }
+    guard let method = viewModel.alternativeSignIn else { return }
     let showsOverlay: Bool
     switch method {
     case .oidc:
       showsOverlay = true
-    case .quickConnect, .oidcRequiresSecureTransport:
+    case .quickConnect:
       showsOverlay = false
     }
     // Routed through `actionTask` like every sibling handler — the property's own doc comment names
@@ -347,20 +342,3 @@ private struct IntegrationOIDCSectionView: View {
   }
 }
 
-/// Shown when the server advertises SSO but the connection is plaintext. Explaining the absence beats
-/// silently hiding an option the user may have come here expecting.
-private struct IntegrationOIDCUnavailableSectionView: View {
-  @EnvironmentObject var theme: ThemeViewModel
-
-  var body: some View {
-    ThemedSection {
-      EmptyView()
-    } header: {
-      Text("integration_sso_section_header".localized)
-        .foregroundStyle(theme.secondaryColor)
-    } footer: {
-      Text("integration_sso_requires_https".localized)
-        .foregroundStyle(theme.secondaryColor)
-    }
-  }
-}

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationConnectionStore.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationConnectionStore.swift
@@ -132,16 +132,23 @@ final class IntegrationConnectionStore<Payload: IntegrationConnectionPayload>: B
   /// outbound references stay valid) and `selectedLibraryId` (kept so the user lands back in the
   /// same library). Construction stays with the caller because only the concrete type knows which
   /// stored property holds its token.
+  /// `replacingID` names the connection a re-authentication started from. When the sign-in lands on
+  /// the same account at a *different* URL — a server that moved host, which self-hosters do
+  /// constantly — the account match finds nothing, and without this the old row would survive as an
+  /// expired orphan next to the new one. The replaced row only matches when its `userID` agrees:
+  /// signing into a different account is genuinely a new connection, not a move.
   @discardableResult
   func upsert(
     url: URL,
     userID: String,
+    replacingID: String? = nil,
     build: (Payload?) -> Payload
   ) -> UpsertResult {
     let replaced = connections.first { $0.isSameAccount(as: url, userID: userID) }
+      ?? connections.first { $0.id == replacingID && $0.userID == userID }
     let saved = build(replaced)
 
-    connections.removeAll { $0.isSameAccount(as: url, userID: userID) }
+    connections.removeAll { $0.isSameAccount(as: url, userID: userID) || $0.id == replaced?.id }
     connections.append(saved)
     setActiveConnectionID(saved.id)
     save()

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
@@ -113,18 +113,51 @@ struct IntegrationServerAddress: Equatable, Sendable {
   // MARK: - The combined host field
 
   /// The host and subpath as one editable string — the design's screen 1 has a single Host row and the
-  /// subpath rides in it (`media.example.com/audiobookshelf`). The setter splits at the first slash;
-  /// IPv6 brackets are safe because they cannot contain one.
+  /// subpath rides in it (`media.example.com/audiobookshelf`).
+  ///
+  /// This setter is where a paste arrives, so it is where decomposition must happen. Deferring it to
+  /// Connect cannot work: splitting a pasted `http://…` at its first slash makes `http:` the host,
+  /// and once that's stored the original URL is unrecoverable — the field showed
+  /// `[http:]//100.81.227.12:13378` and assembled garbage.
   var hostField: String {
     get { host + path }
     set {
-      if let slash = newValue.firstIndex(of: "/") {
-        host = Self.normalizedHost(String(newValue[..<slash]))
-        path = Self.normalizedPath(String(newValue[slash...]))
-      } else {
-        host = Self.normalizedHost(newValue)
-        path = ""
+      // A full URL (pasted, or typed through): distribute across ALL the fields — the scheme
+      // control flips, the port moves to its row, the host keeps only the host and subpath.
+      if newValue.contains("://") {
+        if let pasted = IntegrationServerAddress(parsing: newValue) {
+          self = pasted
+        } else {
+          // Mid-typing through the scheme, or an unparseable paste: hold the raw text so nothing
+          // is mangled or lost. `url` stays nil (a colon-bearing host never assembles), which
+          // keeps Connect disabled until the text resolves into something real.
+          host = newValue
+          path = ""
+        }
+        return
       }
+      // Scheme-less: peel the subpath off first, then a trailing port off the host part —
+      // `host:port` and `host:port/path` are both the mockups' scheme-less paste.
+      var rawHost = newValue
+      var rawPath = ""
+      if let slash = newValue.firstIndex(of: "/") {
+        rawHost = String(newValue[..<slash])
+        rawPath = String(newValue[slash...])
+      }
+      // Exactly one colon with a valid port after it can't be an IPv6 literal (those carry two or
+      // more colons); a bracketed literal announces its port with `]:`.
+      let colonParts = rawHost.split(separator: ":", omittingEmptySubsequences: false)
+      if colonParts.count == 2, let pastedPort = Int(colonParts[1]),
+         (1...65535).contains(pastedPort), !colonParts[0].isEmpty, !colonParts[0].contains("[") {
+        port = pastedPort
+        rawHost = String(colonParts[0])
+      } else if rawHost.hasPrefix("["), let bracket = rawHost.range(of: "]:"),
+                let pastedPort = Int(rawHost[bracket.upperBound...]), (1...65535).contains(pastedPort) {
+        port = pastedPort
+        rawHost = String(rawHost[..<bracket.upperBound].dropLast())
+      }
+      host = Self.normalizedHost(rawHost)
+      path = Self.normalizedPath(rawPath)
     }
   }
 

--- a/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
+++ b/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
@@ -174,6 +174,10 @@ extension IntegrationConnectionViewModelProtocol {
   /// The step Connect lands on: the method chooser when there is a choice to make, otherwise straight
   /// to the password form. A server offering only an alternative still gets the method screen — a
   /// single primary button beats auto-launching a browser the user didn't ask for.
+  ///
+  /// Callers must not route here when NO method can work (SSO-only over plaintext): the
+  /// AudiobookShelf view model fails Connect with `insecureTransport` in that configuration instead,
+  /// so the user lands back on the scheme control rather than on a doomed password form.
   var stepAfterConnect: ConnectionFlowStep {
     alternativeSignIn != nil ? .method : .password
   }

--- a/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
+++ b/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
@@ -123,9 +123,6 @@ protocol IntegrationConnectionViewModelProtocol: ObservableObject {
   /// Cancel adding a new server
   func handleCancelAddServerAction()
 
-  /// Persist any changes made to the custom-headers list while the connection is already live.
-  func handleCustomHeadersUpdate()
-
   /// Put the form into a state the user can actually re-authenticate from, seeded with the saved
   /// connection (URL, name, custom headers).
   ///

--- a/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
+++ b/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
@@ -19,6 +19,17 @@ enum SignInStep {
   case enteringCredentials
 }
 
+/// One pushed screen of the redesigned add-server flow. The address screen is the stack's root, so it
+/// has no case; everything after it is pushed by appending here.
+enum ConnectionFlowStep: Hashable {
+  /// "How do you want to sign in?" — rendered only when an alternative to the password exists.
+  case method
+  /// Username + password form.
+  case password
+  /// Read-only list of the custom headers carried by the pending connection.
+  case headersDetail
+}
+
 enum IntegrationViewMode {
   /// Bound to a live library session; pre-populates form from the active connection.
   case regular
@@ -125,6 +136,18 @@ protocol IntegrationConnectionViewModelProtocol: ObservableObject {
   /// needs `/status`). Without that, an SSO-only user with no password has no way back in.
   func prepareReauth()
 
+  // MARK: - Redesigned flow
+
+  /// Navigation path of the pushed add-server flow; the address screen is the root. Owned by the view
+  /// model so the *decision* of what follows Connect — method chooser, or straight to the password
+  /// form when nothing else exists — is plain testable logic, not view code.
+  var flowPath: [ConnectionFlowStep] { get set }
+
+  /// Whether the validated server accepts username/password sign-in at all. AudiobookShelf admins can
+  /// disable local auth (SSO-only servers); the method screen uses this to decide whether the password
+  /// button exists. Default: true — Jellyfin's core API always accepts it.
+  var supportsPasswordSignIn: Bool { get }
+
   // MARK: - Alternative sign-in
 
   /// What the alternative-sign-in slot offers for the server the user just validated — not merely
@@ -149,6 +172,15 @@ protocol IntegrationConnectionViewModelProtocol: ObservableObject {
 
 /// No-op defaults, so an integration without an alternative sign-in implements none of it.
 extension IntegrationConnectionViewModelProtocol {
+  var supportsPasswordSignIn: Bool { true }
+
+  /// The step Connect lands on: the method chooser when there is a choice to make, otherwise straight
+  /// to the password form. A server offering only an alternative still gets the method screen — a
+  /// single primary button beats auto-launching a browser the user didn't ask for.
+  var stepAfterConnect: ConnectionFlowStep {
+    alternativeSignIn != nil ? .method : .password
+  }
+
   var alternativeSignIn: AlternativeSignInState? { nil }
   var quickConnectStatus: QuickConnectStatus? { nil }
   func handleStartAlternativeSignIn() async throws {}

--- a/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
+++ b/BookPlayer/MediaServerIntegration/IntegrationConnectionViewModelProtocol.swift
@@ -46,25 +46,8 @@ enum AlternativeSignInState: Equatable {
   /// the provider's own button label when the server supplied one; nil falls back to a generic string.
   case oidc(buttonText: String?)
 
-  /// The server advertises SSO but the connection is plaintext, so we refuse to run it — the
-  /// authorization code, PKCE verifier, and returned token all traverse the redirect chain
-  /// (RFC 6749 §10.9). Rendered as an explanation, not a button, so the absence isn't silent.
-  case oidcRequiresSecureTransport
-
   /// Out-of-band code flow (Jellyfin Quick Connect).
   case quickConnect
-
-  /// Whether the state offers something the user can actually start. Drives the username-field
-  /// autofocus: an explanation-only state must not suppress the keyboard the way a real
-  /// alternative does.
-  var isActionable: Bool {
-    switch self {
-    case .oidc, .quickConnect:
-      return true
-    case .oidcRequiresSecureTransport:
-      return false
-    }
-  }
 }
 
 /// Status of an out-of-band code-based authentication flow (Jellyfin Quick Connect).
@@ -146,7 +129,7 @@ protocol IntegrationConnectionViewModelProtocol: ObservableObject {
 
   /// What the alternative-sign-in slot offers for the server the user just validated — not merely
   /// what the integration speaks. Nil when password is the only way in. Default: nil; concrete VMs
-  /// opt in (AudiobookShelf → `.oidc`/`.oidcRequiresSecureTransport`, Jellyfin → `.quickConnect`).
+  /// opt in (AudiobookShelf → `.oidc`, Jellyfin → `.quickConnect`).
   var alternativeSignIn: AlternativeSignInState? { get }
 
   /// Current state of an in-flight Quick Connect flow, or `nil` if none is running. Stays a separate

--- a/BookPlayer/MediaServerIntegration/MediaServersView.swift
+++ b/BookPlayer/MediaServerIntegration/MediaServersView.swift
@@ -45,6 +45,12 @@ struct MediaServersView: View {
   /// one `.sheet(item:)` modifier. Stacking multiple sibling `.sheet(item:)` lets
   /// the second presentation drop silently when state changes happen back-to-back.
   @State private var presentedSheet: SheetRoute?
+
+  /// Which integration finished signing in inside the Add Server sheet. Recorded there and consumed
+  /// in the sheet's `onDismiss`, so the freshly added library presents *after* the dismissal has
+  /// completed — presenting alongside it is the classic present-while-dismissing race, and the
+  /// library sheet would silently never appear.
+  @State private var completedSignInKind: IntegrationKind?
   @State private var editMode: EditMode = .inactive
 
   @EnvironmentObject private var theme: ThemeViewModel
@@ -82,7 +88,15 @@ struct MediaServersView: View {
     }
     .environment(\.editMode, $editMode)
     .tint(theme.linkColor)
-    .sheet(item: $presentedSheet) { route in
+    .sheet(
+      item: $presentedSheet,
+      onDismiss: {
+        if let kind = completedSignInKind {
+          completedSignInKind = nil
+          presentedSheet = .library(kind)
+        }
+      }
+    ) { route in
       switch route {
       case .addServer(let kind):
         addServerSheet(for: kind)
@@ -209,11 +223,15 @@ struct MediaServersView: View {
   private func addServerSheet(for kind: IntegrationKind) -> some View {
     switch kind {
     case .jellyfin:
-      AddServerJellyfinSheet(connectionService: jellyfinService)
-        .environmentObject(theme)
+      AddServerJellyfinSheet(connectionService: jellyfinService) {
+        completedSignInKind = .jellyfin
+      }
+      .environmentObject(theme)
     case .audiobookshelf:
-      AddServerAudiobookShelfSheet(connectionService: audiobookshelfService)
-        .environmentObject(theme)
+      AddServerAudiobookShelfSheet(connectionService: audiobookshelfService) {
+        completedSignInKind = .audiobookshelf
+      }
+      .environmentObject(theme)
     }
   }
 
@@ -298,8 +316,10 @@ private struct ServerRow: Identifiable {
 
 
 // MARK: - Add Server sheets
-// Each wraps `IntegrationConnectionView` with a fresh VM constructed in `.addServer` mode,
-// so its in-flight state is fully isolated from the active library session.
+// Each wraps the pushed flow with a fresh VM constructed in `.addServer` mode, so its in-flight
+// state is fully isolated from the active library session. `onSignedIn` fires BEFORE dismiss so the
+// parent can record which library to present once the dismissal completes — presenting alongside a
+// dismissal is the classic present-while-dismissing race, and the modal silently never appears.
 
 private struct AddServerJellyfinSheet: View {
   let connectionService: JellyfinConnectionService
@@ -307,8 +327,11 @@ private struct AddServerJellyfinSheet: View {
   @EnvironmentObject private var theme: ThemeViewModel
   @Environment(\.dismiss) private var dismiss
 
-  init(connectionService: JellyfinConnectionService) {
+  var onSignedIn: () -> Void
+
+  init(connectionService: JellyfinConnectionService, onSignedIn: @escaping () -> Void) {
     self.connectionService = connectionService
+    self.onSignedIn = onSignedIn
     self._viewModel = .init(
       wrappedValue: JellyfinConnectionViewModel(
         connectionService: connectionService,
@@ -318,15 +341,13 @@ private struct AddServerJellyfinSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
-      IntegrationConnectionView(viewModel: viewModel, integrationName: "Jellyfin")
-        .navigationBarTitleDisplayMode(.inline)
-    }
-    .tint(theme.linkColor)
-    .environmentObject(theme)
-    .onChange(of: viewModel.signInCompletedAt) { _, newValue in
-      if newValue != nil { dismiss() }
-    }
+    IntegrationConnectionFlowView(viewModel: viewModel, integrationName: "Jellyfin")
+      .environmentObject(theme)
+      .onChange(of: viewModel.signInCompletedAt) { _, newValue in
+        guard newValue != nil else { return }
+        onSignedIn()
+        dismiss()
+      }
   }
 }
 
@@ -336,8 +357,11 @@ private struct AddServerAudiobookShelfSheet: View {
   @EnvironmentObject private var theme: ThemeViewModel
   @Environment(\.dismiss) private var dismiss
 
-  init(connectionService: AudiobookShelfConnectionService) {
+  var onSignedIn: () -> Void
+
+  init(connectionService: AudiobookShelfConnectionService, onSignedIn: @escaping () -> Void) {
     self.connectionService = connectionService
+    self.onSignedIn = onSignedIn
     self._viewModel = .init(
       wrappedValue: AudiobookShelfConnectionViewModel(
         connectionService: connectionService,
@@ -347,15 +371,13 @@ private struct AddServerAudiobookShelfSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
-      IntegrationConnectionView(viewModel: viewModel, integrationName: "AudiobookShelf")
-        .navigationBarTitleDisplayMode(.inline)
-    }
-    .tint(theme.linkColor)
-    .environmentObject(theme)
-    .onChange(of: viewModel.signInCompletedAt) { _, newValue in
-      if newValue != nil { dismiss() }
-    }
+    IntegrationConnectionFlowView(viewModel: viewModel, integrationName: "AudiobookShelf")
+      .environmentObject(theme)
+      .onChange(of: viewModel.signInCompletedAt) { _, newValue in
+        guard newValue != nil else { return }
+        onSignedIn()
+        dismiss()
+      }
   }
 }
 

--- a/BookPlayer/MediaServerIntegration/MediaServersView.swift
+++ b/BookPlayer/MediaServerIntegration/MediaServersView.swift
@@ -341,7 +341,7 @@ private struct AddServerJellyfinSheet: View {
   }
 
   var body: some View {
-    IntegrationConnectionFlowView(viewModel: viewModel, integrationName: "Jellyfin")
+    IntegrationConnectionFlowView(viewModel: viewModel, kind: .jellyfin, integrationName: "Jellyfin")
       .environmentObject(theme)
       .onChange(of: viewModel.signInCompletedAt) { _, newValue in
         guard newValue != nil else { return }
@@ -371,7 +371,7 @@ private struct AddServerAudiobookShelfSheet: View {
   }
 
   var body: some View {
-    IntegrationConnectionFlowView(viewModel: viewModel, integrationName: "AudiobookShelf")
+    IntegrationConnectionFlowView(viewModel: viewModel, kind: .audiobookshelf, integrationName: "AudiobookShelf")
       .environmentObject(theme)
       .onChange(of: viewModel.signInCompletedAt) { _, newValue in
         guard newValue != nil else { return }

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "ترتيب الملفات حسب";
 "cancel_button" = "إلغاء";
 "copy_button" = "نسخ";
+"clear_text_button" = "مسح النص";
 "seconds_title" = "ثانية";
 "ok_button" = "موافق";
 "siri_alert_description" = "تتوفر اختصارات Siri في نظام التشغيل iOS 12 والإصدارات الأحدث";

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "ترتيب الملفات حسب";
 "cancel_button" = "إلغاء";
 "copy_button" = "نسخ";
-"clear_text_button" = "مسح النص";
 "seconds_title" = "ثانية";
 "ok_button" = "موافق";
 "siri_alert_description" = "تتوفر اختصارات Siri في نظام التشغيل iOS 12 والإصدارات الأحدث";

--- a/BookPlayer/ar.lproj/Localizable.strings
+++ b/BookPlayer/ar.lproj/Localizable.strings
@@ -378,6 +378,12 @@
 "integration_custom_headers_key_placeholder" = "اسم الرأس";
 "integration_custom_headers_value_placeholder" = "قيمة الرأس";
 "integration_custom_headers_add_button" = "إضافة رأس";
+"integration_address_scheme_label" = "نوع الاتصال";
+"integration_address_host_label" = "المضيف";
+"integration_address_port_label" = "المنفذ";
+"integration_server_section_header" = "الخادم";
+"integration_password_signin_button" = "اسم المستخدم وكلمة المرور";
+"integration_headers_detail_footer" = "تُرفق هذه الرؤوس بكل طلب يُرسل إلى هذا الخادم. ويمكن تعديلها من شاشة عنوان الخادم.";
 "settings_integration_manage_connection_title" = "إدارة الاتصال";
 "integration_internal_error_invalid_url" = "خطأ داخلي: عنوان URL للطلب غير صالح: %@";
 "integration_internal_error_build_url" = "خطأ داخلي: فشل في بناء عنوان URL للطلب";

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Ordena els elements per";
 "cancel_button" = "Cancel·la";
 "copy_button" = "Copia";
-"clear_text_button" = "Esborra el text";
 "seconds_title" = "seg";
 "ok_button" = "D'acord";
 "siri_alert_description" = "Les dreceres de Siri estan disponibles a iOS 12 i posteriors";

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -378,6 +378,12 @@ Estem treballant dur per oferir una experiència perfecta; si és possible, pose
 "integration_custom_headers_key_placeholder" = "Nom de la capçalera";
 "integration_custom_headers_value_placeholder" = "Valor de la capçalera";
 "integration_custom_headers_add_button" = "Afegir capçalera";
+"integration_address_scheme_label" = "Tipus de connexió";
+"integration_address_host_label" = "Amfitrió";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Servidor";
+"integration_password_signin_button" = "Nom d'usuari i contrasenya";
+"integration_headers_detail_footer" = "Aquestes capçaleres s'adjunten a cada petició enviada a aquest servidor. Es poden editar des de la pantalla d'adreça del servidor.";
 "settings_integration_manage_connection_title" = "Gestionar la connexió";
 "integration_internal_error_invalid_url" = "Error intern: l'URL de sol·licitud no és vàlid: %@";
 "integration_internal_error_build_url" = "Error intern: no s'ha pogut crear l'URL de la sol·licitud";

--- a/BookPlayer/ca.lproj/Localizable.strings
+++ b/BookPlayer/ca.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Ordena els elements per";
 "cancel_button" = "Cancel·la";
 "copy_button" = "Copia";
+"clear_text_button" = "Esborra el text";
 "seconds_title" = "seg";
 "ok_button" = "D'acord";
 "siri_alert_description" = "Les dreceres de Siri estan disponibles a iOS 12 i posteriors";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Název hlavičky";
 "integration_custom_headers_value_placeholder" = "Hodnota hlavičky";
 "integration_custom_headers_add_button" = "Přidat hlavičku";
+"integration_address_scheme_label" = "Typ připojení";
+"integration_address_host_label" = "Hostitel";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Uživatelské jméno a heslo";
+"integration_headers_detail_footer" = "Tyto hlavičky se připojí ke každému požadavku odeslanému na tento server. Lze je upravit na obrazovce s adresou serveru.";
 "settings_integration_manage_connection_title" = "Správa připojení";
 "integration_internal_error_invalid_url" = "Interní chyba: Adresa URL požadavku je neplatná: %@";
 "integration_internal_error_build_url" = "Interní chyba: Nepodařilo se vytvořit adresu URL požadavku";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Seřadit položky podle";
 "cancel_button" = "Zrušit";
 "copy_button" = "Kopírovat";
+"clear_text_button" = "Smazat text";
 "seconds_title" = "sekund";
 "ok_button" = "OK";
 "siri_alert_description" = "Zkratky pro Siri jsou k dispozici v iOS 12 a vyšším";

--- a/BookPlayer/cs.lproj/Localizable.strings
+++ b/BookPlayer/cs.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Seřadit položky podle";
 "cancel_button" = "Zrušit";
 "copy_button" = "Kopírovat";
-"clear_text_button" = "Smazat text";
 "seconds_title" = "sekund";
 "ok_button" = "OK";
 "siri_alert_description" = "Zkratky pro Siri jsou k dispozici v iOS 12 a vyšším";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sortér efter";
 "cancel_button" = "Annuller";
 "copy_button" = "Kopiér";
+"clear_text_button" = "Ryd tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-genveje er tilgængelige på iOS 12 og opefter";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Header-navn";
 "integration_custom_headers_value_placeholder" = "Header-værdi";
 "integration_custom_headers_add_button" = "Tilføj header";
+"integration_address_scheme_label" = "Forbindelsestype";
+"integration_address_host_label" = "Vært";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Brugernavn og adgangskode";
+"integration_headers_detail_footer" = "Disse headers vedhæftes til hver anmodning, der sendes til denne server. De kan redigeres fra skærmen med serveradressen.";
 "settings_integration_manage_connection_title" = "Administrer forbindelse";
 "integration_internal_error_invalid_url" = "Intern fejl: Anmodnings-URL er ugyldig: %@";
 "integration_internal_error_build_url" = "Intern fejl: Forespørgsels-URL kunne ikke oprettes";

--- a/BookPlayer/da.lproj/Localizable.strings
+++ b/BookPlayer/da.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sortér efter";
 "cancel_button" = "Annuller";
 "copy_button" = "Kopiér";
-"clear_text_button" = "Ryd tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-genveje er tilgængelige på iOS 12 og opefter";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Liste sortieren";
 "cancel_button" = "Abbrechen";
 "copy_button" = "Kopieren";
-"clear_text_button" = "Text löschen";
 "seconds_title" = "s";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Kurzbefehle sind erst ab iOS 12 verfügbar.";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Liste sortieren";
 "cancel_button" = "Abbrechen";
 "copy_button" = "Kopieren";
+"clear_text_button" = "Text löschen";
 "seconds_title" = "s";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Kurzbefehle sind erst ab iOS 12 verfügbar.";

--- a/BookPlayer/de.lproj/Localizable.strings
+++ b/BookPlayer/de.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Header-Name";
 "integration_custom_headers_value_placeholder" = "Header-Wert";
 "integration_custom_headers_add_button" = "Header hinzufügen";
+"integration_address_scheme_label" = "Verbindungstyp";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Benutzername und Passwort";
+"integration_headers_detail_footer" = "Diese Header werden an jede Anfrage an diesen Server angehängt. Sie können im Bildschirm für die Serveradresse bearbeitet werden.";
 "settings_integration_manage_connection_title" = "Verbindung verwalten";
 "integration_internal_error_invalid_url" = "Interner Fehler: Anforderungs-URL ist ungültig: %@";
 "integration_internal_error_build_url" = "Interner Fehler: Anforderungs-URL konnte nicht erstellt werden";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -378,6 +378,12 @@
 "integration_custom_headers_key_placeholder" = "Όνομα κεφαλίδας";
 "integration_custom_headers_value_placeholder" = "Τιμή κεφαλίδας";
 "integration_custom_headers_add_button" = "Προσθήκη κεφαλίδας";
+"integration_address_scheme_label" = "Τύπος σύνδεσης";
+"integration_address_host_label" = "Κεντρικός υπολογιστής";
+"integration_address_port_label" = "Θύρα";
+"integration_server_section_header" = "Υπηρέτης";
+"integration_password_signin_button" = "Όνομα χρήστη και σύνθημα";
+"integration_headers_detail_footer" = "Αυτές οι κεφαλίδες επισυνάπτονται σε κάθε αίτημα που αποστέλλεται σε αυτόν τον διακομιστή. Μπορούν να τροποποιηθούν από την οθόνη διεύθυνσης του διακομιστή.";
 "settings_integration_manage_connection_title" = "Διαχείριση σύνδεσης";
 "integration_internal_error_invalid_url" = "Εσωτερικό σφάλμα: Η διεύθυνση URL αιτήματος δεν είναι έγκυρη: %@";
 "integration_internal_error_build_url" = "Εσωτερικό σφάλμα: Απέτυχε η δημιουργία διεύθυνσης URL αιτήματος";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Ταξινόμηση αντικειμένων κατά";
 "cancel_button" = "Ματαίωση";
 "copy_button" = "Αντιγραφή";
-"clear_text_button" = "Διαγραφή κειμένου";
 "seconds_title" = "δευτ";
 "ok_button" = "Εντάξει";
 "siri_alert_description" = "Οι συντομεύσεις Siri είναι διαθέσιμες σε iOS 12 και νεότερη έκδοση";

--- a/BookPlayer/el.lproj/Localizable.strings
+++ b/BookPlayer/el.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Ταξινόμηση αντικειμένων κατά";
 "cancel_button" = "Ματαίωση";
 "copy_button" = "Αντιγραφή";
+"clear_text_button" = "Διαγραφή κειμένου";
 "seconds_title" = "δευτ";
 "ok_button" = "Εντάξει";
 "siri_alert_description" = "Οι συντομεύσεις Siri είναι διαθέσιμες σε iOS 12 και νεότερη έκδοση";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sort Items by";
 "cancel_button" = "Cancel";
 "copy_button" = "Copy";
+"clear_text_button" = "Clear text";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Shortcuts are available on iOS 12 and above";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sort Items by";
 "cancel_button" = "Cancel";
 "copy_button" = "Copy";
-"clear_text_button" = "Clear text";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri Shortcuts are available on iOS 12 and above";

--- a/BookPlayer/en.lproj/Localizable.strings
+++ b/BookPlayer/en.lproj/Localizable.strings
@@ -380,6 +380,12 @@ We're working hard on providing a seamless experience, if possible, please conta
 "integration_custom_headers_key_placeholder" = "Header name";
 "integration_custom_headers_value_placeholder" = "Header value";
 "integration_custom_headers_add_button" = "Add Header";
+"integration_address_scheme_label" = "Connection type";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Username & Password";
+"integration_headers_detail_footer" = "These headers are attached to every request sent to this server. They can be edited from the server address screen.";
 "settings_integration_manage_connection_title" = "Manage Connection";
 "integration_internal_error_invalid_url" = "Internal error: Request URL is invalid: %@";
 "integration_internal_error_build_url" = "Internal error: Failed to build request URL";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Ordenar Elementos por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
+"clear_text_button" = "Borrar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Los atajos de Siri están disponibles desde iOS 12 en adelante";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nombre del encabezado";
 "integration_custom_headers_value_placeholder" = "Valor del encabezado";
 "integration_custom_headers_add_button" = "Añadir encabezado";
+"integration_address_scheme_label" = "Tipo de conexión";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Puerto";
+"integration_server_section_header" = "Servidor";
+"integration_password_signin_button" = "Nombre de usuario y contraseña";
+"integration_headers_detail_footer" = "Estos encabezados se adjuntan a cada solicitud enviada a este servidor. Se pueden editar desde la pantalla de dirección del servidor.";
 "settings_integration_manage_connection_title" = "Administrar conexión";
 "integration_internal_error_invalid_url" = "Error interno: La URL de solicitud no es válida: %@";
 "integration_internal_error_build_url" = "Error interno: No se pudo crear la URL de solicitud";

--- a/BookPlayer/es.lproj/Localizable.strings
+++ b/BookPlayer/es.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Ordenar Elementos por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
-"clear_text_button" = "Borrar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Los atajos de Siri están disponibles desde iOS 12 en adelante";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Lajittele kohteet seuraavan mukaan";
 "cancel_button" = "Peruuta";
 "copy_button" = "Kopioi";
+"clear_text_button" = "Tyhjennä teksti";
 "seconds_title" = "sekunteja";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-pikakuvakkeet ovat saatavilla iOS 12:ssa ja uudemmissa";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Otsakkeen nimi";
 "integration_custom_headers_value_placeholder" = "Otsakkeen arvo";
 "integration_custom_headers_add_button" = "Lisää otsake";
+"integration_address_scheme_label" = "Yhteystyyppi";
+"integration_address_host_label" = "Isäntä";
+"integration_address_port_label" = "Portti";
+"integration_server_section_header" = "Palvelin";
+"integration_password_signin_button" = "Käyttäjätunnus ja salasana";
+"integration_headers_detail_footer" = "Nämä otsakkeet liitetään jokaiseen tälle palvelimelle lähetettävään pyyntöön. Niitä voi muokata palvelimen osoitenäytöllä.";
 "settings_integration_manage_connection_title" = "Hallitse yhteyttä";
 "integration_internal_error_invalid_url" = "Sisäinen virhe: Pyynnön URL-osoite on virheellinen: %@";
 "integration_internal_error_build_url" = "Sisäinen virhe: Pyynnön URL-osoitteen luominen epäonnistui";

--- a/BookPlayer/fi.lproj/Localizable.strings
+++ b/BookPlayer/fi.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Lajittele kohteet seuraavan mukaan";
 "cancel_button" = "Peruuta";
 "copy_button" = "Kopioi";
-"clear_text_button" = "Tyhjennä teksti";
 "seconds_title" = "sekunteja";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-pikakuvakkeet ovat saatavilla iOS 12:ssa ja uudemmissa";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Trier les éléments par";
 "cancel_button" = "Annuler";
 "copy_button" = "Copier";
-"clear_text_button" = "Effacer le texte";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Les raccourcis Siri sont disponibles sur iOS 12 et supérieur";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Trier les éléments par";
 "cancel_button" = "Annuler";
 "copy_button" = "Copier";
+"clear_text_button" = "Effacer le texte";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Les raccourcis Siri sont disponibles sur iOS 12 et supérieur";

--- a/BookPlayer/fr.lproj/Localizable.strings
+++ b/BookPlayer/fr.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nom de l'en-tête";
 "integration_custom_headers_value_placeholder" = "Valeur de l'en-tête";
 "integration_custom_headers_add_button" = "Ajouter un en-tête";
+"integration_address_scheme_label" = "Type de connexion";
+"integration_address_host_label" = "Hôte";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Serveur";
+"integration_password_signin_button" = "Nom d'utilisateur et mot de passe";
+"integration_headers_detail_footer" = "Ces en-têtes sont joints à chaque requête envoyée à ce serveur. Ils peuvent être modifiés depuis l'écran d'adresse du serveur.";
 "settings_integration_manage_connection_title" = "Gérer la connexion";
 "integration_internal_error_invalid_url" = "Erreur interne : l'URL de la demande n'est pas valide : %@";
 "integration_internal_error_build_url" = "Erreur interne : échec de la création de l'URL de la demande";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Elemek rendezése";
 "cancel_button" = "Mégsem";
 "copy_button" = "Másolás";
+"clear_text_button" = "Szöveg törlése";
 "seconds_title" = "mp";
 "ok_button" = "OK";
 "siri_alert_description" = "A Siri-parancsok iOS 12-es vagy újabb verziókon érhetőek el";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Elemek rendezése";
 "cancel_button" = "Mégsem";
 "copy_button" = "Másolás";
-"clear_text_button" = "Szöveg törlése";
 "seconds_title" = "mp";
 "ok_button" = "OK";
 "siri_alert_description" = "A Siri-parancsok iOS 12-es vagy újabb verziókon érhetőek el";

--- a/BookPlayer/hu.lproj/Localizable.strings
+++ b/BookPlayer/hu.lproj/Localizable.strings
@@ -378,6 +378,12 @@
 "integration_custom_headers_key_placeholder" = "Fejléc neve";
 "integration_custom_headers_value_placeholder" = "Fejléc értéke";
 "integration_custom_headers_add_button" = "Fejléc hozzáadása";
+"integration_address_scheme_label" = "Kapcsolat típusa";
+"integration_address_host_label" = "Gazdagép";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Szerver";
+"integration_password_signin_button" = "Felhasználónév és jelszó";
+"integration_headers_detail_footer" = "Ezek a fejlécek minden, erre a kiszolgálóra küldött kéréshez csatolódnak. A kiszolgáló címét tartalmazó képernyőn szerkeszthetők.";
 "settings_integration_manage_connection_title" = "Kapcsolat kezelése";
 "integration_internal_error_invalid_url" = "Belső hiba: A kérés URL-je érvénytelen: %@";
 "integration_internal_error_build_url" = "Belső hiba: Nem sikerült létrehozni a kérés URL-jét";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Ordina elementi per";
 "cancel_button" = "Cancella";
 "copy_button" = "Copia";
+"clear_text_button" = "Cancella testo";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Le Shortcuts di Siri sono disponibili da iOS 12 in su";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nome intestazione";
 "integration_custom_headers_value_placeholder" = "Valore intestazione";
 "integration_custom_headers_add_button" = "Aggiungi intestazione";
+"integration_address_scheme_label" = "Tipo di connessione";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Porta";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Nome utente e password";
+"integration_headers_detail_footer" = "Queste intestazioni vengono allegate a ogni richiesta inviata a questo server. Possono essere modificate dalla schermata dell'indirizzo del server.";
 "settings_integration_manage_connection_title" = "Gestisci connessione";
 "integration_internal_error_invalid_url" = "Errore interno: l'URL della richiesta non è valido: %@";
 "integration_internal_error_build_url" = "Errore interno: Impossibile creare l'URL della richiesta";

--- a/BookPlayer/it.lproj/Localizable.strings
+++ b/BookPlayer/it.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Ordina elementi per";
 "cancel_button" = "Cancella";
 "copy_button" = "Copia";
-"clear_text_button" = "Cancella testo";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Le Shortcuts di Siri sono disponibili da iOS 12 in su";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "項目の並び替え";
 "cancel_button" = "キャンセル";
 "copy_button" = "コピー";
-"clear_text_button" = "テキストを消去";
 "seconds_title" = "秒";
 "ok_button" = "OK";
 "siri_alert_description" = "SiriショートカットはiOS 12以降でご利用いただけます。";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -378,6 +378,12 @@
 "integration_custom_headers_key_placeholder" = "ヘッダー名";
 "integration_custom_headers_value_placeholder" = "ヘッダーの値";
 "integration_custom_headers_add_button" = "ヘッダーを追加";
+"integration_address_scheme_label" = "接続タイプ";
+"integration_address_host_label" = "ホスト";
+"integration_address_port_label" = "ポート";
+"integration_server_section_header" = "サーバ";
+"integration_password_signin_button" = "ユーザ名とパスワード";
+"integration_headers_detail_footer" = "これらのヘッダーは、このサーバーへのすべてのリクエストに付加されます。サーバーアドレス画面で編集できます。";
 "settings_integration_manage_connection_title" = "接続を管理";
 "integration_internal_error_invalid_url" = "内部エラー: リクエストURLが無効です: %@";
 "integration_internal_error_build_url" = "内部エラー: リクエストURLの構築に失敗しました";

--- a/BookPlayer/ja.lproj/Localizable.strings
+++ b/BookPlayer/ja.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "項目の並び替え";
 "cancel_button" = "キャンセル";
 "copy_button" = "コピー";
+"clear_text_button" = "テキストを消去";
 "seconds_title" = "秒";
 "ok_button" = "OK";
 "siri_alert_description" = "SiriショートカットはiOS 12以降でご利用いただけます。";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -377,6 +377,12 @@ Vi jobber hardt for å gi deg en sømløs opplevelse. Hvis mulig, kontakt oss p�
 "integration_custom_headers_key_placeholder" = "Header-navn";
 "integration_custom_headers_value_placeholder" = "Header-verdi";
 "integration_custom_headers_add_button" = "Legg til header";
+"integration_address_scheme_label" = "Tilkoblingstype";
+"integration_address_host_label" = "Vert";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Brukernavn og passord";
+"integration_headers_detail_footer" = "Disse headerne vedlegges hver forespørsel som sendes til denne serveren. De kan redigeres fra skjermen for serveradressen.";
 "settings_integration_manage_connection_title" = "Administrer tilkobling";
 "integration_internal_error_invalid_url" = "Intern feil: Forespørsels-URL er ugyldig: %@";
 "integration_internal_error_build_url" = "Intern feil: Kunne ikke lage forespørsels-URL";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sorter elementer etter";
 "cancel_button" = "Avbryt";
 "copy_button" = "Kopier";
+"clear_text_button" = "Fjern tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-snarveier er tilgjengelige på iOS 12 og nyere";

--- a/BookPlayer/nb.lproj/Localizable.strings
+++ b/BookPlayer/nb.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sorter elementer etter";
 "cancel_button" = "Avbryt";
 "copy_button" = "Kopier";
-"clear_text_button" = "Fjern tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-snarveier er tilgjengelige på iOS 12 og nyere";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Artikelen sorteren op";
 "cancel_button" = "Annuleren";
 "copy_button" = "Kopiëren";
+"clear_text_button" = "Tekst wissen";
 "seconds_title" = "sec";
 "ok_button" = "Oké";
 "siri_alert_description" = "Siri-snelkoppelingen zijn beschikbaar op iOS 12 en hoger";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Artikelen sorteren op";
 "cancel_button" = "Annuleren";
 "copy_button" = "Kopiëren";
-"clear_text_button" = "Tekst wissen";
 "seconds_title" = "sec";
 "ok_button" = "Oké";
 "siri_alert_description" = "Siri-snelkoppelingen zijn beschikbaar op iOS 12 en hoger";

--- a/BookPlayer/nl.lproj/Localizable.strings
+++ b/BookPlayer/nl.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Headernaam";
 "integration_custom_headers_value_placeholder" = "Headerwaarde";
 "integration_custom_headers_add_button" = "Header toevoegen";
+"integration_address_scheme_label" = "Verbindingstype";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Poort";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Gebruikersnaam en wachtwoord";
+"integration_headers_detail_footer" = "Deze headers worden bij elk verzoek naar deze server meegestuurd. Ze kunnen worden bewerkt via het scherm met het serveradres.";
 "settings_integration_manage_connection_title" = "Verbinding beheren";
 "integration_internal_error_invalid_url" = "Interne fout: Verzoek-URL is ongeldig: %@";
 "integration_internal_error_build_url" = "Interne fout: het is niet gelukt om de URL van het verzoek te bouwen";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sortuj elementy według";
 "cancel_button" = "Anuluj";
 "copy_button" = "Kopiuj";
-"clear_text_button" = "Wyczyść tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Skróty Siri są dostępne w systemie iOS 12 i nowszym";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sortuj elementy według";
 "cancel_button" = "Anuluj";
 "copy_button" = "Kopiuj";
+"clear_text_button" = "Wyczyść tekst";
 "seconds_title" = "sek";
 "ok_button" = "OK";
 "siri_alert_description" = "Skróty Siri są dostępne w systemie iOS 12 i nowszym";

--- a/BookPlayer/pl.lproj/Localizable.strings
+++ b/BookPlayer/pl.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nazwa nagłówka";
 "integration_custom_headers_value_placeholder" = "Wartość nagłówka";
 "integration_custom_headers_add_button" = "Dodaj nagłówek";
+"integration_address_scheme_label" = "Typ połączenia";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Serwer";
+"integration_password_signin_button" = "Nazwa użytkownika i hasło";
+"integration_headers_detail_footer" = "Te nagłówki są dołączane do każdego żądania wysyłanego do tego serwera. Można je edytować na ekranie adresu serwera.";
 "settings_integration_manage_connection_title" = "Zarządzaj połączeniem";
 "integration_internal_error_invalid_url" = "Błąd wewnętrzny: Adres URL żądania jest nieprawidłowy: %@";
 "integration_internal_error_build_url" = "Błąd wewnętrzny: Nie udało się zbudować adresu URL żądania";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Classificar itens por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
-"clear_text_button" = "Apagar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Os atalhos da Siri estão disponíveis no iOS 12 e superior";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nome do cabeçalho";
 "integration_custom_headers_value_placeholder" = "Valor do cabeçalho";
 "integration_custom_headers_add_button" = "Adicionar cabeçalho";
+"integration_address_scheme_label" = "Tipo de conexão";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Porta";
+"integration_server_section_header" = "Servidor";
+"integration_password_signin_button" = "Nome de usuário e senha";
+"integration_headers_detail_footer" = "Estes cabeçalhos são anexados a cada requisição enviada a este servidor. Podem ser editados na tela de endereço do servidor.";
 "settings_integration_manage_connection_title" = "Gerenciar conexão";
 "integration_internal_error_invalid_url" = "Erro interno: URL da solicitação é inválida: %@";
 "integration_internal_error_build_url" = "Erro interno: Falha ao criar URL de solicitação";

--- a/BookPlayer/pt-BR.lproj/Localizable.strings
+++ b/BookPlayer/pt-BR.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Classificar itens por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
+"clear_text_button" = "Apagar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Os atalhos da Siri estão disponíveis no iOS 12 e superior";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Classificar itens por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
+"clear_text_button" = "Apagar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Os atalhos da Siri só estão disponíveis no iOS 12 e posterior";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Classificar itens por";
 "cancel_button" = "Cancelar";
 "copy_button" = "Copiar";
-"clear_text_button" = "Apagar texto";
 "seconds_title" = "seg";
 "ok_button" = "OK";
 "siri_alert_description" = "Os atalhos da Siri só estão disponíveis no iOS 12 e posterior";

--- a/BookPlayer/pt-PT.lproj/Localizable.strings
+++ b/BookPlayer/pt-PT.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Nome do cabeçalho";
 "integration_custom_headers_value_placeholder" = "Valor do cabeçalho";
 "integration_custom_headers_add_button" = "Adicionar cabeçalho";
+"integration_address_scheme_label" = "Tipo de ligação";
+"integration_address_host_label" = "Host";
+"integration_address_port_label" = "Porta";
+"integration_server_section_header" = "Servidor";
+"integration_password_signin_button" = "Nome de usuário e senha";
+"integration_headers_detail_footer" = "Estes cabeçalhos são anexados a cada pedido enviado para este servidor. Podem ser editados no ecrã de endereço do servidor.";
 "settings_integration_manage_connection_title" = "Gerenciar conexão";
 "integration_internal_error_invalid_url" = "Erro interno: URL da solicitação é inválida: %@";
 "integration_internal_error_build_url" = "Erro interno: Falha ao criar URL de solicitação";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sortează articolele după";
 "cancel_button" = "Anulare";
 "copy_button" = "Copiază";
+"clear_text_button" = "Ștergeți textul";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Comenzile rapide de la Siri sunt disponibile pe iOS 12 și versiuni ulterioare";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Numele antetului";
 "integration_custom_headers_value_placeholder" = "Valoarea antetului";
 "integration_custom_headers_add_button" = "Adaugă antet";
+"integration_address_scheme_label" = "Tip de conexiune";
+"integration_address_host_label" = "Gazdă";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Nume de utilizator și parolă";
+"integration_headers_detail_footer" = "Aceste anteturi sunt atașate fiecărei solicitări trimise către acest server. Pot fi editate din ecranul cu adresa serverului.";
 "settings_integration_manage_connection_title" = "Gestionați conexiunea";
 "integration_internal_error_invalid_url" = "Eroare internă: adresa URL a solicitării este nevalidă: %@";
 "integration_internal_error_build_url" = "Eroare internă: nu s-a putut crea adresa URL a solicitării";

--- a/BookPlayer/ro.lproj/Localizable.strings
+++ b/BookPlayer/ro.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sortează articolele după";
 "cancel_button" = "Anulare";
 "copy_button" = "Copiază";
-"clear_text_button" = "Ștergeți textul";
 "seconds_title" = "sec";
 "ok_button" = "OK";
 "siri_alert_description" = "Comenzile rapide de la Siri sunt disponibile pe iOS 12 și versiuni ulterioare";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Сортировать по";
 "cancel_button" = "Отмена";
 "copy_button" = "Копировать";
-"clear_text_button" = "Очистить текст";
 "seconds_title" = "сек";
 "ok_button" = "OK";
 "siri_alert_description" = "Быстрые команды Siri доступны на iOS 12 и выше";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Имя заголовка";
 "integration_custom_headers_value_placeholder" = "Значение заголовка";
 "integration_custom_headers_add_button" = "Добавить заголовок";
+"integration_address_scheme_label" = "Тип соединения";
+"integration_address_host_label" = "Хост";
+"integration_address_port_label" = "Порт";
+"integration_server_section_header" = "Сервер";
+"integration_password_signin_button" = "Имя пользователя и пароль";
+"integration_headers_detail_footer" = "Эти заголовки прикрепляются к каждому запросу, отправляемому на этот сервер. Их можно изменить на экране адреса сервера.";
 "settings_integration_manage_connection_title" = "Управление соединением";
 "integration_internal_error_invalid_url" = "Внутренняя ошибка: недопустимый URL-адрес запроса: %@";
 "integration_internal_error_build_url" = "Внутренняя ошибка: не удалось создать URL-адрес запроса";

--- a/BookPlayer/ru.lproj/Localizable.strings
+++ b/BookPlayer/ru.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Сортировать по";
 "cancel_button" = "Отмена";
 "copy_button" = "Копировать";
+"clear_text_button" = "Очистить текст";
 "seconds_title" = "сек";
 "ok_button" = "OK";
 "siri_alert_description" = "Быстрые команды Siri доступны на iOS 12 и выше";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Zoradiť položky podľa";
 "cancel_button" = "Zrušiť";
 "copy_button" = "Kopírovať";
+"clear_text_button" = "Vymazať text";
 "seconds_title" = "sek.";
 "ok_button" = "OK";
 "siri_alert_description" = "Skratky pre Siri sú k dispozícii v iOS 12 a vyššom";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Zoradiť položky podľa";
 "cancel_button" = "Zrušiť";
 "copy_button" = "Kopírovať";
-"clear_text_button" = "Vymazať text";
 "seconds_title" = "sek.";
 "ok_button" = "OK";
 "siri_alert_description" = "Skratky pre Siri sú k dispozícii v iOS 12 a vyššom";

--- a/BookPlayer/sk-SK.lproj/Localizable.strings
+++ b/BookPlayer/sk-SK.lproj/Localizable.strings
@@ -378,6 +378,12 @@ Usilovne pracujeme na poskytovaní bezproblémového zážitku, ak je to možné
 "integration_custom_headers_key_placeholder" = "Názov hlavičky";
 "integration_custom_headers_value_placeholder" = "Hodnota hlavičky";
 "integration_custom_headers_add_button" = "Pridať hlavičku";
+"integration_address_scheme_label" = "Typ pripojenia";
+"integration_address_host_label" = "Hostiteľ";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Používateľské meno a heslo";
+"integration_headers_detail_footer" = "Tieto hlavičky sa pripoja ku každej požiadavke odoslanej na tento server. Môžete ich upraviť na obrazovke s adresou servera.";
 "settings_integration_manage_connection_title" = "Správa pripojenia";
 "integration_internal_error_invalid_url" = "Interná chyba: URL požiadavky je neplatná: %@";
 "integration_internal_error_build_url" = "Interná chyba: Nepodarilo sa vytvoriť adresu URL požiadavky";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Headernamn";
 "integration_custom_headers_value_placeholder" = "Headervärde";
 "integration_custom_headers_add_button" = "Lägg till header";
+"integration_address_scheme_label" = "Anslutningstyp";
+"integration_address_host_label" = "Värd";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Server";
+"integration_password_signin_button" = "Användarnamn och lösenord";
+"integration_headers_detail_footer" = "Dessa headrar bifogas varje förfrågan som skickas till denna server. De kan redigeras från skärmen för serveradressen.";
 "settings_integration_manage_connection_title" = "Hantera anslutning";
 "integration_internal_error_invalid_url" = "Internt fel: URL för begäran är ogiltig: %@";
 "integration_internal_error_build_url" = "Internt fel: Det gick inte att skapa webbadress för begäran";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Sortera filer efter";
 "cancel_button" = "Avbryt";
 "copy_button" = "Kopiera";
+"clear_text_button" = "Radera text";
 "seconds_title" = "s";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-genvägar är tillgängliga på iOS 12 och högre";

--- a/BookPlayer/sv.lproj/Localizable.strings
+++ b/BookPlayer/sv.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Sortera filer efter";
 "cancel_button" = "Avbryt";
 "copy_button" = "Kopiera";
-"clear_text_button" = "Radera text";
 "seconds_title" = "s";
 "ok_button" = "OK";
 "siri_alert_description" = "Siri-genvägar är tillgängliga på iOS 12 och högre";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Öğeleri Sıralama Ölçütü";
 "cancel_button" = "İptal";
 "copy_button" = "Kopyala";
-"clear_text_button" = "Metni sil";
 "seconds_title" = "sn";
 "ok_button" = "Tamam";
 "siri_alert_description" = "Siri Kısayolları iOS 12 ve sonraki İOS sürümlerinde kullanılabilir";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Öğeleri Sıralama Ölçütü";
 "cancel_button" = "İptal";
 "copy_button" = "Kopyala";
+"clear_text_button" = "Metni sil";
 "seconds_title" = "sn";
 "ok_button" = "Tamam";
 "siri_alert_description" = "Siri Kısayolları iOS 12 ve sonraki İOS sürümlerinde kullanılabilir";

--- a/BookPlayer/tr.lproj/Localizable.strings
+++ b/BookPlayer/tr.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Başlık adı";
 "integration_custom_headers_value_placeholder" = "Başlık değeri";
 "integration_custom_headers_add_button" = "Başlık ekle";
+"integration_address_scheme_label" = "Bağlantı türü";
+"integration_address_host_label" = "Ana makine";
+"integration_address_port_label" = "Port";
+"integration_server_section_header" = "Sunucu";
+"integration_password_signin_button" = "Kullanıcı adı ve şifre";
+"integration_headers_detail_footer" = "Bu başlıklar bu sunucuya gönderilen her isteğe eklenir. Sunucu adresi ekranından düzenlenebilirler.";
 "settings_integration_manage_connection_title" = "Bağlantıyı Yönet";
 "integration_internal_error_invalid_url" = "Dahili hata: İstek URL'si geçersiz: %@";
 "integration_internal_error_build_url" = "Dahili hata: İstek URL'si oluşturulamadı";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "Назва заголовка";
 "integration_custom_headers_value_placeholder" = "Значення заголовка";
 "integration_custom_headers_add_button" = "Додати заголовок";
+"integration_address_scheme_label" = "Тип підключення";
+"integration_address_host_label" = "Хост";
+"integration_address_port_label" = "Порт";
+"integration_server_section_header" = "Сервер";
+"integration_password_signin_button" = "Ім'я користувача і пароль";
+"integration_headers_detail_footer" = "Ці заголовки додаються до кожного запиту, який надсилається на цей сервер. Їх можна змінити на екрані адреси сервера.";
 "settings_integration_manage_connection_title" = "Керувати підключенням";
 "integration_internal_error_invalid_url" = "Внутрішня помилка: URL-адреса запиту недійсна: %@";
 "integration_internal_error_build_url" = "Внутрішня помилка: не вдалося створити URL-адресу запиту";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "Відсортувати за";
 "cancel_button" = "Скасувати";
 "copy_button" = "Копіювати";
+"clear_text_button" = "Очистити текст";
 "seconds_title" = "сек";
 "ok_button" = "Гаразд";
 "siri_alert_description" = "Команди Siri доступні для iOS 12 і вище";

--- a/BookPlayer/uk.lproj/Localizable.strings
+++ b/BookPlayer/uk.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "Відсортувати за";
 "cancel_button" = "Скасувати";
 "copy_button" = "Копіювати";
-"clear_text_button" = "Очистити текст";
 "seconds_title" = "сек";
 "ok_button" = "Гаразд";
 "siri_alert_description" = "Команди Siri доступні для iOS 12 і вище";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "sort_title" = "排序依据";
 "cancel_button" = "取消";
 "copy_button" = "拷贝";
+"clear_text_button" = "清除文本";
 "seconds_title" = "秒";
 "ok_button" = "确定";
 "siri_alert_description" = "Siri快捷方式在iOS 12及更高版本上可用";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "sort_title" = "排序依据";
 "cancel_button" = "取消";
 "copy_button" = "拷贝";
-"clear_text_button" = "清除文本";
 "seconds_title" = "秒";
 "ok_button" = "确定";
 "siri_alert_description" = "Siri快捷方式在iOS 12及更高版本上可用";

--- a/BookPlayer/zh-Hans.lproj/Localizable.strings
+++ b/BookPlayer/zh-Hans.lproj/Localizable.strings
@@ -377,6 +377,12 @@
 "integration_custom_headers_key_placeholder" = "请求头名称";
 "integration_custom_headers_value_placeholder" = "请求头值";
 "integration_custom_headers_add_button" = "添加请求头";
+"integration_address_scheme_label" = "连接类型";
+"integration_address_host_label" = "主机";
+"integration_address_port_label" = "端口";
+"integration_server_section_header" = "服务器";
+"integration_password_signin_button" = "用户名和密码";
+"integration_headers_detail_footer" = "这些请求头将附加到发送至此服务器的每个请求中。可在服务器地址界面中编辑。";
 "settings_integration_manage_connection_title" = "管理连接";
 "integration_internal_error_invalid_url" = "内部错误：请求 URL 无效： %@";
 "integration_internal_error_build_url" = "内部错误：无法构建请求 URL";

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -203,6 +203,45 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     )
   }
 
+  // MARK: - Re-auth against a moved server
+
+  /// The sharp edge of keying connections on url+user: re-authenticating a server that moved host
+  /// signs into an account no row matches, and without carrying the original connection's id the old
+  /// row would survive as an expired orphan next to the new one.
+  func testReauthWithAnEditedURLUpdatesTheRowInsteadOfForking() async throws {
+    try keychain.set(
+      [
+        AudiobookShelfConnectionData(
+          id: "a",
+          url: URL(string: serverURL)!,
+          serverName: "Home",
+          userID: "u1",
+          userName: "gianni",
+          apiToken: "stale",
+          customHeaders: [:]
+        )
+      ],
+      key: .audiobookshelfConnection
+    )
+    service.setup()
+    let viewModel = AudiobookShelfConnectionViewModel(connectionService: service)
+
+    viewModel.prepareReauth()
+    // The server moved: the user edits the address before reconnecting.
+    viewModel.form.serverUrl = "https://moved.example.com"
+    http.statusPayload = Data(#"{"authMethods":["local"]}"#.utf8)
+    http.pingPayload = Data(#"{"success":true}"#.utf8)
+    try await viewModel.handleConnectAction()
+
+    viewModel.form.username = "gianni"
+    viewModel.form.password = "pw"
+    try await viewModel.handleSignInAction()
+
+    XCTAssertEqual(service.connections.count, 1, "the moved server must update its row, not fork")
+    XCTAssertEqual(service.connections.first?.url.absoluteString, "https://moved.example.com")
+    XCTAssertEqual(service.connections.first?.id, "a", "outbound references survive the move")
+  }
+
   // MARK: - The step after Connect
 
   /// The routing decision the redesigned flow hangs on: which screen Connect lands you on, per what

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -308,6 +308,31 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     }
   }
 
+  /// The dead-end config: SSO-only server over plaintext. We refuse SSO on http and the password
+  /// form cannot authenticate, so Connect must fail with the reason — landing the user back on the
+  /// address screen with its scheme control — rather than route to a form that cannot work.
+  func testConnectFailsWhenNoSignInMethodCanWork() async {
+    let viewModel = AudiobookShelfConnectionViewModel(connectionService: service, mode: .addServer)
+    viewModel.form.serverUrl = "http://abs.example.com"
+    http.statusPayload = Data(#"{"authMethods":["openid"]}"#.utf8)
+    http.pingPayload = Data(#"{"success":true}"#.utf8)
+
+    do {
+      try await viewModel.handleConnectAction()
+      XCTFail("expected insecureTransport")
+    } catch let error as IntegrationError {
+      guard case .insecureTransport = error else {
+        return XCTFail("expected insecureTransport, got \(error)")
+      }
+    } catch {
+      XCTFail("expected IntegrationError, got \(error)")
+    }
+    XCTAssertTrue(viewModel.flowPath.isEmpty, "a failed Connect must not push any screen")
+    if case .enteringCredentials = viewModel.signInFlow {
+      XCTFail("a failed Connect must not advance the sign-in flow")
+    }
+  }
+
   func testReauthAndCancelClearTheFlowPath() async throws {
     let viewModel = AudiobookShelfConnectionViewModel(connectionService: service, mode: .addServer)
     viewModel.form.serverUrl = serverURL

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -242,6 +242,36 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     XCTAssertEqual(service.connections.first?.id, "a", "outbound references survive the move")
   }
 
+  // MARK: - Sign-out
+
+  /// Found on device: signing out the last server from a details sheet redrew the sheet into the old
+  /// URL form, with the presenter's Done and the form's Connect fighting in one toolbar. Sign-out is
+  /// deletion — the presenting screen dismisses, and nothing here may re-enter a sign-in flow.
+  func testSignOutNeverRedrawsASignInFormInPlace() throws {
+    try keychain.set(
+      [
+        AudiobookShelfConnectionData(
+          id: "a",
+          url: URL(string: serverURL)!,
+          serverName: "Home",
+          userID: "u1",
+          userName: "gianni",
+          apiToken: "t",
+          customHeaders: [:]
+        )
+      ],
+      key: .audiobookshelfConnection
+    )
+    service.setup()
+    let viewModel = AudiobookShelfConnectionViewModel(connectionService: service, mode: .viewDetails)
+
+    viewModel.handleSignOutAction()
+
+    XCTAssertTrue(service.connections.isEmpty)
+    XCTAssertNil(viewModel.signInFlow, "no in-place redraw — the presenter dismisses instead")
+    XCTAssertTrue(viewModel.flowPath.isEmpty)
+  }
+
   // MARK: - The step after Connect
 
   /// The routing decision the redesigned flow hangs on: which screen Connect lands you on, per what

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -74,26 +74,20 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     // Sign-in itself must persist them.
     XCTAssertEqual(try persistedHeaders(), ["CF-Access-Client-Id": "abc123"])
 
-    // …and the form must still mirror them. `IntegrationCustomHeadersSectionView` commits on
-    // `onDisappear`, so a form that was silently emptied here writes that emptiness straight over the
-    // saved connection the moment the sheet closes.
+    // …and the form must still mirror them. The editable details section that once committed form
+    // state over the saved connection is gone, but the form staying truthful still matters: the
+    // re-auth flow prefills from it.
     XCTAssertEqual(
       viewModel.form.customHeadersDictionary(),
       ["CF-Access-Client-Id": "abc123"],
-      "form headers were cleared after sign-in; the next commit would wipe them from the Keychain"
-    )
-
-    // Simulate exactly that commit.
-    viewModel.handleCustomHeadersUpdate()
-
-    XCTAssertEqual(
-      try persistedHeaders(),
-      ["CF-Access-Client-Id": "abc123"],
-      "a commit after sign-in wiped the persisted custom headers"
+      "form headers were cleared after sign-in"
     )
   }
 
-  func testCustomHeadersSurviveAConnectionDetailsRoundTrip() async throws {
+  /// The commit-on-close that once made this dangerous is gone — connection details is read-only —
+  /// but the form still prefills from the saved connection, and re-auth depends on those headers
+  /// arriving intact: a Cloudflare-Access server can't even be pinged without them.
+  func testDetailsFormPrefillsTheSavedHeaders() throws {
     // Seed a saved connection that already has headers, as a relaunch would.
     try keychain.set(
       [
@@ -111,15 +105,14 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     )
     service.setup()
 
-    // Opening connection details and closing it again commits the form state.
     let viewModel = AudiobookShelfConnectionViewModel(connectionService: service)
-    viewModel.handleCustomHeadersUpdate()
 
     XCTAssertEqual(
-      try persistedHeaders(),
+      viewModel.form.customHeadersDictionary(),
       ["CF-Access-Client-Id": "abc123"],
-      "merely opening and closing connection details erased the saved headers"
+      "the details form must mirror the saved headers — re-auth prefills from it"
     )
+    XCTAssertEqual(try persistedHeaders(), ["CF-Access-Client-Id": "abc123"])
   }
 
   // MARK: - Re-authentication

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -197,14 +197,9 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     http.pingPayload = Data(#"{"success":true}"#.utf8)
     try await viewModel.handleConnectAction()
 
-    XCTAssertEqual(
+    XCTAssertNil(
       viewModel.alternativeSignIn,
-      .oidcRequiresSecureTransport,
-      "the UI should explain the absence rather than silently hiding SSO"
-    )
-    XCTAssertFalse(
-      viewModel.alternativeSignIn?.isActionable ?? true,
-      "an explanation is not an offer — username autofocus must behave as if no alternative exists"
+      "SSO over plaintext is simply not offered — the scheme control makes http visible and actionable"
     )
   }
 

--- a/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/AudiobookShelfConnectionViewModelTests.swift
@@ -203,6 +203,62 @@ final class AudiobookShelfConnectionViewModelTests: XCTestCase {
     )
   }
 
+  // MARK: - The step after Connect
+
+  /// The routing decision the redesigned flow hangs on: which screen Connect lands you on, per what
+  /// the server offers. Wrong routing is invisible in review — a server config you don't have renders
+  /// a screen you never see — so the whole matrix is pinned.
+  func testConnectRoutesToTheRightStep() async throws {
+    struct Row {
+      let authMethods: String
+      let scheme: String
+      let expected: [ConnectionFlowStep]
+      let passwordOffered: Bool
+    }
+    let matrix: [Row] = [
+      // Both methods → the chooser, password still offered there.
+      Row(authMethods: #"["local","openid"]"#, scheme: "https", expected: [.method], passwordOffered: true),
+      // SSO-only → still the chooser (one primary button beats auto-launching a browser),
+      // and the password button must NOT exist — the form cannot work.
+      Row(authMethods: #"["openid"]"#, scheme: "https", expected: [.method], passwordOffered: false),
+      // Password-only → skip the chooser entirely.
+      Row(authMethods: #"["local"]"#, scheme: "https", expected: [.password], passwordOffered: true),
+      // SSO advertised but refused over plaintext → not offered, so password is the only path.
+      Row(authMethods: #"["local","openid"]"#, scheme: "http", expected: [.password], passwordOffered: true),
+      // Probe answered nothing usable → fail safe toward the password form.
+      Row(authMethods: "[]", scheme: "https", expected: [.password], passwordOffered: true),
+    ]
+
+    for row in matrix {
+      let viewModel = AudiobookShelfConnectionViewModel(connectionService: service, mode: .addServer)
+      viewModel.form.serverUrl = "\(row.scheme)://abs.example.com"
+      http.statusPayload = Data(#"{"authMethods":"#.appending(row.authMethods).appending("}").utf8)
+      http.pingPayload = Data(#"{"success":true}"#.utf8)
+
+      try await viewModel.handleConnectAction()
+
+      XCTAssertEqual(viewModel.flowPath, row.expected, "authMethods \(row.authMethods) over \(row.scheme)")
+      XCTAssertEqual(
+        viewModel.supportsPasswordSignIn,
+        row.passwordOffered,
+        "authMethods \(row.authMethods) over \(row.scheme)"
+      )
+    }
+  }
+
+  func testReauthAndCancelClearTheFlowPath() async throws {
+    let viewModel = AudiobookShelfConnectionViewModel(connectionService: service, mode: .addServer)
+    viewModel.form.serverUrl = serverURL
+    http.statusPayload = Data(#"{"authMethods":["local"]}"#.utf8)
+    http.pingPayload = Data(#"{"success":true}"#.utf8)
+    try await viewModel.handleConnectAction()
+    XCTAssertEqual(viewModel.flowPath, [.password])
+
+    viewModel.handleCancelAddServerAction()
+
+    XCTAssertTrue(viewModel.flowPath.isEmpty, "an abandoned flow must not leave pushed screens behind")
+  }
+
   // MARK: - Capability probe
 
   /// The case the probe used to miss entirely: an admin who disabled local auth. `authMethods` then

--- a/BookPlayerTests/MediaServerIntegration/IntegrationConnectionStoreTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/IntegrationConnectionStoreTests.swift
@@ -57,6 +57,51 @@ final class IntegrationConnectionStoreTests: XCTestCase {
     )
   }
 
+  // MARK: - Re-auth against a moved server
+
+  /// The store half of the moved-server contract, pinned here because the Jellyfin service has no
+  /// injectable network seam to drive it end-to-end the way the AudiobookShelf VM tests do.
+  func testUpsertReplacingIDUpdatesTheRowWhenTheURLChanged() {
+    sut.upsert(url: URL(string: "https://old.example.com")!, userID: "user-1") { _ in
+      self.makeConnection(id: "a", url: "https://old.example.com", selectedLibraryId: "lib-9")
+    }
+
+    let result = sut.upsert(
+      url: URL(string: "https://moved.example.com")!,
+      userID: "user-1",
+      replacingID: "a"
+    ) { existing in
+      self.makeConnection(
+        id: existing?.id ?? UUID().uuidString,
+        url: "https://moved.example.com",
+        selectedLibraryId: existing?.selectedLibraryId
+      )
+    }
+
+    XCTAssertEqual(result.replaced?.id, "a", "the account match finds nothing; replacingID must")
+    XCTAssertEqual(sut.connections.count, 1, "the old-URL row must not survive as an orphan")
+    XCTAssertEqual(sut.connections.first?.id, "a", "outbound references survive the move")
+    XCTAssertEqual(sut.connections.first?.selectedLibraryId, "lib-9", "library selection survives")
+  }
+
+  /// A different account is genuinely a new connection, not a moved server — the old row stays.
+  func testUpsertReplacingIDRefusesADifferentAccount() {
+    sut.upsert(url: URL(string: "https://old.example.com")!, userID: "user-1") { _ in
+      self.makeConnection(id: "a", url: "https://old.example.com")
+    }
+
+    sut.upsert(
+      url: URL(string: "https://moved.example.com")!,
+      userID: "someone-else",
+      replacingID: "a"
+    ) { existing in
+      XCTAssertNil(existing, "a different userID must not inherit the old row's identity")
+      return self.makeConnection(id: "b", url: "https://moved.example.com", userID: "someone-else")
+    }
+
+    XCTAssertEqual(sut.connections.count, 2, "signing into a different account forks, by design")
+  }
+
   // MARK: - Loading
 
   func testReloadLoadsStoredConnectionsAndActivatesTheFirst() throws {

--- a/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
@@ -164,6 +164,56 @@ final class IntegrationServerAddressTests: XCTestCase {
     XCTAssertEqual(viaField.path, "/jellyfin")
   }
 
+  // MARK: - Paste decomposition
+
+  /// Found on device: a URL pasted into the Host field split at the first slash of "http://",
+  /// bracketed "http:" as if it were IPv6, and showed "[http:]//…" — with the original paste
+  /// unrecoverable by the time Connect ran. Decomposition happens in the setter, where the paste
+  /// actually arrives.
+  func testPastedFullURLDistributesAcrossAllFields() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    address.hostField = "http://100.81.227.12:13378"
+
+    XCTAssertEqual(address.scheme, .http, "the scheme control must flip to match the paste")
+    XCTAssertEqual(address.host, "100.81.227.12")
+    XCTAssertEqual(address.port, 13378)
+    XCTAssertEqual(address.hostField, "100.81.227.12", "the field keeps only host + subpath")
+    XCTAssertEqual(address.urlString, "http://100.81.227.12:13378")
+  }
+
+  func testPastedSchemelessHostPortAndPathDecompose() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    address.hostField = "example.com:8096/audiobookshelf"
+
+    XCTAssertEqual(address.scheme, .https, "no scheme in the paste — the control keeps its setting")
+    XCTAssertEqual(address.host, "example.com")
+    XCTAssertEqual(address.port, 8096)
+    XCTAssertEqual(address.path, "/audiobookshelf")
+  }
+
+  func testPastedBracketedIPv6WithPortDecomposes() {
+    var address = IntegrationServerAddress(scheme: .http, host: "")
+
+    address.hostField = "[::1]:8096"
+
+    XCTAssertEqual(address.host, "[::1]")
+    XCTAssertEqual(address.port, 8096)
+    XCTAssertEqual(address.urlString, "http://[::1]:8096")
+  }
+
+  /// Mid-typing through a scheme ("http://" with nothing after it yet) must neither mangle the text
+  /// nor produce a connectable URL.
+  func testIncompleteSchemeHoldsRawTextWithoutAssembling() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    address.hostField = "http://"
+
+    XCTAssertEqual(address.hostField, "http://", "raw text preserved while incomplete")
+    XCTAssertNil(address.url, "Connect must stay disabled until the text resolves")
+  }
+
   // MARK: - The combined host field
 
   func testHostFieldSetterSplitsAtTheFirstSlash() {

--- a/BookPlayerTests/MediaServerIntegration/JellyfinQuickConnectTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/JellyfinQuickConnectTests.swift
@@ -97,6 +97,18 @@ final class JellyfinQuickConnectTests: XCTestCase {
     XCTAssertNotEqual(message, "jellyfin_quick_connect_error_generic", "key missing from Base.lproj")
   }
 
+  // MARK: - Flow path
+
+  /// The Jellyfin side of the rule pinned for AudiobookShelf: an abandoned flow leaves no pushed
+  /// screens behind. Driven directly since the Jellyfin connect path has no network seam.
+  func testCancellingAddServerClearsTheFlowPath() {
+    viewModel.flowPath = [.method, .password]
+
+    viewModel.handleCancelAddServerAction()
+
+    XCTAssertTrue(viewModel.flowPath.isEmpty)
+  }
+
   // MARK: - Cancellation during the token exchange
 
   /// `.authenticated` kicks off a network round-trip while the sheet still shows a live Cancel button.


### PR DESCRIPTION
The connection screen rendered Quick Connect/SSO and the username/password form as sibling sections, which read as "fill in both." One pushed screen per decision instead. Design + mockups discussed separately; groundwork landed in #1575.

### The flow

**Address** — explicit `http`/`https` control, host (carries any reverse-proxy subpath), port (integration's usual port as a placeholder example, never substituted — empty means no port, as in a browser), editable custom headers, and the assembled URL shown before Connect. A pasted full URL decomposes into the fields. **Method** — only when the server offers an alternative; the alternative is primary, password secondary, and absent entirely on SSO-only servers (which previously got a form that cannot work). **Password** — its own screen, always auto-focused. Quick Connect and SSO stay modal. Primary actions pinned at the bottom throughout, per `LoginView`.

### Entry points & success

Add Server, session-expired re-auth, and initial connect all present the same flow; re-auth arrives prefilled. On success in Add Server, the library the user just connected presents *after* the sheet's dismissal completes (`onDismiss`), never alongside it.

### Fixes riding along

- **Re-auth against a moved server updates the original row** instead of orphaning it (id threaded from `prepareReauth` through the services into `upsert`; same-userID required, so a different account still forks). Writing the test exposed that ABS password sign-in used a private `URLSession` no test could reach — now routed through the injected client like the OIDC path.
- **Connection-details headers are read-only** — the editable section committed on `onDisappear`, so a form left showing an empty list wrote that emptiness over the saved connection.
- Refused SSO (advertised, but over `http`) is simply not offered; the explanation section is gone — the scheme control makes the `http` choice visible.

### Known transitional state

Signing out the last server from inside a details sheet still shows the old single-form flow (functional, pre-redesign visuals). Slimming `IntegrationConnectionView` to details-only is follow-up cleanup.

### Strings & tests

6 new keys, translated in all 26 catalogs in the same PR. 475 tests green — new coverage: routing matrix (5 server configs → screen/buttons), flow-path lifecycle, moved-server re-auth.