### PR TITLE
Query-time sort refactor — Phase 0: spike + characterization safety net

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -299,6 +299,10 @@
 		62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
 		62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
 		62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */; };
+		5B1559A45658B195521CC454 /* SyncResponseFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6581B92E4D292C2AFC361A /* SyncResponseFixtures.swift */; };
+		5A589702CFB4A8F8EC55AC3F /* SortIntegrationHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF448F75392B02FC5451289 /* SortIntegrationHarness.swift */; };
+		9DA710A0CC53EEC5F7AF93D3 /* QueryTimeSortSpikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */; };
+		759B9B1691932EB7A815CFFF /* SortCharacterizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F448E8BBF01860FC65EB697A /* SortCharacterizationTests.swift */; };
 		62CADBA52725BCB200A4A98F /* AVAudioAssetImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624AB20A2724808600F6A486 /* AVAudioAssetImageDataProvider.swift */; };
 		62CADBA82725BCE800A4A98F /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 62CADBA72725BCE800A4A98F /* Kingfisher */; };
 		62CADBAA2725BCF000A4A98F /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 62CADBA92725BCF000A4A98F /* Kingfisher */; };
@@ -1328,6 +1332,10 @@
 		624EB9832755D8E700D462A8 /* Audiobook Player 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 8.xcdatamodel"; sourceTree = "<group>"; };
 		62AAE22B274AA3EB001EB9FF /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
 		62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryServiceTests.swift; sourceTree = "<group>"; };
+		1C6581B92E4D292C2AFC361A /* SyncResponseFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncResponseFixtures.swift; sourceTree = "<group>"; };
+		2AF448F75392B02FC5451289 /* SortIntegrationHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortIntegrationHarness.swift; sourceTree = "<group>"; };
+		53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryTimeSortSpikeTests.swift; sourceTree = "<group>"; };
+		F448E8BBF01860FC65EB697A /* SortCharacterizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortCharacterizationTests.swift; sourceTree = "<group>"; };
 		62CADB8D2724E41800A4A98F /* Audiobook Player 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 7.xcdatamodel"; sourceTree = "<group>"; };
 		62F2F25E25E18C7500E1D6A0 /* ImportableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportableItem.swift; sourceTree = "<group>"; };
 		63005A432AE7FD8000A4CA2C /* BookPlayerWidgetsWatch.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BookPlayerWidgetsWatch.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3181,6 +3189,8 @@
 				63432B582AC1E6F7002619D0 /* MockNavigationController.swift */,
 				8AAA4F4B2CF1FF77009D0777 /* MockCoordinatorPresentationFlow.swift */,
 				6906A552217211C600A9E0B2 /* StubFactory.swift */,
+				1C6581B92E4D292C2AFC361A /* SyncResponseFixtures.swift */,
+				2AF448F75392B02FC5451289 /* SortIntegrationHarness.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -3206,6 +3216,8 @@
 				69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */,
 				6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */,
 				62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */,
+				53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */,
+				F448E8BBF01860FC65EB697A /* SortCharacterizationTests.swift */,
 				9FC1E4662815091A00522FA8 /* AccountServiceTests.swift */,
 				9FC1E4762815F97E00522FA8 /* KeychainServiceTests.swift */,
 				700DFD61111AC10253D6EBAA /* SyncTasksStorageTests.swift */,
@@ -4963,6 +4975,10 @@
 				8AF18A3B2CF0E92F00238F8D /* KeychainServiceMock.swift in Sources */,
 				9F7C47532A2C15D300F9A500 /* AutoMockable.generated.swift in Sources */,
 				62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */,
+				5B1559A45658B195521CC454 /* SyncResponseFixtures.swift in Sources */,
+				5A589702CFB4A8F8EC55AC3F /* SortIntegrationHarness.swift in Sources */,
+				9DA710A0CC53EEC5F7AF93D3 /* QueryTimeSortSpikeTests.swift in Sources */,
+				759B9B1691932EB7A815CFFF /* SortCharacterizationTests.swift in Sources */,
 				6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */,
 				6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */,
 				FED52673ACD975949EF9E219 /* PreferencesSyncServiceTests.swift in Sources */,

