### PR TITLE
Fix progress label sheet animation

### DIFF
--- a/BookPlayer/Player/Views/ListeningProgressView.swift
+++ b/BookPlayer/Player/Views/ListeningProgressView.swift
@@ -52,7 +52,7 @@ struct ListeningProgressView: View {
           Text(progressLabel)
             .lineLimit(1)
             .bpFont(.miniPlayerTitle)
-            .transaction { $0.animation = nil }
+            .animation(nil, value: progressLabel)
         }
         .layoutPriority(1)
         


### PR DESCRIPTION
## Bugfix

The progress label jittered strangely when moving the player overlay.

## Approach

Scope disabling animations on the progress label to only text updates.

## Screenshots

| Before | After |
| -------- | -------- |
|  <video src="https://github.com/user-attachments/assets/152f21eb-55a1-4329-b03c-2f3a07516857" controls preload></video> |  <video src="https://github.com/user-attachments/assets/201b26cf-cde1-4682-8031-00a537827555" controls preload></video> |