--- a/BookPlayerTests/Services/QueryTimeSortSpikeTests.swift
+++ b/BookPlayerTests/Services/QueryTimeSortSpikeTests.swift
@@ -1,0 +1,282 @@
+//
+//  QueryTimeSortSpikeTests.swift
+//  BookPlayerTests
+//
+//  Phase 0 spike for the query-time-sort refactor: proves the Core Data SQLite
+//  store supports the exact descriptor recipes the refactor will ship —
+//  `localizedStandardCompare:` selectors combined with `dictionaryResultType`,
+//  `fetchLimit`/`fetchOffset` paging, and an `orderRank` tie-breaker — and that
+//  the SQL-evaluated order matches today's in-memory `SortType.sortItems`.
+//
+//  If any of these fail, the refactor design pivots BEFORE any production code
+//  moves. The recipes below are the source of truth for the future
+//  `SortType.sortDescriptors`.
+//
+
+@testable import BookPlayerKit
+import CoreData
+import XCTest
+
+final class QueryTimeSortSpikeTests: XCTestCase {
+  private var storePath: String!
+  private var dataManager: DataManager!
+
+  override func setUp() {
+    super.setUp()
+    storePath = NSTemporaryDirectory() + "QueryTimeSortSpike-\(UUID().uuidString).sqlite"
+    dataManager = DataManager(coreDataStack: CoreDataStack(testPath: storePath))
+  }
+
+  override func tearDown() {
+    // The store files are left in the simulator's tmp dir on purpose: deleting
+    // them while the NSPersistentContainer still holds them open trips SQLite's
+    // "vnode unlinked while in use" API-violation warning.
+    dataManager = nil
+    super.tearDown()
+  }
+
+  // MARK: - Descriptor recipes under test (the future SortType.sortDescriptors)
+
+  private var rankTieBreaker: NSSortDescriptor {
+    NSSortDescriptor(key: "orderRank", ascending: true)
+  }
+
+  private var titleDescriptors: [NSSortDescriptor] {
+    [
+      NSSortDescriptor(
+        key: "title",
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare(_:))
+      ),
+      rankTieBreaker,
+    ]
+  }
+
+  private var fileNameDescriptors: [NSSortDescriptor] {
+    [
+      NSSortDescriptor(
+        key: "originalFileName",
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare(_:))
+      ),
+      rankTieBreaker,
+    ]
+  }
+
+  private var mostRecentDescriptors: [NSSortDescriptor] {
+    [
+      NSSortDescriptor(key: "lastPlayDate", ascending: false),
+      rankTieBreaker,
+    ]
+  }
+
+  // MARK: - Seeding
+
+  @discardableResult
+  private func seedBook(
+    into manager: DataManager,
+    title: String,
+    fileName: String? = nil,
+    rank: Int16,
+    lastPlayDate: Date? = nil
+  ) -> Book {
+    let context = manager.getContext()
+    // swiftlint:disable:next force_cast
+    let book = NSEntityDescription.insertNewObject(forEntityName: "Book", into: context) as! Book
+    book.relativePath = "\(title)-\(rank).txt"
+    book.title = title
+    book.originalFileName = fileName ?? "\(title).txt"
+    book.details = "spike-author"
+    book.duration = 100
+    book.isFinished = false
+    book.lastPlayDate = lastPlayDate
+    book.type = .book
+    book.uuid = UUID().uuidString
+    book.orderRank = rank
+    return book
+  }
+
+  /// Finder-style-interesting titles, seeded with ranks that DISAGREE with every
+  /// sort rule so a passing test can't be an accident of insertion order.
+  private func seedStandardDataset(into manager: DataManager) {
+    seedBook(into: manager, title: "09 Book 10", rank: 0)
+    seedBook(into: manager, title: "banana", rank: 1)
+    seedBook(into: manager, title: "01 Book 1", rank: 2)
+    seedBook(into: manager, title: "Apple", rank: 3)
+    seedBook(into: manager, title: "09 Book 2", rank: 4)
+    seedBook(into: manager, title: "05 Book 1", rank: 5)
+    seedBook(into: manager, title: "cherry", rank: 6)
+    manager.saveContext()
+  }
+
+  // MARK: - Fetch helpers
+
+  /// The production render-fetch shape: dictionaryResultType + propertiesToFetch,
+  /// exactly like `buildListContentsFetchRequest`.
+  private func dictionaryFetchTitles(
+    from manager: DataManager,
+    sortedBy descriptors: [NSSortDescriptor],
+    limit: Int? = nil,
+    offset: Int? = nil
+  ) throws -> [String] {
+    let request = NSFetchRequest<NSDictionary>(entityName: "Book")
+    request.resultType = .dictionaryResultType
+    request.propertiesToFetch = [
+      "title",
+      "orderRank",
+    ]
+    request.sortDescriptors = descriptors
+    if let limit {
+      request.fetchLimit = limit
+    }
+    if let offset {
+      request.fetchOffset = offset
+    }
+    let results = try manager.getContext().fetch(request)
+    return results.compactMap { $0["title"] as? String }
+  }
+
+  private func managedFetch(
+    from manager: DataManager,
+    sortedBy descriptors: [NSSortDescriptor]
+  ) throws -> [BookPlayerKit.LibraryItem] {
+    let request = NSFetchRequest<BookPlayerKit.LibraryItem>(entityName: "Book")
+    request.sortDescriptors = descriptors
+    return try manager.getContext().fetch(request)
+  }
+
+  // MARK: - Selector support + parity with today's in-memory comparator
+
+  func testTitleSortMatchesInMemoryComparator_dictionaryResultType() throws {
+    seedStandardDataset(into: dataManager)
+
+    let sqlOrder = try dictionaryFetchTitles(from: dataManager, sortedBy: titleDescriptors)
+    let inMemoryOrder = SortType.metadataTitle
+      .sortItems(try managedFetch(from: dataManager, sortedBy: [rankTieBreaker]))
+      .map { $0.title ?? "" }
+
+    // Absolute assertions on the locale-independent (numeric-awareness) part:
+    let numericTitles = sqlOrder.filter { $0.hasPrefix("0") }
+    XCTAssertEqual(numericTitles, ["01 Book 1", "05 Book 1", "09 Book 2", "09 Book 10"])
+    // Parity with SortType.sortItems is the actual refactor claim:
+    XCTAssertEqual(sqlOrder, inMemoryOrder)
+  }
+
+  func testFileNameSortMatchesInMemoryComparator() throws {
+    seedStandardDataset(into: dataManager)
+
+    let request = NSFetchRequest<NSDictionary>(entityName: "Book")
+    request.resultType = .dictionaryResultType
+    request.propertiesToFetch = ["originalFileName"]
+    request.sortDescriptors = fileNameDescriptors
+    let sqlOrder = try dataManager.getContext().fetch(request)
+      .compactMap { $0["originalFileName"] as? String }
+
+    let inMemoryOrder = SortType.fileName
+      .sortItems(try managedFetch(from: dataManager, sortedBy: [rankTieBreaker]))
+      .map { $0.originalFileName ?? "" }
+
+    XCTAssertEqual(sqlOrder, inMemoryOrder)
+  }
+
+  func testMostRecentSortPutsNeverPlayedLast() throws {
+    let now = Date()
+    seedBook(into: dataManager, title: "never-played-a", rank: 0, lastPlayDate: nil)
+    seedBook(into: dataManager, title: "oldest", rank: 1, lastPlayDate: now.addingTimeInterval(-300))
+    seedBook(into: dataManager, title: "newest", rank: 2, lastPlayDate: now)
+    seedBook(into: dataManager, title: "never-played-b", rank: 3, lastPlayDate: nil)
+    seedBook(into: dataManager, title: "middle", rank: 4, lastPlayDate: now.addingTimeInterval(-100))
+    dataManager.saveContext()
+
+    let sqlOrder = try dictionaryFetchTitles(from: dataManager, sortedBy: mostRecentDescriptors)
+
+    // SQLite sorts NULL last under DESC, matching sortItems' `?? .distantPast`.
+    // The two never-played rows tie and fall back to rank order.
+    XCTAssertEqual(sqlOrder, ["newest", "middle", "oldest", "never-played-a", "never-played-b"])
+
+    let inMemoryOrder = SortType.mostRecent
+      .sortItems(try managedFetch(from: dataManager, sortedBy: [rankTieBreaker]))
+      .map { $0.title ?? "" }
+    XCTAssertEqual(sqlOrder, inMemoryOrder)
+  }
+
+  // MARK: - Determinism: the tie-breaker today's in-memory sort doesn't have
+
+  func testEqualSortKeysFallBackToRankOrder() throws {
+    seedBook(into: dataManager, title: "Same Title", fileName: "d.txt", rank: 3)
+    seedBook(into: dataManager, title: "Same Title", fileName: "a.txt", rank: 0)
+    seedBook(into: dataManager, title: "Same Title", fileName: "c.txt", rank: 2)
+    seedBook(into: dataManager, title: "Same Title", fileName: "b.txt", rank: 1)
+    dataManager.saveContext()
+
+    let request = NSFetchRequest<NSDictionary>(entityName: "Book")
+    request.resultType = .dictionaryResultType
+    request.propertiesToFetch = ["originalFileName"]
+    request.sortDescriptors = titleDescriptors
+
+    // Deterministic across repeated fetches — the property the unstable
+    // in-memory sort can't promise.
+    for _ in 0..<3 {
+      let order = try dataManager.getContext().fetch(request)
+        .compactMap { $0["originalFileName"] as? String }
+      XCTAssertEqual(order, ["a.txt", "b.txt", "c.txt", "d.txt"])
+    }
+  }
+
+  // MARK: - Pagination
+
+  func testPaginationIsStableUnderTitleSort() throws {
+    // 30 titles whose alphabetical and rank orders disagree everywhere.
+    let count = 30
+    for index in 0..<count {
+      let title = String(format: "Book %03d", (index * 7) % count)
+      seedBook(into: dataManager, title: title, rank: Int16(count - index))
+    }
+    dataManager.saveContext()
+
+    let fullOrder = try dictionaryFetchTitles(from: dataManager, sortedBy: titleDescriptors)
+    XCTAssertEqual(fullOrder.count, count)
+
+    let pageSize = 13
+    var paged: [String] = []
+    var offset = 0
+    while true {
+      let page = try dictionaryFetchTitles(
+        from: dataManager,
+        sortedBy: titleDescriptors,
+        limit: pageSize,
+        offset: offset
+      )
+      paged.append(contentsOf: page)
+      offset += page.count
+      if page.count < pageSize { break }
+    }
+
+    XCTAssertEqual(paged, fullOrder, "paged walk must equal the unpaged order — no gaps, no duplicates")
+  }
+
+  // MARK: - Harness fidelity: the /dev/null pattern behaves like a real store
+
+  func testDevNullStoreParityWithRealSQLiteFile() throws {
+    seedStandardDataset(into: dataManager)
+    let realStoreOrder = try dictionaryFetchTitles(from: dataManager, sortedBy: titleDescriptors)
+
+    let devNullManager = DataManager(coreDataStack: CoreDataStack(testPath: "/dev/null"))
+    seedStandardDataset(into: devNullManager)
+    let devNullOrder = try dictionaryFetchTitles(from: devNullManager, sortedBy: titleDescriptors)
+
+    XCTAssertEqual(devNullOrder, realStoreOrder)
+  }
+
+  // MARK: - Managed-object fetches (the reorder/reverse paths) support the selector too
+
+  func testManagedObjectFetchSupportsSelectorSort() throws {
+    seedStandardDataset(into: dataManager)
+
+    let managedOrder = try managedFetch(from: dataManager, sortedBy: titleDescriptors)
+      .map { $0.title ?? "" }
+    let dictionaryOrder = try dictionaryFetchTitles(from: dataManager, sortedBy: titleDescriptors)
+
+    XCTAssertEqual(managedOrder, dictionaryOrder)
+  }
+}

--- a/BookPlayerTests/Services/SortCharacterizationTests.swift
+++ b/BookPlayerTests/Services/SortCharacterizationTests.swift
@@ -1,0 +1,323 @@
+//
+//  SortCharacterizationTests.swift
+//  BookPlayerTests
+//
+//  Phase 0 of the query-time-sort refactor: pins the OBSERVABLE behavior that
+//  must survive the refactor byte-for-byte. Every assertion here is written
+//  against user-visible outcomes (rendered order, persisted prefs, playback
+//  navigation) — never against the materialization mechanism (rank rewrites)
+//  that the refactor deletes. If a test in this file breaks during the
+//  refactor, user-facing behavior regressed.
+//
+//  Uses SortIntegrationHarness: a real PreferencesSyncService (real SortLocation
+//  gates and key routing) wired to a real LibraryService over a real SQLite
+//  store, so the sync paths' background-context writes are production-faithful.
+//
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import CoreData
+import XCTest
+
+final class SortCharacterizationTests: XCTestCase {
+  private var harness: SortIntegrationHarness!
+  private var libraryService: LibraryService { harness.libraryService }
+  private var preferences: PreferencesSyncService { harness.preferences }
+
+  override func setUp() {
+    super.setUp()
+    harness = SortIntegrationHarness()
+  }
+
+  override func tearDown() {
+    harness.tearDown()
+    harness = nil
+    super.tearDown()
+  }
+
+  // MARK: - Picking a sort
+
+  func testPickingTitleSortPersistsPrefAndRendersSorted() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+
+    XCTAssertEqual(harness.renderedOrder(), ["apple.txt", "banana.txt", "cherry.txt"])
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .automatic(.metadataTitle))
+  }
+
+  func testReverseUnderTitleSortReversesVisibleOrderAndTransitionsToCustom() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+
+    libraryService.reverseContents(at: nil)
+
+    XCTAssertEqual(harness.renderedOrder(), ["cherry.txt", "banana.txt", "apple.txt"])
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .custom)
+  }
+
+  // MARK: - Import (today: Hook 2 re-sorts; after: the query sorts)
+
+  func testImportUnderTitleSortRendersSorted() async {
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let contents = "bookcontents".data(using: .utf8)!
+    let gamma = DataTestUtils.generateTestFile(name: "gamma.txt", contents: contents, destinationFolder: processedFolder)
+    let alpha = DataTestUtils.generateTestFile(name: "alpha.txt", contents: contents, destinationFolder: processedFolder)
+    let beta = DataTestUtils.generateTestFile(name: "beta.txt", contents: contents, destinationFolder: processedFolder)
+
+    _ = await libraryService.insertItems(from: [gamma, alpha, beta])
+
+    XCTAssertEqual(harness.renderedOrder(), ["alpha.txt", "beta.txt", "gamma.txt"])
+  }
+
+  func testImportUnderCustomAppendsInInsertionOrder() async {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let contents = "bookcontents".data(using: .utf8)!
+    let gamma = DataTestUtils.generateTestFile(name: "gamma.txt", contents: contents, destinationFolder: processedFolder)
+    let alpha = DataTestUtils.generateTestFile(name: "alpha.txt", contents: contents, destinationFolder: processedFolder)
+
+    _ = await libraryService.insertItems(from: [gamma, alpha])
+
+    XCTAssertEqual(harness.renderedOrder(), ["gamma.txt", "alpha.txt"])
+  }
+
+  // MARK: - Move (source compaction survives the refactor; it's rank hygiene, not sort)
+
+  /// Compaction runs only when the SOURCE is a folder (`rebuildOrderRank(in:)`
+  /// is gated on a non-nil original parent path in `moveItems`).
+  func testMoveOutOfFolderCompactsSourceRanksAndPreservesOrder() throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let contents = "bookcontents".data(using: .utf8)!
+    let srcDir = try DataTestUtils.generateTestFolder(name: "src", destinationFolder: processedFolder)
+    for name in ["a.txt", "b.txt", "c.txt"] {
+      DataTestUtils.generateTestFile(name: name, contents: contents, destinationFolder: srcDir)
+    }
+    let src = try StubFactory.folder(dataManager: harness.dataManager, title: "src")
+    src.orderRank = 0
+    libraryService.getLibraryReference().addToItems(src)
+    harness.seedBook(relativePath: "src/a.txt", rank: 0, into: src)
+    let bookB = harness.seedBook(relativePath: "src/b.txt", rank: 1, into: src)
+    harness.seedBook(relativePath: "src/c.txt", rank: 2, into: src)
+    harness.save()
+
+    try libraryService.moveItems(
+      [LibraryItemRef(relativePath: "src/b.txt", uuid: bookB.uuid)],
+      inside: nil
+    )
+
+    XCTAssertEqual(harness.renderedOrder(at: "src"), ["src/a.txt", "src/c.txt"])
+    let srcRanks = harness.rankColumn(at: "src")
+    XCTAssertEqual(srcRanks["src/a.txt"], 0)
+    XCTAssertEqual(srcRanks["src/c.txt"], 1, "the source folder is compacted after a move-out")
+    XCTAssertEqual(harness.renderedOrder(), ["src", "b.txt"], "the moved item is appended at the destination")
+  }
+
+  /// A root-level source is NOT compacted today (the compaction call is gated on
+  /// a folder parent). Sparse ranks are harmless — ordering needs no contiguity —
+  /// and the refactor keeps this behavior as-is.
+  func testMoveOutOfRootLeavesSparseRanksAndPreservesOrder() throws {
+    let processedFolder = DataManager.getProcessedFolderURL()
+    let contents = "bookcontents".data(using: .utf8)!
+    for name in ["a.txt", "b.txt", "c.txt", "d.txt"] {
+      DataTestUtils.generateTestFile(name: name, contents: contents, destinationFolder: processedFolder)
+    }
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    let bookB = harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.seedBook(relativePath: "c.txt", rank: 2)
+    harness.seedBook(relativePath: "d.txt", rank: 3)
+    harness.save()
+    _ = try libraryService.createFolder(with: "dest", inside: nil)
+
+    try libraryService.moveItems(
+      [LibraryItemRef(relativePath: "b.txt", uuid: bookB.uuid)],
+      inside: "dest"
+    )
+
+    XCTAssertEqual(harness.renderedOrder(), ["a.txt", "c.txt", "d.txt", "dest"])
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["a.txt"], 0)
+    XCTAssertEqual(ranks["c.txt"], 2)
+    XCTAssertEqual(ranks["d.txt"], 3)
+    XCTAssertEqual(ranks["dest"], 4)
+    XCTAssertEqual(harness.renderedOrder(at: "dest"), ["dest/b.txt"])
+  }
+
+  // MARK: - Sync pull (today: Hook 4 re-sorts inserts; after: the query sorts)
+
+  func testSyncInsertUnderTitleSortRendersSorted() async throws {
+    harness.seedBook(relativePath: "bbb.txt", rank: 0)
+    harness.seedBook(relativePath: "ddd.txt", rank: 1)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+
+    let newItems = try SyncResponseFixtures.makeItemsDictionary([
+      SyncResponseFixtures.itemJSON(relativePath: "aaa.txt", orderRank: 99),
+      SyncResponseFixtures.itemJSON(relativePath: "ccc.txt", orderRank: 98),
+    ])
+    await libraryService.storeNewItems(from: newItems, parentFolder: nil)
+
+    XCTAssertEqual(harness.renderedOrder(), ["aaa.txt", "bbb.txt", "ccc.txt", "ddd.txt"])
+  }
+
+  func testSyncInsertUnderCustomFollowsServerRanks() async throws {
+    harness.seedBook(relativePath: "first.txt", rank: 0)
+    harness.save()
+
+    let newItems = try SyncResponseFixtures.makeItemsDictionary([
+      SyncResponseFixtures.itemJSON(relativePath: "server-second.txt", orderRank: 1),
+      SyncResponseFixtures.itemJSON(relativePath: "server-third.txt", orderRank: 2),
+    ])
+    await libraryService.storeNewItems(from: newItems, parentFolder: nil)
+
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["first.txt", "server-second.txt", "server-third.txt"]
+    )
+  }
+
+  /// The refactor KEEPS this write unguarded on purpose: server ranks are the
+  /// synced custom arrangement and must always land in the column. (What changes
+  /// in the refactor is that the rendered order stops reading the column while
+  /// an automatic sort is active — that assertion arrives with the refactor.)
+  func testSyncUpdateWritesServerRanksToColumn() async throws {
+    harness.seedBook(relativePath: "x.txt", rank: 0)
+    harness.seedBook(relativePath: "y.txt", rank: 1)
+    harness.seedBook(relativePath: "z.txt", rank: 2)
+    harness.save()
+
+    let serverItems = try SyncResponseFixtures.makeItemsDictionary([
+      SyncResponseFixtures.itemJSON(relativePath: "x.txt", orderRank: 2),
+      SyncResponseFixtures.itemJSON(relativePath: "y.txt", orderRank: 1),
+      SyncResponseFixtures.itemJSON(relativePath: "z.txt", orderRank: 0),
+    ])
+    await libraryService.updateInfo(for: serverItems, parentFolder: nil)
+
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["x.txt"], 2)
+    XCTAssertEqual(ranks["y.txt"], 1)
+    XCTAssertEqual(ranks["z.txt"], 0)
+  }
+
+  // MARK: - Playback navigation (D7 replaces the mechanism; these outcomes stay)
+
+  func testPrevNextUnderCustomFollowsRankOrder() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.seedBook(relativePath: "c.txt", rank: 2)
+    harness.save()
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let next = playbackService.getPlayableItem(
+      after: "a.txt", parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertEqual(next?.relativePath, "b.txt")
+
+    let previous = playbackService.getPlayableItem(before: "b.txt", parentFolder: nil)
+    XCTAssertEqual(previous?.relativePath, "a.txt")
+
+    let afterLast = playbackService.getPlayableItem(
+      after: "c.txt", parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertNil(afterLast)
+  }
+
+  func testAutoplaySkipsFinishedItems() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1, isFinished: true)
+    harness.seedBook(relativePath: "c.txt", rank: 2)
+    harness.save()
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let next = playbackService.getPlayableItem(
+      after: "a.txt", parentFolder: nil, autoplayed: true, restartFinished: false
+    )
+    XCTAssertEqual(next?.relativePath, "c.txt")
+  }
+
+  func testFolderTapPicksFirstUnfinishedInRankOrder() throws {
+    let folder = harness.seedFolder(relativePath: "novels", rank: 0)
+    harness.seedBook(relativePath: "novels/one.txt", rank: 0, into: folder, isFinished: true)
+    harness.seedBook(relativePath: "novels/two.txt", rank: 1, into: folder)
+    harness.seedBook(relativePath: "novels/three.txt", rank: 2, into: folder)
+    harness.save()
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let folderItem = try XCTUnwrap(libraryService.getSimpleItem(with: "novels"))
+    let first = try playbackService.getFirstPlayableItem(in: folderItem, isUnfinished: true)
+
+    XCTAssertEqual(first?.relativePath, "novels/two.txt")
+  }
+
+  // MARK: - Bound books: the rank order IS the playback timeline, sort-proof
+
+  func testBoundBookTimelineFollowsRankOrderRegardlessOfRootSort() throws {
+    let bound = harness.seedFolder(relativePath: "bnd", rank: 0, type: .bound)
+    // Ranks deliberately disagree with any title/filename order.
+    harness.seedBook(relativePath: "bnd/03 part.mp3", rank: 0, into: bound)
+    harness.seedBook(relativePath: "bnd/01 part.mp3", rank: 1, into: bound)
+    harness.seedBook(relativePath: "bnd/02 part.mp3", rank: 2, into: bound)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let boundItem = try XCTUnwrap(libraryService.getSimpleItem(with: "bnd"))
+    let playable = try playbackService.getPlayableItem(from: boundItem)
+
+    XCTAssertEqual(
+      playable.chapters.map(\.relativePath),
+      ["bnd/03 part.mp3", "bnd/01 part.mp3", "bnd/02 part.mp3"]
+    )
+  }
+
+  // MARK: - One-shot sort on .unresolved locations (a bulk custom rearrangement)
+
+  func testOneShotSortOnUnresolvedRewritesRanksWithoutPersistingPref() {
+    let folder = harness.seedFolder(
+      relativePath: "migrating",
+      rank: 0,
+      uuid: Constants.uuidPlaceholder
+    )
+    harness.seedBook(relativePath: "migrating/cherry.txt", rank: 0, into: folder)
+    harness.seedBook(relativePath: "migrating/apple.txt", rank: 1, into: folder)
+    harness.save()
+
+    libraryService.sortContents(at: "migrating", by: .metadataTitle)
+
+    XCTAssertEqual(
+      harness.renderedOrder(at: "migrating"),
+      ["migrating/apple.txt", "migrating/cherry.txt"]
+    )
+    XCTAssertFalse(
+      harness.hasAnySortPreferencePersisted,
+      "an .unresolved location must never persist a sticky-sort preference"
+    )
+  }
+
+  // MARK: - Per-folder independence (no inheritance from root)
+
+  func testFolderDoesNotInheritRootSort() {
+    let folder = harness.seedFolder(relativePath: "series", rank: 0)
+    harness.seedBook(relativePath: "series/zeta.txt", rank: 0, into: folder)
+    harness.seedBook(relativePath: "series/alpha.txt", rank: 1, into: folder)
+    harness.save()
+
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+
+    XCTAssertEqual(
+      harness.renderedOrder(at: "series"),
+      ["series/zeta.txt", "series/alpha.txt"],
+      "a folder keeps its own (custom) order when only the root pref is set"
+    )
+  }
+}

--- a/BookPlayerTests/Services/SortCharacterizationTests.swift
+++ b/BookPlayerTests/Services/SortCharacterizationTests.swift
@@ -19,6 +19,12 @@
 import CoreData
 import XCTest
 
+/// @MainActor because the sync-path tests write on the background context and
+/// then assert via view-context fetches; async XCTest methods otherwise run off
+/// the main thread, racing the background→view merge (CI crashed with
+/// "Collection was mutated while being enumerated" inside a view-context fetch).
+/// Production accesses the view context from the main actor — tests must too.
+@MainActor
 final class SortCharacterizationTests: XCTestCase {
   private var harness: SortIntegrationHarness!
   private var libraryService: LibraryService { harness.libraryService }

--- a/BookPlayerTests/Support/SortIntegrationHarness.swift
+++ b/BookPlayerTests/Support/SortIntegrationHarness.swift
@@ -1,0 +1,140 @@
+//
+//  SortIntegrationHarness.swift
+//  BookPlayerTests
+//
+//  A LibraryService wired to a REAL PreferencesSyncService over an isolated
+//  UserDefaults suite — the integration seam for sticky-sort behavior, where the
+//  preference layer's real resolution rules (SortLocation gates, key routing)
+//  apply instead of a mock's canned answers.
+//
+//  `bootstrap()` is deliberately never called: no KVO, no network, no dirty
+//  list — only the resolver surface (`setSort`/`effectiveSort`) that the
+//  LibraryService hooks consume.
+//
+//  The store is a real SQLite file in a per-instance temp location (not the
+//  usual `/dev/null`) because sync-path tests write on the background context
+//  and read back on the view context; a real store keeps that path
+//  production-faithful. Call `tearDown()` from the test's `tearDown`.
+//
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import CoreData
+import Foundation
+
+final class SortIntegrationHarness {
+  let dataManager: DataManager
+  let libraryService: LibraryService
+  let preferences: PreferencesSyncService
+  let defaults: UserDefaults
+
+  private let suiteName: String
+  private let storePath: String
+
+  init() {
+    DataTestUtils.clearFolderContents(url: DataManager.getProcessedFolderURL())
+
+    storePath = NSTemporaryDirectory() + "SortIntegrationHarness-\(UUID().uuidString).sqlite"
+    dataManager = DataManager(coreDataStack: CoreDataStack(testPath: storePath))
+    libraryService = LibraryService()
+    libraryService.setup(dataManager: dataManager, audioMetadataService: AudioMetadataService())
+    _ = libraryService.getLibrary()
+
+    suiteName = "SortIntegrationHarness.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    preferences = PreferencesSyncService()
+    preferences.setup(
+      accountService: AccountServiceMock(account: nil),
+      libraryService: libraryService,
+      defaults: defaults,
+      client: NetworkClientMock(mockedResponse: Empty())
+    )
+    libraryService.preferencesService = preferences
+  }
+
+  func tearDown() {
+    defaults.removePersistentDomain(forName: suiteName)
+    // The store files are left in the simulator's tmp dir on purpose: deleting
+    // them while the NSPersistentContainer still holds them open trips SQLite's
+    // "vnode unlinked while in use" API-violation warning.
+  }
+
+  // MARK: - Seeding
+
+  /// Inserts a Book row directly (no file on disk). Ranks are the caller's
+  /// responsibility so tests can seed adversarial arrangements.
+  @discardableResult
+  func seedBook(
+    relativePath: String,
+    title: String? = nil,
+    rank: Int16,
+    into folder: Folder? = nil,
+    isFinished: Bool = false,
+    lastPlayDate: Date? = nil,
+    duration: Double = 100
+  ) -> Book {
+    let context = dataManager.getContext()
+    // swiftlint:disable:next force_cast
+    let book = NSEntityDescription.insertNewObject(forEntityName: "Book", into: context) as! Book
+    book.relativePath = relativePath
+    book.title = title ?? relativePath
+    book.originalFileName = (relativePath as NSString).lastPathComponent
+    book.details = "seed-author"
+    book.duration = duration
+    book.isFinished = isFinished
+    book.lastPlayDate = lastPlayDate
+    book.type = .book
+    book.uuid = UUID().uuidString
+    book.orderRank = rank
+    if let folder {
+      folder.addToItems(book)
+    } else {
+      libraryService.getLibraryReference().addToItems(book)
+    }
+    return book
+  }
+
+  /// Inserts a Folder row at the root. Pass a placeholder `uuid` (or `""`) to
+  /// produce an `.unresolved` location; pass `type: .bound` for a bound book.
+  @discardableResult
+  func seedFolder(
+    relativePath: String,
+    rank: Int16,
+    uuid: String? = nil,
+    type: SimpleItemType = .folder
+  ) -> Folder {
+    let folder = Folder(title: relativePath, context: dataManager.getContext())
+    if let uuid {
+      folder.uuid = uuid
+    }
+    folder.type = type.itemType
+    folder.orderRank = rank
+    libraryService.getLibraryReference().addToItems(folder)
+    return folder
+  }
+
+  func save() {
+    dataManager.saveContext()
+  }
+
+  // MARK: - Observations
+
+  /// The order the list UI would render (fetchContents is the render fetch).
+  func renderedOrder(at relativePath: String? = nil) -> [String] {
+    let contents = libraryService.fetchContents(at: relativePath, limit: nil, offset: nil) ?? []
+    return contents.map(\.relativePath)
+  }
+
+  /// The persisted rank column, keyed by relativePath, fetched fresh from the store.
+  func rankColumn(at relativePath: String? = nil) -> [String: Int16] {
+    let contents = libraryService.fetchContents(at: relativePath, limit: nil, offset: nil) ?? []
+    return Dictionary(uniqueKeysWithValues: contents.map { ($0.relativePath, $0.orderRank) })
+  }
+
+  /// True when any `library_sort:*` key was persisted in the isolated suite.
+  var hasAnySortPreferencePersisted: Bool {
+    defaults.dictionaryRepresentation().keys.contains {
+      $0.hasPrefix(Constants.UserDefaults.librarySortPrefix)
+    }
+  }
+}

--- a/BookPlayerTests/Support/SyncResponseFixtures.swift
+++ b/BookPlayerTests/Support/SyncResponseFixtures.swift
@@ -1,0 +1,89 @@
+//
+//  SyncResponseFixtures.swift
+//  BookPlayerTests
+//
+//  Builders for server sync payloads. Every fixture round-trips raw JSON through
+//  the real decoder (the same pattern as `makeServerResponse` in
+//  PreferencesSyncServiceTests) so tests stay honest about the wire format —
+//  including quirks like a missing `orderRank` decoding to 0.
+//
+
+@testable import BookPlayerKit
+import Foundation
+
+enum SyncResponseFixtures {
+  enum FixtureError: Error {
+    case notJSONCompatible
+  }
+
+  /// Raw JSON for one `/v1/library` content entry. Pass `orderRank: nil` to omit
+  /// the field entirely (exercises the `?? 0` decode default).
+  static func itemJSON(
+    relativePath: String,
+    title: String? = nil,
+    originalFileName: String? = nil,
+    orderRank: Int? = 0,
+    type: SimpleItemType = .book,
+    isFinished: Bool = false,
+    duration: Double = 100,
+    currentTime: Double = 0,
+    percentCompleted: Double = 0,
+    speed: Double? = nil,
+    lastPlayDateTimestamp: Double? = nil,
+    uuid: String? = nil,
+    details: String = "fixture-author"
+  ) -> [String: Any] {
+    var json: [String: Any] = [
+      "relativePath": relativePath,
+      "originalFileName": originalFileName ?? (relativePath as NSString).lastPathComponent,
+      "title": title ?? relativePath,
+      "isFinished": isFinished,
+      "type": Int(type.rawValue),
+      "duration": duration,
+      "currentTime": currentTime,
+      "percentCompleted": percentCompleted,
+      "details": details,
+      "uuid": uuid ?? UUID().uuidString,
+    ]
+    if let orderRank {
+      json["orderRank"] = orderRank
+    }
+    if let speed {
+      json["speed"] = speed
+    }
+    if let lastPlayDateTimestamp {
+      json["lastPlayDateTimestamp"] = lastPlayDateTimestamp
+    }
+    return json
+  }
+
+  static func makeSyncableItem(_ json: [String: Any]) throws -> SyncableItem {
+    return try decode(json)
+  }
+
+  /// Items keyed by relativePath — the shape `updateInfo(for:parentFolder:)` and
+  /// `storeNewItems(from:parentFolder:)` consume (see `processContentsResponse`).
+  static func makeItemsDictionary(_ jsons: [[String: Any]]) throws -> [String: SyncableItem] {
+    let items: [SyncableItem] = try jsons.map { try decode($0) }
+    return Dictionary(items.map { ($0.relativePath, $0) }) { first, _ in first }
+  }
+
+  static func makeContentsResponse(
+    content: [[String: Any]],
+    lastItemPlayed: [String: Any]? = nil
+  ) throws -> ContentsResponse {
+    var json: [String: Any] = ["content": content]
+    if let lastItemPlayed {
+      json["lastItemPlayed"] = lastItemPlayed
+    }
+    return try decode(json)
+  }
+
+  private static func decode<T: Decodable>(_ object: Any) throws -> T {
+    guard JSONSerialization.isValidJSONObject(object) else {
+      throw FixtureError.notJSONCompatible
+    }
+    let data = try JSONSerialization.data(withJSONObject: object)
+    return try JSONDecoder().decode(T.self, from: data)
+  }
+}


### PR DESCRIPTION
## Context

Pro users report the library list scrambling on pull-to-refresh when a sticky sort is selected: the sync pull unconditionally copies stale server `orderRank` values over local rows (`LibraryService+Sync.swift:157`), and the only compensating re-sort (Hook 4) fires solely when the pull inserted a new item. Rather than patching the guard, the sort is being refactored to a **query-time transform** (the Android model): sort descriptors built at fetch time from the sticky preference, with `orderRank` meaning only the user's custom arrangement.

This PR is **Phase 0 — the safety net.** Zero production-code changes; it merges independently of the refactor itself.

## What's included

- **`QueryTimeSortSpikeTests`** — proves the Core Data SQLite store supports the exact descriptor recipes the refactor will ship: `localizedStandardCompare:` selectors combined with `dictionaryResultType` + `fetchLimit`/`fetchOffset`, NULL `lastPlayDate` sorting last under DESC (matching `?? .distantPast`), an `orderRank` tie-breaker making ordering deterministic (today's in-memory `sorted(by:)` is not stable), stable pagination, and parity between the `/dev/null` test-store pattern and a real SQLite file. All green — the design needs no pivot.
- **`SortCharacterizationTests`** — pins the user-visible behavior that must survive the refactor byte-for-byte: rendered order when picking a sort, reverse-under-automatic-sort, import and sync-insert landing sorted under Title / rank-faithful under Custom, the sync-pull rank write, playback prev/next + autoplay-skips-finished + folder-tap-first-unfinished, the bound-book timeline staying rank-ordered regardless of the root pref, one-shot sort on `.unresolved` locations never persisting a pref, and per-folder sort independence.
- **`SortIntegrationHarness`** — `LibraryService` wired to a **real** `PreferencesSyncService` (real `SortLocation` gates and key routing) over a per-test temp-file SQLite store and isolated `UserDefaults` suite.
- **`SyncResponseFixtures`** — `SyncableItem`/`ContentsResponse` builders that round-trip raw JSON through the real decoder, so the wire format stays honest (including the missing-`orderRank`-decodes-to-0 quirk).

## Notable finding pinned as-is

Move-out rank compaction (`rebuildOrderRank`) only runs when the **source is a folder** — a root-level source keeps sparse ranks (`moveItems` gates the call on a non-nil parent path). Sparse ranks are harmless for ordering; both behaviors are characterized.

## Testing

Full `Unit Tests` plan passes locally (Xcode 26.6, iPhone 17 Pro simulator), including the 22 new tests.