### PR TITLE
Query-time sort refactor — Phase 1: orderRank becomes custom-arrangement-only

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		62AAE22D274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
 		62AAE22E274AA6DE001EB9FF /* LibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE22B274AA3EB001EB9FF /* LibraryService.swift */; };
 		62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */; };
+		689DBBD518EB5F7760ED1518 /* QueryTimeSortRefactorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C78CCAAFEB5A9D78AA108EC /* QueryTimeSortRefactorTests.swift */; };
 		5B1559A45658B195521CC454 /* SyncResponseFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6581B92E4D292C2AFC361A /* SyncResponseFixtures.swift */; };
 		5A589702CFB4A8F8EC55AC3F /* SortIntegrationHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF448F75392B02FC5451289 /* SortIntegrationHarness.swift */; };
 		9DA710A0CC53EEC5F7AF93D3 /* QueryTimeSortSpikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */; };
@@ -1332,6 +1333,7 @@
 		624EB9832755D8E700D462A8 /* Audiobook Player 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Audiobook Player 8.xcdatamodel"; sourceTree = "<group>"; };
 		62AAE22B274AA3EB001EB9FF /* LibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryService.swift; sourceTree = "<group>"; };
 		62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryServiceTests.swift; sourceTree = "<group>"; };
+		4C78CCAAFEB5A9D78AA108EC /* QueryTimeSortRefactorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryTimeSortRefactorTests.swift; sourceTree = "<group>"; };
 		1C6581B92E4D292C2AFC361A /* SyncResponseFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncResponseFixtures.swift; sourceTree = "<group>"; };
 		2AF448F75392B02FC5451289 /* SortIntegrationHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortIntegrationHarness.swift; sourceTree = "<group>"; };
 		53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryTimeSortSpikeTests.swift; sourceTree = "<group>"; };
@@ -3216,6 +3218,7 @@
 				69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */,
 				6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */,
 				62AAE230274ABB5D001EB9FF /* LibraryServiceTests.swift */,
+				4C78CCAAFEB5A9D78AA108EC /* QueryTimeSortRefactorTests.swift */,
 				53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */,
 				F448E8BBF01860FC65EB697A /* SortCharacterizationTests.swift */,
 				9FC1E4662815091A00522FA8 /* AccountServiceTests.swift */,
@@ -4975,6 +4978,7 @@
 				8AF18A3B2CF0E92F00238F8D /* KeychainServiceMock.swift in Sources */,
 				9F7C47532A2C15D300F9A500 /* AutoMockable.generated.swift in Sources */,
 				62AAE231274ABB5D001EB9FF /* LibraryServiceTests.swift in Sources */,
+				689DBBD518EB5F7760ED1518 /* QueryTimeSortRefactorTests.swift in Sources */,
 				5B1559A45658B195521CC454 /* SyncResponseFixtures.swift in Sources */,
 				5A589702CFB4A8F8EC55AC3F /* SortIntegrationHarness.swift in Sources */,
 				9DA710A0CC53EEC5F7AF93D3 /* QueryTimeSortSpikeTests.swift in Sources */,

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -418,6 +418,26 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return findFirstItemInIsUnfinishedReturnValue
         }
     }
+    //MARK: - getOrderedSiblings
+
+    var getOrderedSiblingsInCallsCount = 0
+    var getOrderedSiblingsInCalled: Bool {
+        return getOrderedSiblingsInCallsCount > 0
+    }
+    var getOrderedSiblingsInReceivedParentFolder: String?
+    var getOrderedSiblingsInReceivedInvocations: [String?] = []
+    var getOrderedSiblingsInReturnValue: [SimpleNavigationItem]?
+    var getOrderedSiblingsInClosure: ((String?) -> [SimpleNavigationItem]?)?
+    func getOrderedSiblings(in parentFolder: String?) -> [SimpleNavigationItem]? {
+        getOrderedSiblingsInCallsCount += 1
+        getOrderedSiblingsInReceivedParentFolder = parentFolder
+        getOrderedSiblingsInReceivedInvocations.append(parentFolder)
+        if let getOrderedSiblingsInClosure = getOrderedSiblingsInClosure {
+            return getOrderedSiblingsInClosure(parentFolder)
+        } else {
+            return getOrderedSiblingsInReturnValue
+        }
+    }
     //MARK: - getChapters
 
     var getChaptersFromCallsCount = 0

--- a/BookPlayer/Generated/AutoMockable.generated.swift
+++ b/BookPlayer/Generated/AutoMockable.generated.swift
@@ -418,46 +418,6 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
             return findFirstItemInIsUnfinishedReturnValue
         }
     }
-    //MARK: - findFirstItem
-
-    var findFirstItemInBeforeRankCallsCount = 0
-    var findFirstItemInBeforeRankCalled: Bool {
-        return findFirstItemInBeforeRankCallsCount > 0
-    }
-    var findFirstItemInBeforeRankReceivedArguments: (parentFolder: String?, beforeRank: Int16?)?
-    var findFirstItemInBeforeRankReceivedInvocations: [(parentFolder: String?, beforeRank: Int16?)] = []
-    var findFirstItemInBeforeRankReturnValue: SimpleLibraryItem?
-    var findFirstItemInBeforeRankClosure: ((String?, Int16?) -> SimpleLibraryItem?)?
-    func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem? {
-        findFirstItemInBeforeRankCallsCount += 1
-        findFirstItemInBeforeRankReceivedArguments = (parentFolder: parentFolder, beforeRank: beforeRank)
-        findFirstItemInBeforeRankReceivedInvocations.append((parentFolder: parentFolder, beforeRank: beforeRank))
-        if let findFirstItemInBeforeRankClosure = findFirstItemInBeforeRankClosure {
-            return findFirstItemInBeforeRankClosure(parentFolder, beforeRank)
-        } else {
-            return findFirstItemInBeforeRankReturnValue
-        }
-    }
-    //MARK: - findFirstItem
-
-    var findFirstItemInAfterRankIsUnfinishedCallsCount = 0
-    var findFirstItemInAfterRankIsUnfinishedCalled: Bool {
-        return findFirstItemInAfterRankIsUnfinishedCallsCount > 0
-    }
-    var findFirstItemInAfterRankIsUnfinishedReceivedArguments: (parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?)?
-    var findFirstItemInAfterRankIsUnfinishedReceivedInvocations: [(parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?)] = []
-    var findFirstItemInAfterRankIsUnfinishedReturnValue: SimpleLibraryItem?
-    var findFirstItemInAfterRankIsUnfinishedClosure: ((String?, Int16?, Bool?) -> SimpleLibraryItem?)?
-    func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) -> SimpleLibraryItem? {
-        findFirstItemInAfterRankIsUnfinishedCallsCount += 1
-        findFirstItemInAfterRankIsUnfinishedReceivedArguments = (parentFolder: parentFolder, afterRank: afterRank, isUnfinished: isUnfinished)
-        findFirstItemInAfterRankIsUnfinishedReceivedInvocations.append((parentFolder: parentFolder, afterRank: afterRank, isUnfinished: isUnfinished))
-        if let findFirstItemInAfterRankIsUnfinishedClosure = findFirstItemInAfterRankIsUnfinishedClosure {
-            return findFirstItemInAfterRankIsUnfinishedClosure(parentFolder, afterRank, isUnfinished)
-        } else {
-            return findFirstItemInAfterRankIsUnfinishedReturnValue
-        }
-    }
     //MARK: - getChapters
 
     var getChaptersFromCallsCount = 0
@@ -660,21 +620,6 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         updateDetailsAtDetailsReceivedInvocations.append((relativePath: relativePath, details: details))
         updateDetailsAtDetailsClosure?(relativePath, details)
     }
-    //MARK: - reorderItem
-
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathCallsCount = 0
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathCalled: Bool {
-        return reorderItemWithInsideSourceIndexPathDestinationIndexPathCallsCount > 0
-    }
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedArguments: (relativePath: String, folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath)?
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedInvocations: [(relativePath: String, folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath)] = []
-    var reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure: ((String, String?, IndexPath, IndexPath) -> Void)?
-    func reorderItem(with relativePath: String, inside folderRelativePath: String?, sourceIndexPath: IndexPath, destinationIndexPath: IndexPath) {
-        reorderItemWithInsideSourceIndexPathDestinationIndexPathCallsCount += 1
-        reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedArguments = (relativePath: relativePath, folderRelativePath: folderRelativePath, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath)
-        reorderItemWithInsideSourceIndexPathDestinationIndexPathReceivedInvocations.append((relativePath: relativePath, folderRelativePath: folderRelativePath, sourceIndexPath: sourceIndexPath, destinationIndexPath: destinationIndexPath))
-        reorderItemWithInsideSourceIndexPathDestinationIndexPathClosure?(relativePath, folderRelativePath, sourceIndexPath, destinationIndexPath)
-    }
     //MARK: - sortContents
 
     var sortContentsAtByCallsCount = 0
@@ -690,20 +635,20 @@ class LibraryServiceProtocolMock: LibraryServiceProtocol {
         sortContentsAtByReceivedInvocations.append((relativePath: relativePath, type: type))
         sortContentsAtByClosure?(relativePath, type)
     }
-    //MARK: - sortContents
+    //MARK: - adoptCurrentOrderAsCustom
 
-    var sortContentsInByCallsCount = 0
-    var sortContentsInByCalled: Bool {
-        return sortContentsInByCallsCount > 0
+    var adoptCurrentOrderAsCustomAtCallsCount = 0
+    var adoptCurrentOrderAsCustomAtCalled: Bool {
+        return adoptCurrentOrderAsCustomAtCallsCount > 0
     }
-    var sortContentsInByReceivedArguments: (location: SortLocation, type: SortType)?
-    var sortContentsInByReceivedInvocations: [(location: SortLocation, type: SortType)] = []
-    var sortContentsInByClosure: ((SortLocation, SortType) -> Void)?
-    func sortContents(in location: SortLocation, by type: SortType) {
-        sortContentsInByCallsCount += 1
-        sortContentsInByReceivedArguments = (location: location, type: type)
-        sortContentsInByReceivedInvocations.append((location: location, type: type))
-        sortContentsInByClosure?(location, type)
+    var adoptCurrentOrderAsCustomAtReceivedRelativePath: String?
+    var adoptCurrentOrderAsCustomAtReceivedInvocations: [String?] = []
+    var adoptCurrentOrderAsCustomAtClosure: ((String?) -> Void)?
+    func adoptCurrentOrderAsCustom(at relativePath: String?) {
+        adoptCurrentOrderAsCustomAtCallsCount += 1
+        adoptCurrentOrderAsCustomAtReceivedRelativePath = relativePath
+        adoptCurrentOrderAsCustomAtReceivedInvocations.append(relativePath)
+        adoptCurrentOrderAsCustomAtClosure?(relativePath)
     }
     //MARK: - reverseContents
 

--- a/BookPlayer/Library/ItemList/ItemListView+Sheets.swift
+++ b/BookPlayer/Library/ItemList/ItemListView+Sheets.swift
@@ -33,12 +33,13 @@ extension ItemListView {
       onSelectionChange: { effective in
         switch effective {
         case .automatic(let sort):
-          // Goes through `sortContents` which rewrites ranks and writes the pref via Hook 1.
+          // Persists the sticky pref; the list re-fetches with the rule's
+          // query-time sort descriptors.
           model.handleSort(by: sort)
         case .custom:
-          // No drag happened — just flip the pref. orderRanks stay where they are; from now
-          // on, sync will push rank changes since the location is no longer auto-sorted.
-          preferencesService.setSort(.custom, forLocation: location)
+          // Freezes the currently-visible order into orderRank (WYSIWYG) and
+          // flips the pref — the frozen arrangement syncs like a manual drag.
+          model.handleSetCustomSort()
         }
       },
       onReverseOrder: {

--- a/BookPlayer/Library/ItemList/ItemListView.swift
+++ b/BookPlayer/Library/ItemList/ItemListView.swift
@@ -84,10 +84,9 @@ struct ItemListView: View {
         }
       }
       .onReceive(preferencesService.preferencesChanged.receive(on: DispatchQueue.main)) { key in
-        // Server-driven sort change for the location currently on screen:
-        // PreferencesSyncService has already rewritten orderRank in CoreData
-        // via dispatchResort → sortContents. The cached `[SimpleLibraryItem]`
-        // in the view model is stale until we trigger a reload here.
+        // Server-driven sort change for the location currently on screen: the
+        // pulled pref value is already stored, and order is derived from it at
+        // query time — so a re-fetch here is the entire application step.
         guard model.libraryNode.matchesSortPrefKey(key) else { return }
         listState.reloadAll()
       }

--- a/BookPlayer/Library/ItemList/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList/ItemListViewModel.swift
@@ -341,6 +341,12 @@ final class ItemListViewModel: ObservableObject {
     reloadItems()
   }
 
+  /// The picker's "Custom" option: freezes the currently-visible order into
+  /// `orderRank` (WYSIWYG — no visible change) and flips the sticky pref.
+  func handleSetCustomSort() {
+    libraryService.adoptCurrentOrderAsCustom(at: libraryNode.folderRelativePath)
+  }
+
   func handleReverseOrder() {
     libraryService.reverseContents(at: libraryNode.folderRelativePath)
     reloadItems()

--- a/BookPlayer/Library/ItemList/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList/ItemListViewModel.swift
@@ -139,8 +139,13 @@ final class ItemListViewModel: ObservableObject {
         offset: offset
       ) ?? []
 
-    items += fetchedItems
-    offset = items.count
+    /// Under a live sort key ("Most recent" while playing) rows can shift
+    /// between page fetches, re-returning an item already loaded — and a
+    /// duplicate id breaks SwiftUI's ForEach. Advance the offset by what was
+    /// fetched, but only append unseen items.
+    offset += fetchedItems.count
+    let loadedIds = Set(items.map(\.id))
+    items += fetchedItems.filter { !loadedIds.contains($0.id) }
 
     canLoadMore = fetchedItems.count == pageSize
     isLoading = false

--- a/BookPlayer/Library/ItemList/Views/LibraryOptionsView.swift
+++ b/BookPlayer/Library/ItemList/Views/LibraryOptionsView.swift
@@ -185,10 +185,11 @@ struct LibraryOptionsView: View {
     .presentationDetents([.medium])
   }
 
-  /// Single-tap action for `.unresolved` locations. The user picks a sort,
-  /// items are re-ranked locally via `onSelectionChange → handleSort →
-  /// sortContents(at:by:)`, and the resolver no-ops the pref write because
-  /// the location resolves to `.unresolved`.
+  /// Single-tap action for `.unresolved` locations. The user picks a sort and
+  /// `onSelectionChange → handleSort → sortContents(at:by:)` takes the
+  /// one-shot path: ranks are rewritten once (a bulk custom rearrangement,
+  /// synced like any manual reorder) and no sticky preference is persisted —
+  /// `.unresolved` locations have no preference key.
   @ViewBuilder
   private func oneShotSortRow(
     _ sort: SortType,

--- a/BookPlayerTests/Services/LibraryServiceTests.swift
+++ b/BookPlayerTests/Services/LibraryServiceTests.swift
@@ -1114,7 +1114,7 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(sortedFolderContents?[3].title == book4.title)
   }
 
-  func testReorderItem() throws {
+  func testReorderItems() throws {
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
@@ -1125,11 +1125,10 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(contents?[0].title == book3.title)
     XCTAssert(contents?[2].title == book1.title)
 
-    self.sut.reorderItem(
-      with: book3.relativePath,
+    self.sut.reorderItems(
       inside: nil,
-      sourceIndexPath: IndexPath(row: 0, section: 0),
-      destinationIndexPath: IndexPath(row: 2, section: 0)
+      fromOffsets: IndexSet(integer: 0),
+      toOffset: 3
     )
 
     let sortedContents = sut.fetchContents(at: nil, limit: nil, offset: nil)
@@ -1146,11 +1145,10 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(folderContents?[0].title == book1.title)
     XCTAssert(folderContents?[2].title == book3.title)
 
-    self.sut.reorderItem(
-      with: book3.relativePath,
+    self.sut.reorderItems(
       inside: folder.relativePath,
-      sourceIndexPath: IndexPath(row: 2, section: 0),
-      destinationIndexPath: IndexPath(row: 0, section: 0)
+      fromOffsets: IndexSet(integer: 2),
+      toOffset: 0
     )
 
     let sortedFolderContents = sut.fetchContents(at: folder.relativePath, limit: nil, offset: nil)
@@ -1395,7 +1393,9 @@ class ModifyLibraryTests: LibraryServiceTests {
     XCTAssert(fetchedBook4?.relativePath == book4.relativePath)
   }
 
-  func testFindItemBeforeRank() throws {
+  /// Previous-item navigation walks the visible order, hopping up to the
+  /// parent folder at boundaries (replaces the old `beforeRank` cursor).
+  func testFindPreviousPlayableItem() throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
@@ -1403,17 +1403,26 @@ class ModifyLibraryTests: LibraryServiceTests {
     let book3 = StubFactory.book(dataManager: self.sut.dataManager, title: "book3", duration: 100)
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     try self.sut.moveItems([LibraryItemRef(relativePath: book3.relativePath, uuid: book3.uuid), LibraryItemRef(relativePath: book4.relativePath, uuid: book4.uuid)], inside: folder.relativePath)
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: self.sut)
 
-    let fetchedBook1 = self.sut.findFirstItem(in: nil, beforeRank: 1)
+    let previousOfBook2 = playbackService.getPlayableItem(before: book2.relativePath, parentFolder: nil)
+    XCTAssertEqual(previousOfBook2?.relativePath, book1.relativePath)
 
-    XCTAssert(fetchedBook1?.relativePath == book1.relativePath)
+    let previousOfBook4 = playbackService.getPlayableItem(before: book4.relativePath, parentFolder: folder.relativePath)
+    XCTAssertEqual(previousOfBook4?.relativePath, book3.relativePath)
 
-    let fetchedBook2 = self.sut.findFirstItem(in: folder.relativePath, beforeRank: 1)
+    // First item of the folder: hops up and resolves the sibling above the folder.
+    let previousOfBook3 = playbackService.getPlayableItem(before: book3.relativePath, parentFolder: folder.relativePath)
+    XCTAssertEqual(previousOfBook3?.relativePath, book2.relativePath)
 
-    XCTAssert(fetchedBook2?.relativePath == book3.relativePath)
+    let previousOfFirst = playbackService.getPlayableItem(before: book1.relativePath, parentFolder: nil)
+    XCTAssertNil(previousOfFirst)
   }
 
-  func testFindItemAfterRank() throws {
+  /// Next-item navigation walks the visible order with the autoplay
+  /// unfinished filter (replaces the old `afterRank` cursor).
+  func testFindNextPlayableItem() throws {
     let book1 = StubFactory.book(dataManager: self.sut.dataManager, title: "book1", duration: 100)
     let book2 = StubFactory.book(dataManager: self.sut.dataManager, title: "book2", duration: 100)
     let folder = try StubFactory.folder(dataManager: self.sut.dataManager, title: "folder")
@@ -1422,21 +1431,33 @@ class ModifyLibraryTests: LibraryServiceTests {
     let book4 = StubFactory.book(dataManager: self.sut.dataManager, title: "book4", duration: 100)
     try self.sut.moveItems([LibraryItemRef(relativePath: book3.relativePath, uuid: book3.uuid), LibraryItemRef(relativePath: book4.relativePath, uuid: book4.uuid)], inside: folder.relativePath)
 
-    book1.isFinished = true
     book3.isFinished = true
     self.sut.dataManager.saveContext()
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: self.sut)
 
-    let fetchedBook1 = self.sut.findFirstItem(in: nil, afterRank: nil, isUnfinished: nil)
-    let fetchedBook2 = self.sut.findFirstItem(in: nil, afterRank: 0, isUnfinished: true)
+    let nextOfBook1 = playbackService.getPlayableItem(
+      after: book1.relativePath, parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertEqual(nextOfBook1?.relativePath, book2.relativePath)
 
-    XCTAssert(fetchedBook1?.relativePath == book1.relativePath)
-    XCTAssert(fetchedBook2?.relativePath == book2.relativePath)
+    // Next of book2 is the folder: descends to its first child.
+    let nextOfBook2 = playbackService.getPlayableItem(
+      after: book2.relativePath, parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertEqual(nextOfBook2?.relativePath, book3.relativePath)
 
-    let fetchedBook3 = self.sut.findFirstItem(in: folder.relativePath, afterRank: nil, isUnfinished: nil)
-    let fetchedBook4 = self.sut.findFirstItem(in: folder.relativePath, afterRank: 0, isUnfinished: true)
+    // Autoplay skips finished items when descending.
+    let nextOfBook2Autoplay = playbackService.getPlayableItem(
+      after: book2.relativePath, parentFolder: nil, autoplayed: true, restartFinished: false
+    )
+    XCTAssertEqual(nextOfBook2Autoplay?.relativePath, book4.relativePath)
 
-    XCTAssert(fetchedBook3?.relativePath == book3.relativePath)
-    XCTAssert(fetchedBook4?.relativePath == book4.relativePath)
+    // Last item of the last folder: hops up, nothing after the folder → nil.
+    let nextOfLast = playbackService.getPlayableItem(
+      after: book4.relativePath, parentFolder: folder.relativePath, autoplayed: false, restartFinished: false
+    )
+    XCTAssertNil(nextOfLast)
   }
 
   func testFilterBookItems() throws {

--- a/BookPlayerTests/Services/PreferencesSyncServiceTests.swift
+++ b/BookPlayerTests/Services/PreferencesSyncServiceTests.swift
@@ -386,11 +386,13 @@ final class PreferencesSyncServiceTests: XCTestCase {
     // by key prefix — so a sort entry and a display entry can ride the
     // same response and both land correctly.
     //
-    // The `sortContentsInByCallsCount` assertion guards against a
-    // regression of the cross-prefix snapshot drift bug: with the
-    // single-request pull, exactly ONE side-effect dispatch should
-    // happen per applied sort key. A higher count would mean an entry
-    // is being applied (and its side effect fired) more than once.
+    // The publish-count assertion guards against a regression of the
+    // cross-prefix snapshot drift bug: with the single-request pull,
+    // exactly ONE `preferencesChanged` publish should happen per applied
+    // key. A higher count would mean an entry is being applied (and its
+    // change broadcast) more than once. The zero-rank-writes assertions
+    // pin the query-time-sort contract: a pulled sort pref is data, never
+    // a rank mutation.
     account.syncEnabled = true
 
     let libraryServiceMock = LibraryServiceProtocolMock()
@@ -416,7 +418,11 @@ final class PreferencesSyncServiceTests: XCTestCase {
       client: NetworkClientMock(mockedResponse: response)
     )
 
+    var publishedKeys: [String] = []
+    let subscription = sut.preferencesChanged.sink { publishedKeys.append($0) }
+
     await sut.pullFromServer(force: true)
+    subscription.cancel()
 
     XCTAssertEqual(
       sut.effectiveSort(forLocation: .libraryRoot),
@@ -424,9 +430,16 @@ final class PreferencesSyncServiceTests: XCTestCase {
     )
     XCTAssertTrue(defaults.bool(forKey: Constants.UserDefaults.libraryDisplayProgressStyle))
 
-    // Exactly one resort dispatch — for the sort entry. The display
-    // entry's side effect is `.none`, so it should not contribute.
-    XCTAssertEqual(libraryServiceMock.sortContentsInByCallsCount, 1)
+    // Exactly one publish per applied key — no duplicate application.
+    XCTAssertEqual(publishedKeys.sorted(), [
+      Constants.UserDefaults.libraryDisplayProgressStyle,
+      Constants.UserDefaults.librarySortDefault,
+    ].sorted())
+
+    // A pulled sort pref never mutates ranks: order is derived at query time.
+    XCTAssertEqual(libraryServiceMock.sortContentsAtByCallsCount, 0)
+    XCTAssertEqual(libraryServiceMock.adoptCurrentOrderAsCustomAtCallsCount, 0)
+    XCTAssertEqual(libraryServiceMock.reverseContentsAtCallsCount, 0)
   }
 
   func testPullRejectsIntOutsideBoolRange() async {

--- a/BookPlayerTests/Services/QueryTimeSortRefactorTests.swift
+++ b/BookPlayerTests/Services/QueryTimeSortRefactorTests.swift
@@ -1,0 +1,223 @@
+//
+//  QueryTimeSortRefactorTests.swift
+//  BookPlayerTests
+//
+//  The query-time-sort refactor's own suite: asserts the NEW contract that
+//  SortCharacterizationTests deliberately couldn't — `orderRank` is owned by
+//  the custom arrangement (sync + manual reorders) and automatic sorts never
+//  touch it; order is derived from the sticky pref at fetch time.
+//
+//  The headline test is the scramble regression: a sync pull overwriting the
+//  rank column must not reorder an automatically-sorted list.
+//
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import CoreData
+import XCTest
+
+@MainActor
+final class QueryTimeSortRefactorTests: XCTestCase {
+  private var harness: SortIntegrationHarness!
+  private var libraryService: LibraryService { harness.libraryService }
+  private var preferences: PreferencesSyncService { harness.preferences }
+
+  override func setUp() {
+    super.setUp()
+    harness = SortIntegrationHarness()
+  }
+
+  override func tearDown() {
+    harness.tearDown()
+    harness = nil
+    super.tearDown()
+  }
+
+  // MARK: - The bug this refactor exists to fix
+
+  /// Pro-user scramble regression: with an automatic sort selected, a sync pull
+  /// that overwrites the rank column with stale server ranks must not change
+  /// the rendered order. The rank write itself is EXPECTED (server ranks are
+  /// the synced custom arrangement) — the screen just no longer reads them.
+  func testSyncPullDoesNotReorderAutoSortedList() async throws {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+    XCTAssertEqual(harness.renderedOrder(), ["apple.txt", "banana.txt", "cherry.txt"])
+
+    // Adversarial server ranks: would render banana, cherry, apple if obeyed.
+    let serverItems = try SyncResponseFixtures.makeItemsDictionary([
+      SyncResponseFixtures.itemJSON(relativePath: "cherry.txt", orderRank: 1),
+      SyncResponseFixtures.itemJSON(relativePath: "apple.txt", orderRank: 2),
+      SyncResponseFixtures.itemJSON(relativePath: "banana.txt", orderRank: 0),
+    ])
+    await libraryService.updateInfo(for: serverItems, parentFolder: nil)
+
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["apple.txt", "banana.txt", "cherry.txt"],
+      "a pull must never scramble an automatically-sorted list"
+    )
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["banana.txt"], 0, "server ranks still land in the column")
+    XCTAssertEqual(ranks["cherry.txt"], 1)
+    XCTAssertEqual(ranks["apple.txt"], 2)
+  }
+
+  // MARK: - Automatic sorts never write ranks
+
+  func testPickingSortPersistsPrefWithoutTouchingRanks() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.save()
+
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+
+    XCTAssertEqual(harness.renderedOrder(), ["apple.txt", "cherry.txt"])
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .automatic(.metadataTitle))
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["cherry.txt"], 0, "the latent custom arrangement survives underneath")
+    XCTAssertEqual(ranks["apple.txt"], 1)
+  }
+
+  func testSyncInsertLandsSortedWithoutRankRewrite() async throws {
+    harness.seedBook(relativePath: "bbb.txt", rank: 0)
+    harness.seedBook(relativePath: "ddd.txt", rank: 1)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+
+    let newItems = try SyncResponseFixtures.makeItemsDictionary([
+      SyncResponseFixtures.itemJSON(relativePath: "aaa.txt", orderRank: 99)
+    ])
+    await libraryService.storeNewItems(from: newItems, parentFolder: nil)
+
+    XCTAssertEqual(harness.renderedOrder(), ["aaa.txt", "bbb.txt", "ddd.txt"])
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["bbb.txt"], 0, "existing ranks are untouched — no re-sort hook ran")
+    XCTAssertEqual(ranks["ddd.txt"], 1)
+    XCTAssertEqual(ranks["aaa.txt"], 99, "the insert keeps its server rank")
+  }
+
+  // MARK: - Custom transition freezes the visible order
+
+  func testAdoptCurrentOrderAsCustomFreezesVisibleOrder() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+
+    libraryService.adoptCurrentOrderAsCustom(at: nil)
+
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .custom)
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["apple.txt", "banana.txt", "cherry.txt"],
+      "WYSIWYG: the transition freezes exactly what was on screen"
+    )
+    let ranks = harness.rankColumn()
+    XCTAssertEqual(ranks["apple.txt"], 0)
+    XCTAssertEqual(ranks["banana.txt"], 1)
+    XCTAssertEqual(ranks["cherry.txt"], 2)
+  }
+
+  func testAdoptCurrentOrderAsCustomIsIdempotent() {
+    harness.seedBook(relativePath: "b.txt", rank: 0)
+    harness.seedBook(relativePath: "a.txt", rank: 1)
+    harness.save()
+
+    libraryService.adoptCurrentOrderAsCustom(at: nil)
+    let firstFreeze = harness.rankColumn()
+    libraryService.adoptCurrentOrderAsCustom(at: nil)
+
+    XCTAssertEqual(harness.rankColumn(), firstFreeze)
+    XCTAssertEqual(harness.renderedOrder(), ["b.txt", "a.txt"])
+  }
+
+  // MARK: - Drag operates on the visible order (capture-before-flip)
+
+  func testDragUnderAutomaticSortMovesVisibleRows() {
+    // Ranks deliberately disagree with the title order the user is looking at.
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+    // Visible: apple, banana, cherry. Drag the top row below the last row.
+    libraryService.reorderItems(inside: nil, fromOffsets: IndexSet(integer: 0), toOffset: 3)
+
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .custom)
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["banana.txt", "cherry.txt", "apple.txt"],
+      "the drag applies to what the user saw, not to the hidden rank order"
+    )
+  }
+
+  // MARK: - "Most recent" is live (the staleness fix)
+
+  func testMostRecentReflectsPlaybackImmediately() {
+    let now = Date()
+    harness.seedBook(relativePath: "a.txt", rank: 0, lastPlayDate: now.addingTimeInterval(-200))
+    let bookB = harness.seedBook(relativePath: "b.txt", rank: 1, lastPlayDate: now.addingTimeInterval(-100))
+    harness.seedBook(relativePath: "c.txt", rank: 2, lastPlayDate: nil)
+    harness.save()
+    preferences.setSort(.automatic(.mostRecent), forLocation: .libraryRoot)
+    XCTAssertEqual(harness.renderedOrder(), ["b.txt", "a.txt", "c.txt"])
+
+    bookB.lastPlayDate = now.addingTimeInterval(-300)
+    harness.seedBook(relativePath: "d.txt", rank: 3, lastPlayDate: now)
+    harness.save()
+
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["d.txt", "a.txt", "b.txt", "c.txt"],
+      "the order keys on live lastPlayDate — no hook needed to refresh it"
+    )
+  }
+
+  // MARK: - Playback navigation follows the visible order
+
+  func testPrevNextFollowVisibleOrderUnderTitleSort() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let next = playbackService.getPlayableItem(
+      after: "apple.txt", parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertEqual(next?.relativePath, "banana.txt", "next matches the list, not the rank column")
+
+    let previous = playbackService.getPlayableItem(before: "cherry.txt", parentFolder: nil)
+    XCTAssertEqual(previous?.relativePath, "banana.txt")
+
+    let afterLast = playbackService.getPlayableItem(
+      after: "cherry.txt", parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertNil(afterLast)
+  }
+
+  // MARK: - watchOS fallback (no preferences service wired)
+
+  func testNilPreferencesServiceFallsBackToRankOrder() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
+    XCTAssertEqual(harness.renderedOrder(), ["apple.txt", "cherry.txt"])
+
+    libraryService.preferencesService = nil
+
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["cherry.txt", "apple.txt"],
+      "without a preferences service (watchOS) the fetch is rank-ordered"
+    )
+  }
+}

--- a/BookPlayerTests/Services/QueryTimeSortRefactorTests.swift
+++ b/BookPlayerTests/Services/QueryTimeSortRefactorTests.swift
@@ -13,6 +13,7 @@
 
 @testable import BookPlayer
 @testable import BookPlayerKit
+import Combine
 import CoreData
 import XCTest
 
@@ -201,6 +202,85 @@ final class QueryTimeSortRefactorTests: XCTestCase {
       after: "cherry.txt", parentFolder: nil, autoplayed: false, restartFinished: false
     )
     XCTAssertNil(afterLast)
+  }
+
+  /// A repeat freeze must not just leave ranks unchanged — it must emit ZERO
+  /// sync updates. This is the contract the `orderRank != index` filter in
+  /// `freezeVisibleOrder` provides; without this test that clause could be
+  /// deleted as "redundant" without anything failing.
+  func testRepeatAdoptEmitsNoSyncUpdates() {
+    harness.seedBook(relativePath: "b.txt", rank: 5)
+    harness.seedBook(relativePath: "a.txt", rank: 9)
+    harness.save()
+
+    libraryService.adoptCurrentOrderAsCustom(at: nil)
+
+    var emissions: [[String: Any]] = []
+    let subscription = libraryService.immediateProgressUpdatePublisher.sink { emissions.append($0) }
+    libraryService.adoptCurrentOrderAsCustom(at: nil)
+    subscription.cancel()
+
+    XCTAssertTrue(emissions.isEmpty, "a repeat freeze must not schedule sync work")
+  }
+
+  /// The pref flip deliberately precedes the empty-contents guard (matching
+  /// `reverseContents`' pinned behavior): an empty folder still becomes Custom.
+  func testAdoptOnEmptyFolderStillFlipsPref() {
+    let folder = harness.seedFolder(relativePath: "empty", rank: 0)
+    harness.save()
+    preferences.setSort(.automatic(.metadataTitle), forLocation: .folder(
+      LibraryItemRef(relativePath: "empty", uuid: folder.uuid)
+    ))
+
+    libraryService.adoptCurrentOrderAsCustom(at: "empty")
+
+    XCTAssertEqual(
+      preferences.effectiveSort(forLocation: .folder(LibraryItemRef(relativePath: "empty", uuid: folder.uuid))),
+      .custom
+    )
+  }
+
+  // MARK: - Sign-out must not re-scramble the library
+
+  /// Logout wipes every `library_sort:*` key; the visible order must survive
+  /// via the freeze-before-wipe in `PreferencesSyncService.handleLogout`.
+  func testLogoutPreservesVisibleOrder() {
+    harness.seedBook(relativePath: "cherry.txt", rank: 0)
+    harness.seedBook(relativePath: "apple.txt", rank: 1)
+    harness.seedBook(relativePath: "banana.txt", rank: 2)
+    harness.save()
+    libraryService.sortContents(at: nil, by: .metadataTitle)
+    XCTAssertEqual(harness.renderedOrder(), ["apple.txt", "banana.txt", "cherry.txt"])
+
+    preferences.handleLogout()
+
+    XCTAssertFalse(harness.hasAnySortPreferencePersisted, "logout still wipes the pref keys")
+    XCTAssertEqual(
+      harness.renderedOrder(),
+      ["apple.txt", "banana.txt", "cherry.txt"],
+      "the order the user saw survives sign-out, frozen into ranks"
+    )
+    XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .custom)
+  }
+
+  // MARK: - Navigation edge: current item unknown
+
+  /// If the playing item was deleted/moved mid-playback, "next" must stop —
+  /// never hop out of the stale folder (symmetric with "previous").
+  func testNextReturnsNilWhenCurrentItemMissingFromSiblings() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.save()
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: libraryService)
+
+    let next = playbackService.getPlayableItem(
+      after: "ghost.txt", parentFolder: nil, autoplayed: false, restartFinished: false
+    )
+    XCTAssertNil(next)
+
+    let previous = playbackService.getPlayableItem(before: "ghost.txt", parentFolder: nil)
+    XCTAssertNil(previous)
   }
 
   // MARK: - watchOS fallback (no preferences service wired)

--- a/BookPlayerTests/Services/SortCharacterizationTests.swift
+++ b/BookPlayerTests/Services/SortCharacterizationTests.swift
@@ -68,7 +68,7 @@ final class SortCharacterizationTests: XCTestCase {
     XCTAssertEqual(preferences.effectiveSort(forLocation: .libraryRoot), .custom)
   }
 
-  // MARK: - Import (today: Hook 2 re-sorts; after: the query sorts)
+  // MARK: - Import (rendered position under an automatic sort, however derived)
 
   func testImportUnderTitleSortRendersSorted() async {
     preferences.setSort(.automatic(.metadataTitle), forLocation: .libraryRoot)
@@ -155,7 +155,7 @@ final class SortCharacterizationTests: XCTestCase {
     XCTAssertEqual(harness.renderedOrder(at: "dest"), ["dest/b.txt"])
   }
 
-  // MARK: - Sync pull (today: Hook 4 re-sorts inserts; after: the query sorts)
+  // MARK: - Sync pull (inserts land in sorted position, however derived)
 
   func testSyncInsertUnderTitleSortRendersSorted() async throws {
     harness.seedBook(relativePath: "bbb.txt", rank: 0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,10 +384,17 @@ data, and share the error type `MediaServerIntegration/IntegrationError.swift` (
   records are created via `LibraryService.createBook/createFolder`; artwork is extracted lazily by
   `ArtworkService`, not inline. App-managed source files are removed after copy.
 - **Library** (`Library/ItemList/…`, backed by `Shared/Services/LibraryService.swift`): the main list, folders,
-  and drag-drop reordering. **Reordering invariant ("Hook 5"):** write the sticky `.custom` sort to
-  `preferencesService` **before** rebuilding `orderRank`, so rank changes flow to cloud sync — reversing the order
-  silently drops them. UI reads on `viewContext`, background on `backgroundContext`, only `Simple*` snapshots
-  cross back to UI.
+  and drag-drop reordering. **Ordering model (query-time sort):** `orderRank` means ONLY the user's custom
+  arrangement (written by drag/reverse/Custom-freeze/one-shot sorts and by sync; never by an automatic sort).
+  An automatic sticky sort is applied at fetch time — `resolveSortDescriptors` in `LibraryService` maps the
+  location's effective sort to `SortType.sortDescriptors` (`localizedStandardCompare:` + `orderRank` tie-break);
+  sync may overwrite ranks freely and the rendered order is unaffected unless the location is Custom. Rank
+  updates always sync (no auto-sort suppression exists anymore). **Two mutation invariants:** (1) the rank
+  mutations (`reorderItems`/`reverseContents`/`adoptCurrentOrderAsCustom`) must resolve the effective (visible)
+  descriptors **before** flipping the pref to `.custom` — flipping first would act on rank order instead of what
+  the user sees; (2) the `.custom` pref write still precedes the rank rebuild so the next fetch doesn't re-sort
+  the user's arrangement away. Playback prev/next walks `fetchContents` order (visible order), not rank cursors.
+  UI reads on `viewContext`, background on `backgroundContext`, only `Simple*` snapshots cross back to UI.
 - **Search** (`Search/`): **local-only** CoreData search (`LibraryService.searchAllBooks`), 0.3s debounce,
   results grouped by parent folder. Remote search lives in the integration view models, **not** here — don't
   expect network calls in `Search/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,12 +388,21 @@ data, and share the error type `MediaServerIntegration/IntegrationError.swift` (
   arrangement (written by drag/reverse/Custom-freeze/one-shot sorts and by sync; never by an automatic sort).
   An automatic sticky sort is applied at fetch time — `resolveSortDescriptors` in `LibraryService` maps the
   location's effective sort to `SortType.sortDescriptors` (`localizedStandardCompare:` + `orderRank` tie-break);
-  sync may overwrite ranks freely and the rendered order is unaffected unless the location is Custom. Rank
-  updates always sync (no auto-sort suppression exists anymore). **Two mutation invariants:** (1) the rank
-  mutations (`reorderItems`/`reverseContents`/`adoptCurrentOrderAsCustom`) must resolve the effective (visible)
-  descriptors **before** flipping the pref to `.custom` — flipping first would act on rank order instead of what
-  the user sees; (2) the `.custom` pref write still precedes the rank rebuild so the next fetch doesn't re-sort
-  the user's arrangement away. Playback prev/next walks `fetchContents` order (visible order), not rank cursors.
+  sync may overwrite ranks freely — the rendered order only follows ranks where the effective sort resolves to
+  rank order: Custom, `.unresolved`/bound locations, and any target with no `preferencesService` wired.
+  **watchOS is such a target** (only the iOS app assigns `preferencesService`), so the watch renders rank order
+  for a folder the phone renders rule-sorted — a known, deliberate platform fork (same as Android Wear). Rank
+  updates always sync (no auto-sort suppression exists anymore). **Both mutation invariants live in
+  `freezeVisibleOrder(at:transform:)`** — the single core of `reorderItems`/`reverseContents`/
+  `adoptCurrentOrderAsCustom`: (1) capture-before-flip — the effective (visible) descriptors are resolved
+  **before** the pref flips to `.custom`, else the mutation acts on rank order instead of what the user sees;
+  (2) the `.custom` pref write precedes the rank rebuild so the next fetch doesn't re-sort the user's
+  arrangement away. Route any new user-arrangement rank mutation through that helper (the one-shot
+  materialization for `.unresolved` locations in `sortContents` is the deliberate exception — it has no pref
+  key to flip). Playback prev/next walks
+  `getOrderedSiblings` (visible order, lightweight entries), not rank cursors. On logout,
+  `PreferencesSyncService` freezes automatically-sorted locations into ranks before wiping `library_sort:*`,
+  so sign-out doesn't visibly re-scramble the library.
   UI reads on `viewContext`, background on `backgroundContext`, only `Simple*` snapshots cross back to UI.
 - **Search** (`Search/`): **local-only** CoreData search (`LibraryService.searchAllBooks`), 0.3s debounce,
   results grouped by parent folder. Remote search lives in the integration view models, **not** here — don't

--- a/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
+++ b/Shared/CoreData/Lightweight-Models/SimpleLibraryItem.swift
@@ -162,3 +162,19 @@ extension SimpleLibraryItem {
     return title
   }
 }
+
+/// Minimal ordered view of a library item for playback navigation walks
+/// (prev/next/first-playable). Deliberately tiny: the hot path fetches one of
+/// these per sibling instead of a full `SimpleLibraryItem` row, and skips
+/// `parseFetchedItems`' folder-details side effects entirely. The chosen
+/// neighbor is then materialized via `getSimpleItem(with:)`, which carries
+/// the type/metadata the player needs.
+public struct SimpleNavigationItem {
+  public let relativePath: String
+  public let isFinished: Bool
+
+  public init(relativePath: String, isFinished: Bool) {
+    self.relativePath = relativePath
+    self.isFinished = isFinished
+  }
+}

--- a/Shared/Services/LibraryService+Sync.swift
+++ b/Shared/Services/LibraryService+Sync.swift
@@ -15,12 +15,6 @@ public protocol LibrarySyncProtocol {
   var metadataUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
   var progressUpdatePublisher: AnyPublisher<[String: Any], Never> { get }
 
-  /// Returns true if the item at the given path is inside a location with an
-  /// automatic sticky sort. Used by the sync layer (Decision 9) to suppress
-  /// `orderRank`-only updates that other devices recompute locally from
-  /// (item set + sort rule).
-  func isParentLocationAutoSorted(itemRelativePath: String) -> Bool
-
   /// Fetch all the stored items in the library that are not in the remote identifiers array
   func getItemsToSync(remoteIdentifiers: [String]) async -> [SyncableItem]?
   /// Update local items with synced info
@@ -182,8 +176,6 @@ extension LibraryService: LibrarySyncProtocol {
   }
 
   public func storeNewItems(from itemsDict: [String: SyncableItem], parentFolder: String?) async {
-    var didInsertItems = false
-
     await withCheckedContinuation { continuation in
       let context = dataManager.getBackgroundContext()
       context.perform { [unowned self, context] in
@@ -194,19 +186,12 @@ extension LibraryService: LibrarySyncProtocol {
         for key in newKeys {
           guard let item = itemsDict[key] else { continue }
 
-          // All three types appear as siblings in the parent list, so all three
-          // need the parent re-sort below. The bound case adds a folder of type
-          // `.bound` which is itself a sortable sibling — its own children are
-          // never user-sortable, but that's a separate concern (handled by the
-          // resolver returning `.unresolved` for any folder with a placeholder
-          // UUID, including bound internals).
           switch item.type {
           case .book:
             addBook(from: item, parentFolder: parentFolder, context: context)
           case .folder, .bound:
             addFolder(from: item, parentFolder: parentFolder, context: context)
           }
-          didInsertItems = true
         }
 
         dataManager.saveSyncContext(context)
@@ -214,16 +199,9 @@ extension LibraryService: LibrarySyncProtocol {
       }
     }
 
-    // Hook 4: hop to the main actor (after the background save commits) and re-sort
-    // the parent if its effective sort is automatic.
-    guard didInsertItems, let prefs = preferencesService else { return }
-
-    await MainActor.run {
-      let parentLocation = makeLocation(forRelativePath: parentFolder)
-      if case .automatic(let sort) = prefs.effectiveSort(forLocation: parentLocation) {
-        sortContents(at: parentFolder, by: sort)
-      }
-    }
+    // No re-sort needed: an automatically-sorted parent derives its order from
+    // the rule at query time, so the server ranks these inserts carry have no
+    // visible effect there. (Custom parents intentionally follow server ranks.)
   }
 
   func addBook(from item: SyncableItem, parentFolder: String?, context: NSManagedObjectContext) {

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -76,12 +76,9 @@ public protocol LibraryServiceProtocol: AnyObject {
     offset: Int?
   ) -> [SimpleLibraryItem]?
   /// Autoplay
-  /// Find first item that is unfinished in a folder
+  /// Find first item (optionally: first unfinished) in a folder, in the
+  /// location's effective (visible) order
   func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem?
-  /// Fetch first item before a specific position in a folder
-  func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem?
-  /// Fetch first item after a specific position in a folder considering if it's unfinished or not
-  func findFirstItem(in parentFolder: String?, afterRank: Int16?, isUnfinished: Bool?) -> SimpleLibraryItem?
   /// Get metadata chapters from item
   func getChapters(from relativePath: String) -> [SimpleChapter]?
 
@@ -107,20 +104,15 @@ public protocol LibraryServiceProtocol: AnyObject {
   func renameFolder(at relativePath: String, with newTitle: String) throws -> String
   /// Update item details
   func updateDetails(at relativePath: String, details: String)
-  /// Update item order to new rank
-  func reorderItem(
-    with relativePath: String,
-    inside folderRelativePath: String?,
-    sourceIndexPath: IndexPath,
-    destinationIndexPath: IndexPath
-  )
-  /// Sort entire list at the given path
+  /// Apply a sort to the list at the given path: persists the sticky preference
+  /// for resolvable locations (order is derived at query time); performs a
+  /// one-shot rank materialization for `.unresolved` locations
   func sortContents(at relativePath: String?, by type: SortType)
-  /// Sort entire list at the given location. `nil` represents the library root.
-  /// Convenience that resolves the relativePath from the ref and delegates.
-  func sortContents(in location: SortLocation, by type: SortType)
-  /// One-off reverse: flips the current order at the given path and transitions the
-  /// location's sticky sort to `.custom` (same transition as a manual drag-drop).
+  /// Freeze the location's currently-visible order into `orderRank` and
+  /// transition the sticky sort to `.custom` (the picker's "Custom" option)
+  func adoptCurrentOrderAsCustom(at relativePath: String?)
+  /// One-off reverse: flips the current visible order at the given path and transitions
+  /// the location's sticky sort to `.custom` (same transition as a manual drag-drop).
   func reverseContents(at relativePath: String?)
   /// Look up the relativePath for a library item by its uuid.
   /// Returns nil for placeholder uuids or if no matching item is found.
@@ -341,11 +333,45 @@ public final class LibraryService: LibraryServiceProtocol, @unchecked Sendable {
     return result?["hasProperty"] ?? false
   }
 
+  /// How a contents fetch orders its results.
+  enum ContentsOrdering {
+    /// The location's effective sticky sort: an automatic rule becomes
+    /// fetch-time sort descriptors; `.custom` (and `.unresolved`/bound
+    /// locations, or when no preferences service is wired, e.g. watchOS)
+    /// falls back to `orderRank`.
+    case effective
+    /// Raw `orderRank` — for internal reconciliation reads whose consumers
+    /// are order-insensitive, and for rank mutations that operate on the
+    /// stored custom arrangement.
+    case byRank
+  }
+
+  /// Single choke point resolving the sort descriptors for a location.
+  /// `orderRank` means only the custom arrangement; every automatic rule is
+  /// applied here, at query time, never materialized into the rank column.
+  func resolveSortDescriptors(
+    forRelativePath relativePath: String?,
+    ordering: ContentsOrdering,
+    context: NSManagedObjectContext
+  ) -> [NSSortDescriptor] {
+    let byRank = [NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true)]
+    guard case .effective = ordering, let prefs = preferencesService else {
+      return byRank
+    }
+    let location = makeLocation(forRelativePath: relativePath, context: context)
+    guard case .automatic(let sort) = prefs.effectiveSort(forLocation: location) else {
+      return byRank
+    }
+    return sort.sortDescriptors
+  }
+
   func buildListContentsFetchRequest(
     properties: [String],
     relativePath: String?,
     limit: Int?,
-    offset: Int?
+    offset: Int?,
+    ordering: ContentsOrdering,
+    context: NSManagedObjectContext
   ) -> NSFetchRequest<NSDictionary> {
     let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
     fetchRequest.propertiesToFetch = properties
@@ -355,8 +381,11 @@ public final class LibraryService: LibraryServiceProtocol, @unchecked Sendable {
     } else {
       fetchRequest.predicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
     }
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true)
-    fetchRequest.sortDescriptors = [sort]
+    fetchRequest.sortDescriptors = resolveSortDescriptors(
+      forRelativePath: relativePath,
+      ordering: ordering,
+      context: context
+    )
 
     if let limit = limit {
       fetchRequest.fetchLimit = limit
@@ -722,14 +751,9 @@ extension LibraryService {
 
     dataManager.saveContext()
 
-    // Hook 2: if the parent has an automatic sort, re-rank to put new items in the right slot.
-    if let prefs = preferencesService {
-      let parentLocation = makeLocation(forRelativePath: parentPath)
-      if case .automatic(let sort) = prefs.effectiveSort(forLocation: parentLocation) {
-        sortContents(at: parentPath, by: sort)
-      }
-    }
-
+    // No re-sort needed: an automatically-sorted parent derives its order from
+    // the rule at query time, so the appended ranks have no visible effect there.
+    // (Custom parents intentionally keep new items appended at the end.)
     return processedFiles
   }
 
@@ -1133,14 +1157,6 @@ extension LibraryService {
       rebuildOrderRank(in: originalParentPath)
     }
 
-    // Hook 3: if the destination has an automatic sort, re-rank to put moved items in the right slot.
-    if let prefs = preferencesService {
-      let destLocation = makeLocation(forRelativePath: relativePath)
-      if case .automatic(let sort) = prefs.effectiveSort(forLocation: destLocation) {
-        sortContents(at: relativePath, by: sort)
-      }
-    }
-
     /// The moved items' stored relativePaths (and any folder descendants, via the
     /// path-prefix rule) are now stale, so prune them from the Last Played widget
     /// snapshot. They reappear once played again at the new location.
@@ -1301,7 +1317,9 @@ extension LibraryService {
       properties: SimpleLibraryItem.fetchRequestProperties,
       relativePath: relativePath,
       limit: limit,
-      offset: offset
+      offset: offset,
+      ordering: .effective,
+      context: context
     )
 
     let results = try? context.fetch(fetchRequest) as? [[String: Any]]
@@ -1315,13 +1333,21 @@ extension LibraryService {
     return fetchRawContents(
       at: relativePath,
       propertiesToFetch: propertiesToFetch,
+      sortedBy: resolveSortDescriptors(forRelativePath: relativePath, ordering: .byRank, context: context),
       context: context
     )
   }
 
+  /// Managed-object contents fetch. Defaults to rank order (the stored custom
+  /// arrangement); the rank mutations (drag/reverse/freeze) resolve the
+  /// effective descriptors BEFORE flipping the sticky pref to `.custom` and
+  /// pass them in explicitly.
   func fetchRawContents(
     at relativePath: String?,
     propertiesToFetch: [String],
+    sortedBy sortDescriptors: [NSSortDescriptor] = [
+      NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true)
+    ],
     context: NSManagedObjectContext
   ) -> [LibraryItem]? {
     let fetchRequest: NSFetchRequest<LibraryItem> = LibraryItem.fetchRequest()
@@ -1332,8 +1358,7 @@ extension LibraryService {
     } else {
       fetchRequest.predicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
     }
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true)
-    fetchRequest.sortDescriptors = [sort]
+    fetchRequest.sortDescriptors = sortDescriptors
 
     return try? context.fetch(fetchRequest)
   }
@@ -1507,7 +1532,9 @@ extension LibraryService {
       properties: ["relativePath", "uuid"],
       relativePath: parentFolder,
       limit: nil,
-      offset: nil
+      offset: nil,
+      ordering: .byRank,
+      context: context
     )
 
     let results = try? context.fetch(fetchRequest) as? [[String: Any]]
@@ -1519,7 +1546,9 @@ extension LibraryService {
       properties: ["relativePath"],
       relativePath: parentFolder,
       limit: nil,
-      offset: nil
+      offset: nil,
+      ordering: .byRank,
+      context: context
     )
 
     let results = try? context.fetch(fetchRequest) as? [[String: Any]]
@@ -1608,95 +1637,13 @@ extension LibraryService {
     return parseFetchedItems(from: results, context: context)
   }
 
-  func findFirstItem(
-    in parentFolder: String?,
-    rankPredicate: NSPredicate?,
-    sortAscending: Bool,
-    isUnfinished: Bool?
-  ) -> SimpleLibraryItem? {
-    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest<NSDictionary>(entityName: "LibraryItem")
-
-    let pathPredicate: NSPredicate
-
-    if let parentFolder = parentFolder {
-      pathPredicate = NSPredicate(
-        format: "%K == %@",
-        #keyPath(LibraryItem.folder.relativePath),
-        parentFolder
-      )
-    } else {
-      pathPredicate = NSPredicate(format: "%K != nil", #keyPath(LibraryItem.library))
-    }
-
-    var predicates = [
-      pathPredicate
-    ]
-
-    if let rankPredicate = rankPredicate {
-      predicates.append(rankPredicate)
-    }
-
-    if isUnfinished != nil {
-      // TODO: Add default value for `isFinished`
-      predicates.append(
-        NSPredicate(
-          format: "%K == 0 || %K == nil",
-          #keyPath(LibraryItem.isFinished),
-          #keyPath(LibraryItem.isFinished)
-        )
-      )
-    }
-
-    fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-    let sort = NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: sortAscending)
-    fetchRequest.sortDescriptors = [sort]
-    fetchRequest.fetchLimit = 1
-    fetchRequest.propertiesToFetch = SimpleLibraryItem.fetchRequestProperties
-    fetchRequest.resultType = .dictionaryResultType
-
-    let context = dataManager.getContext()
-    let results = try? context.fetch(fetchRequest) as? [[String: Any]]
-
-    return parseFetchedItems(from: results, context: context)?.first
-  }
-
+  /// First child of the parent in its EFFECTIVE (visible) order.
+  /// Note: `isUnfinished` is nil-checked only (matching the pre-existing
+  /// contract) — passing `false` still filters for unfinished items.
   public func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem? {
-    return findFirstItem(
-      in: parentFolder,
-      rankPredicate: nil,
-      sortAscending: true,
-      isUnfinished: isUnfinished
-    )
-  }
-
-  public func findFirstItem(in parentFolder: String?, beforeRank: Int16?) -> SimpleLibraryItem? {
-    var rankPredicate: NSPredicate?
-    if let beforeRank = beforeRank {
-      rankPredicate = NSPredicate(format: "%K < %d", #keyPath(LibraryItem.orderRank), beforeRank)
-    }
-    return findFirstItem(
-      in: parentFolder,
-      rankPredicate: rankPredicate,
-      sortAscending: false,
-      isUnfinished: nil
-    )
-  }
-
-  public func findFirstItem(
-    in parentFolder: String?,
-    afterRank: Int16?,
-    isUnfinished: Bool?
-  ) -> SimpleLibraryItem? {
-    var rankPredicate: NSPredicate?
-    if let afterRank = afterRank {
-      rankPredicate = NSPredicate(format: "%K > %d", #keyPath(LibraryItem.orderRank), afterRank)
-    }
-    return findFirstItem(
-      in: parentFolder,
-      rankPredicate: rankPredicate,
-      sortAscending: true,
-      isUnfinished: isUnfinished
-    )
+    guard let siblings = fetchContents(at: parentFolder, limit: nil, offset: nil) else { return nil }
+    guard isUnfinished != nil else { return siblings.first }
+    return siblings.first { !$0.isFinished }
   }
 
   public func getChapters(from relativePath: String) -> [SimpleChapter]? {
@@ -2206,10 +2153,20 @@ extension LibraryService {
     fromOffsets source: IndexSet,
     toOffset destination: Int
   ) {
-    // Hook 5: write .custom BEFORE rank rewrite so the orderRank-suppression check
-    // sees the location as custom *during* the rebuild — rank changes correctly DO sync (user-arranged data).
+    let context = dataManager.getContext()
+    /// The drag offsets are positions in the VISIBLE (effective) order, so the
+    /// descriptors must be captured BEFORE the pref flips to `.custom` below —
+    /// flipping first would resolve to rank order and move the wrong rows.
+    let visibleOrder = resolveSortDescriptors(
+      forRelativePath: folderRelativePath,
+      ordering: .effective,
+      context: context
+    )
+
+    // Hook 5: the pref flip precedes the rank rebuild so the arrangement the
+    // user just made isn't re-sorted away by the next (query-time-sorted) fetch.
     if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: folderRelativePath)
+      let location = makeLocation(forRelativePath: folderRelativePath, context: context)
       prefs.setSort(.custom, forLocation: location)
     }
 
@@ -2220,13 +2177,15 @@ extension LibraryService {
           #keyPath(LibraryItem.relativePath),
           #keyPath(LibraryItem.orderRank),
           #keyPath(LibraryItem.uuid)
-        ]
+        ],
+        sortedBy: visibleOrder,
+        context: context
       )
     else { return }
 
     contents.move(fromOffsets: source, toOffset: destination)
 
-    /// Rebuild order rank
+    /// Freeze the rearranged visible order into ranks
     for (index, item) in contents.enumerated() {
       item.orderRank = Int16(index)
       metadataPassthroughPublisher.send([
@@ -2239,33 +2198,38 @@ extension LibraryService {
     dataManager.saveContext()
   }
 
-  public func reorderItem(
-    with relativePath: String,
-    inside folderRelativePath: String?,
-    sourceIndexPath: IndexPath,
-    destinationIndexPath: IndexPath
-  ) {
-    // Hook 5: write .custom BEFORE rank rewrite (see reorderItems above for rationale).
+  /// Freezes the location's currently-visible order into `orderRank` and
+  /// transitions the sticky sort to `.custom` — the picker's "Custom" option.
+  /// WYSIWYG by design (Android parity), and it self-heals stale server ranks
+  /// the first time it runs. Same capture-before-flip rule as `reorderItems`.
+  public func adoptCurrentOrderAsCustom(at relativePath: String?) {
+    let context = dataManager.getContext()
+    let visibleOrder = resolveSortDescriptors(
+      forRelativePath: relativePath,
+      ordering: .effective,
+      context: context
+    )
+
     if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: folderRelativePath)
+      let location = makeLocation(forRelativePath: relativePath, context: context)
       prefs.setSort(.custom, forLocation: location)
     }
 
     guard
-      var contents = fetchRawContents(
-        at: folderRelativePath,
+      let contents = fetchRawContents(
+        at: relativePath,
         propertiesToFetch: [
           #keyPath(LibraryItem.relativePath),
           #keyPath(LibraryItem.orderRank),
-        ]
-      )
+          #keyPath(LibraryItem.uuid)
+        ],
+        sortedBy: visibleOrder,
+        context: context
+      ),
+      !contents.isEmpty
     else { return }
 
-    let movedItem = contents.remove(at: sourceIndexPath.row)
-    contents.insert(movedItem, at: destinationIndexPath.row)
-
-    /// Rebuild order rank
-    for (index, item) in contents.enumerated() {
+    for (index, item) in contents.enumerated() where item.orderRank != Int16(index) {
       item.orderRank = Int16(index)
       metadataPassthroughPublisher.send([
         #keyPath(LibraryItem.relativePath): item.relativePath!,
@@ -2274,16 +2238,24 @@ extension LibraryService {
       ])
     }
 
-    self.dataManager.saveContext()
+    dataManager.saveContext()
   }
 
-  /// One-off reverse: flips the current order and transitions the location's sticky sort to `.custom`,
-  /// the same transition a manual drag-drop produces. Same Hook 5 ordering as `reorderItems` —
-  /// write `.custom` BEFORE rebuilding ranks so the orderRank-suppression check sees the new sort
-  /// during the rebuild and the rank changes correctly flow to sync.
+  /// One-off reverse: flips the current VISIBLE order and transitions the location's
+  /// sticky sort to `.custom`, the same transition a manual drag-drop produces.
+  /// Same capture-before-flip rule as `reorderItems`: the effective descriptors are
+  /// resolved before the pref flips, so reversing an automatically-sorted list
+  /// freezes the reversed rule order — what the user sees, reversed.
   public func reverseContents(at relativePath: String?) {
+    let context = dataManager.getContext()
+    let visibleOrder = resolveSortDescriptors(
+      forRelativePath: relativePath,
+      ordering: .effective,
+      context: context
+    )
+
     if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: relativePath)
+      let location = makeLocation(forRelativePath: relativePath, context: context)
       prefs.setSort(.custom, forLocation: location)
     }
 
@@ -2294,7 +2266,9 @@ extension LibraryService {
           #keyPath(LibraryItem.relativePath),
           #keyPath(LibraryItem.orderRank),
           #keyPath(LibraryItem.uuid)
-        ]
+        ],
+        sortedBy: visibleOrder,
+        context: context
       ),
       !contents.isEmpty
     else { return }
@@ -2314,12 +2288,21 @@ extension LibraryService {
   }
 
   public func sortContents(at relativePath: String?, by type: SortType) {
-    // Hook 1: write pref BEFORE rank rewrite so the orderRank-suppression check sees the new sort.
-    if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: relativePath)
+    let context = dataManager.getContext()
+    let location = makeLocation(forRelativePath: relativePath, context: context)
+
+    // Resolvable location with a preferences service: the sort is a sticky
+    // preference applied at query time — persist it and let the next fetch
+    // order by it. No rank writes; `orderRank` keeps the custom arrangement.
+    if let prefs = preferencesService, location != .unresolved {
       prefs.setSort(.automatic(type), forLocation: location)
+      return
     }
 
+    // One-shot path (`.unresolved` locations, or no preferences service, e.g.
+    // watchOS): a bulk custom rearrangement — materialize the rule into
+    // `orderRank` once and sync the new arrangement like any manual reorder.
+    // No preference is (or can be) persisted.
     guard
       let results = fetchRawContents(at: relativePath, propertiesToFetch: type.fetchProperties()),
       !results.isEmpty
@@ -2327,7 +2310,6 @@ extension LibraryService {
 
     let sortedResults = type.sortItems(results)
 
-    /// Rebuild order rank
     for (index, item) in sortedResults.enumerated() {
       item.orderRank = Int16(index)
       metadataPassthroughPublisher.send([
@@ -2352,32 +2334,20 @@ extension LibraryService {
   ///   tried to write a sticky sort for the bound's UUID, this gate keeps
   ///   the children's `orderRank` stable.
   public func makeLocation(forRelativePath relativePath: String?) -> SortLocation {
+    makeLocation(forRelativePath: relativePath, context: dataManager.getContext())
+  }
+
+  public func makeLocation(forRelativePath relativePath: String?, context: NSManagedObjectContext) -> SortLocation {
     guard let relativePath else { return .libraryRoot }
     guard
-      let uuid = getItemProperty(#keyPath(LibraryItem.uuid), relativePath: relativePath) as? String,
+      let uuid = getItemProperty(#keyPath(LibraryItem.uuid), relativePath: relativePath, context: context) as? String,
       Constants.isRealUuid(uuid)
     else { return .unresolved }
-    if let rawType = getItemProperty(#keyPath(LibraryItem.type), relativePath: relativePath) as? Int16,
+    if let rawType = getItemProperty(#keyPath(LibraryItem.type), relativePath: relativePath, context: context) as? Int16,
        rawType == ItemType.bound.rawValue {
       return .unresolved
     }
     return .folder(LibraryItemRef(relativePath: relativePath, uuid: uuid))
-  }
-
-  public func sortContents(in location: SortLocation, by type: SortType) {
-    let relativePath: String?
-    switch location {
-    case .libraryRoot:
-      relativePath = nil
-    case .folder(let ref):
-      relativePath = ref.relativePath
-    case .unresolved:
-      // Folder with placeholder UUID — pref writes are no-ops at the resolver,
-      // so re-sorting the underlying CoreData ranks would be a partial action.
-      // Skip until the UUID is materialized and the caller re-tries.
-      return
-    }
-    sortContents(at: relativePath, by: type)
   }
 
   public func getRelativePath(forUuid uuid: String) -> String? {
@@ -2396,27 +2366,6 @@ extension LibraryService {
     } catch {
       return nil
     }
-  }
-
-  /// Decision 9: returns true when the item's parent location has an automatic sticky sort.
-  /// The sync subscriber uses this to drop `orderRank`-only updates (other devices recompute).
-  public func isParentLocationAutoSorted(itemRelativePath: String) -> Bool {
-    guard let prefs = preferencesService else { return false }
-
-    // Derive parent path from the item's relativePath. Root-level items have no parent path.
-    let components = itemRelativePath.split(separator: "/")
-    let parentPath: String?
-    if components.count <= 1 {
-      parentPath = nil
-    } else {
-      parentPath = components.dropLast().joined(separator: "/")
-    }
-
-    let location = makeLocation(forRelativePath: parentPath)
-    if case .automatic = prefs.effectiveSort(forLocation: location) {
-      return true
-    }
-    return false
   }
 
   public func updatePlaybackTime(relativePath: String, time: Double, date: Date, scheduleSave: Bool) {

--- a/Shared/Services/LibraryService.swift
+++ b/Shared/Services/LibraryService.swift
@@ -79,6 +79,9 @@ public protocol LibraryServiceProtocol: AnyObject {
   /// Find first item (optionally: first unfinished) in a folder, in the
   /// location's effective (visible) order
   func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem?
+  /// The parent's children as lightweight navigation entries in the location's
+  /// effective (visible) order — the playback prev/next walk's data source
+  func getOrderedSiblings(in parentFolder: String?) -> [SimpleNavigationItem]?
   /// Get metadata chapters from item
   func getChapters(from relativePath: String) -> [SimpleChapter]?
 
@@ -1265,12 +1268,14 @@ extension LibraryService {
   }
 
   func deleteFolderContents(_ folder: SimpleLibraryItem, context: NSManagedObjectContext) throws {
-    // Delete folder contents
+    // Delete folder contents — order-insensitive, and this runs on the sync
+    // background context, so skip the preference resolution.
     guard
       let items = fetchContents(
         at: folder.relativePath,
         limit: nil,
         offset: nil,
+        ordering: .byRank,
         context: context
       )
     else { return }
@@ -1307,10 +1312,11 @@ extension LibraryService {
     )
   }
 
-  public func fetchContents(
+  func fetchContents(
     at relativePath: String?,
     limit: Int?,
     offset: Int?,
+    ordering: ContentsOrdering = .effective,
     context: NSManagedObjectContext
   ) -> [SimpleLibraryItem]? {
     let fetchRequest = buildListContentsFetchRequest(
@@ -1318,7 +1324,7 @@ extension LibraryService {
       relativePath: relativePath,
       limit: limit,
       offset: offset,
-      ordering: .effective,
+      ordering: ordering,
       context: context
     )
 
@@ -1327,14 +1333,13 @@ extension LibraryService {
     return parseFetchedItems(from: results, context: context)
   }
 
+  /// Rank-ordered by the `sortedBy` default — internal reads of the stored
+  /// custom arrangement.
   func fetchRawContents(at relativePath: String?, propertiesToFetch: [String]) -> [LibraryItem]? {
-    let context = dataManager.getContext()
-
     return fetchRawContents(
       at: relativePath,
       propertiesToFetch: propertiesToFetch,
-      sortedBy: resolveSortDescriptors(forRelativePath: relativePath, ordering: .byRank, context: context),
-      context: context
+      context: dataManager.getContext()
     )
   }
 
@@ -1641,9 +1646,40 @@ extension LibraryService {
   /// Note: `isUnfinished` is nil-checked only (matching the pre-existing
   /// contract) — passing `false` still filters for unfinished items.
   public func findFirstItem(in parentFolder: String?, isUnfinished: Bool?) -> SimpleLibraryItem? {
-    guard let siblings = fetchContents(at: parentFolder, limit: nil, offset: nil) else { return nil }
-    guard isUnfinished != nil else { return siblings.first }
-    return siblings.first { !$0.isFinished }
+    guard let siblings = getOrderedSiblings(in: parentFolder) else { return nil }
+    let first: SimpleNavigationItem?
+    if isUnfinished != nil {
+      first = siblings.first { !$0.isFinished }
+    } else {
+      first = siblings.first
+    }
+    guard let first else { return nil }
+    return getSimpleItem(with: first.relativePath)
+  }
+
+  public func getOrderedSiblings(in parentFolder: String?) -> [SimpleNavigationItem]? {
+    let context = dataManager.getContext()
+    let fetchRequest = buildListContentsFetchRequest(
+      properties: [
+        #keyPath(LibraryItem.relativePath),
+        #keyPath(LibraryItem.isFinished),
+      ],
+      relativePath: parentFolder,
+      limit: nil,
+      offset: nil,
+      ordering: .effective,
+      context: context
+    )
+
+    guard let results = try? context.fetch(fetchRequest) as? [[String: Any]] else { return nil }
+
+    return results.compactMap { dictionary in
+      guard let relativePath = dictionary[#keyPath(LibraryItem.relativePath)] as? String else { return nil }
+      return SimpleNavigationItem(
+        relativePath: relativePath,
+        isFinished: dictionary[#keyPath(LibraryItem.isFinished)] as? Bool ?? false
+      )
+    }
   }
 
   public func getChapters(from relativePath: String) -> [SimpleChapter]? {
@@ -2148,61 +2184,21 @@ extension LibraryService {
     return results["totalDuration"] ?? 0
   }
 
-  public func reorderItems(
-    inside folderRelativePath: String?,
-    fromOffsets source: IndexSet,
-    toOffset destination: Int
+  /// Shared core of the custom-arrangement mutations (drag, reverse,
+  /// Custom-freeze). Two ordering invariants live here so no caller can get
+  /// them wrong individually:
+  /// 1. Capture-before-flip: the effective (visible) descriptors are resolved
+  ///    BEFORE the pref flips to `.custom` — flipping first would resolve to
+  ///    rank order and the mutation would act on an order the user isn't
+  ///    looking at.
+  /// 2. The `.custom` pref write precedes the rank rebuild, so the next
+  ///    (query-time-sorted) fetch can't re-sort the arrangement away.
+  /// Emits one sync update per actually-changed rank; the whole arrangement
+  /// is user-made, so these always sync.
+  private func freezeVisibleOrder(
+    at relativePath: String?,
+    transform: ([LibraryItem]) -> [LibraryItem]
   ) {
-    let context = dataManager.getContext()
-    /// The drag offsets are positions in the VISIBLE (effective) order, so the
-    /// descriptors must be captured BEFORE the pref flips to `.custom` below —
-    /// flipping first would resolve to rank order and move the wrong rows.
-    let visibleOrder = resolveSortDescriptors(
-      forRelativePath: folderRelativePath,
-      ordering: .effective,
-      context: context
-    )
-
-    // Hook 5: the pref flip precedes the rank rebuild so the arrangement the
-    // user just made isn't re-sorted away by the next (query-time-sorted) fetch.
-    if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: folderRelativePath, context: context)
-      prefs.setSort(.custom, forLocation: location)
-    }
-
-    guard
-      var contents = fetchRawContents(
-        at: folderRelativePath,
-        propertiesToFetch: [
-          #keyPath(LibraryItem.relativePath),
-          #keyPath(LibraryItem.orderRank),
-          #keyPath(LibraryItem.uuid)
-        ],
-        sortedBy: visibleOrder,
-        context: context
-      )
-    else { return }
-
-    contents.move(fromOffsets: source, toOffset: destination)
-
-    /// Freeze the rearranged visible order into ranks
-    for (index, item) in contents.enumerated() {
-      item.orderRank = Int16(index)
-      metadataPassthroughPublisher.send([
-        #keyPath(LibraryItem.relativePath): item.relativePath!,
-        #keyPath(LibraryItem.orderRank): item.orderRank,
-        #keyPath(LibraryItem.uuid): item.uuid
-      ])
-    }
-
-    dataManager.saveContext()
-  }
-
-  /// Freezes the location's currently-visible order into `orderRank` and
-  /// transitions the sticky sort to `.custom` — the picker's "Custom" option.
-  /// WYSIWYG by design (Android parity), and it self-heals stale server ranks
-  /// the first time it runs. Same capture-before-flip rule as `reorderItems`.
-  public func adoptCurrentOrderAsCustom(at relativePath: String?) {
     let context = dataManager.getContext()
     let visibleOrder = resolveSortDescriptors(
       forRelativePath: relativePath,
@@ -2229,7 +2225,7 @@ extension LibraryService {
       !contents.isEmpty
     else { return }
 
-    for (index, item) in contents.enumerated() where item.orderRank != Int16(index) {
+    for (index, item) in transform(contents).enumerated() where item.orderRank != Int16(index) {
       item.orderRank = Int16(index)
       metadataPassthroughPublisher.send([
         #keyPath(LibraryItem.relativePath): item.relativePath!,
@@ -2241,50 +2237,35 @@ extension LibraryService {
     dataManager.saveContext()
   }
 
+  public func reorderItems(
+    inside folderRelativePath: String?,
+    fromOffsets source: IndexSet,
+    toOffset destination: Int
+  ) {
+    /// The drag offsets are positions in the visible order; the freeze helper
+    /// fetches in exactly that order before applying them.
+    freezeVisibleOrder(at: folderRelativePath) { contents in
+      var rearranged = contents
+      rearranged.move(fromOffsets: source, toOffset: destination)
+      return rearranged
+    }
+  }
+
+  /// Freezes the location's currently-visible order into `orderRank` and
+  /// transitions the sticky sort to `.custom` — the picker's "Custom" option.
+  /// WYSIWYG by design (Android parity), and it self-heals stale server ranks
+  /// the first time it runs. Idempotent: a repeat freeze changes no ranks and
+  /// emits no sync updates.
+  public func adoptCurrentOrderAsCustom(at relativePath: String?) {
+    freezeVisibleOrder(at: relativePath) { $0 }
+  }
+
   /// One-off reverse: flips the current VISIBLE order and transitions the location's
   /// sticky sort to `.custom`, the same transition a manual drag-drop produces.
-  /// Same capture-before-flip rule as `reorderItems`: the effective descriptors are
-  /// resolved before the pref flips, so reversing an automatically-sorted list
-  /// freezes the reversed rule order — what the user sees, reversed.
+  /// Reversing an automatically-sorted list freezes the reversed rule order —
+  /// what the user sees, reversed.
   public func reverseContents(at relativePath: String?) {
-    let context = dataManager.getContext()
-    let visibleOrder = resolveSortDescriptors(
-      forRelativePath: relativePath,
-      ordering: .effective,
-      context: context
-    )
-
-    if let prefs = preferencesService {
-      let location = makeLocation(forRelativePath: relativePath, context: context)
-      prefs.setSort(.custom, forLocation: location)
-    }
-
-    guard
-      var contents = fetchRawContents(
-        at: relativePath,
-        propertiesToFetch: [
-          #keyPath(LibraryItem.relativePath),
-          #keyPath(LibraryItem.orderRank),
-          #keyPath(LibraryItem.uuid)
-        ],
-        sortedBy: visibleOrder,
-        context: context
-      ),
-      !contents.isEmpty
-    else { return }
-
-    contents.reverse()
-
-    for (index, item) in contents.enumerated() {
-      item.orderRank = Int16(index)
-      metadataPassthroughPublisher.send([
-        #keyPath(LibraryItem.relativePath): item.relativePath!,
-        #keyPath(LibraryItem.orderRank): item.orderRank,
-        #keyPath(LibraryItem.uuid): item.uuid,
-      ])
-    }
-
-    self.dataManager.saveContext()
+    freezeVisibleOrder(at: relativePath) { $0.reversed() }
   }
 
   public func sortContents(at relativePath: String?, by type: SortType) {
@@ -2337,13 +2318,23 @@ extension LibraryService {
     makeLocation(forRelativePath: relativePath, context: dataManager.getContext())
   }
 
-  public func makeLocation(forRelativePath relativePath: String?, context: NSManagedObjectContext) -> SortLocation {
+  /// Single-fetch resolution (uuid + type in one round trip): this runs on the
+  /// render path via `resolveSortDescriptors`, so per-call cost matters.
+  func makeLocation(forRelativePath relativePath: String?, context: NSManagedObjectContext) -> SortLocation {
     guard let relativePath else { return .libraryRoot }
+
+    let fetchRequest: NSFetchRequest<NSDictionary> = NSFetchRequest(entityName: "LibraryItem")
+    fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(LibraryItem.relativePath), relativePath)
+    fetchRequest.propertiesToFetch = [#keyPath(LibraryItem.uuid), #keyPath(LibraryItem.type)]
+    fetchRequest.resultType = .dictionaryResultType
+    fetchRequest.fetchLimit = 1
+
     guard
-      let uuid = getItemProperty(#keyPath(LibraryItem.uuid), relativePath: relativePath, context: context) as? String,
+      let row = (try? context.fetch(fetchRequest))?.first,
+      let uuid = row[#keyPath(LibraryItem.uuid)] as? String,
       Constants.isRealUuid(uuid)
     else { return .unresolved }
-    if let rawType = getItemProperty(#keyPath(LibraryItem.type), relativePath: relativePath, context: context) as? Int16,
+    if let rawType = row[#keyPath(LibraryItem.type)] as? Int16,
        rawType == ItemType.bound.rawValue {
       return .unresolved
     }

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -61,19 +61,16 @@ public final class PlaybackService: PlaybackServiceProtocol {
   }
 
   public func getPlayableItem(before relativePath: String, parentFolder: String?) -> PlayableItem? {
+    /// Walk the parent's children in their EFFECTIVE (visible) order — the
+    /// contract is "previous is whatever sits above this item in the list",
+    /// under automatic sorts and Custom alike. Rank cursors can't express the
+    /// Finder-style collation, so we index into the ordered sibling list.
     guard
-      let orderRank = self.libraryService.getItemProperty(
-        #keyPath(LibraryItem.orderRank),
-        relativePath: relativePath
-      ) as? Int16
+      let siblings = self.libraryService.fetchContents(at: parentFolder, limit: nil, offset: nil),
+      let currentIndex = siblings.firstIndex(where: { $0.relativePath == relativePath })
     else { return nil }
 
-    guard
-      let previousItem = self.libraryService.findFirstItem(
-        in: parentFolder,
-        beforeRank: orderRank
-      )
-    else {
+    guard currentIndex > 0 else {
       if let parentFolderPath = parentFolder {
         let containerPathForParentFolder =
           self.libraryService.getItemProperty(
@@ -88,6 +85,8 @@ public final class PlaybackService: PlaybackServiceProtocol {
 
       return nil
     }
+
+    let previousItem = siblings[currentIndex - 1]
 
     if previousItem.type == .folder {
       return try? getFirstPlayableItem(
@@ -105,13 +104,6 @@ public final class PlaybackService: PlaybackServiceProtocol {
     autoplayed: Bool,
     restartFinished: Bool
   ) -> PlayableItem? {
-    guard
-      let orderRank = self.libraryService.getItemProperty(
-        #keyPath(LibraryItem.orderRank),
-        relativePath: relativePath
-      ) as? Int16
-    else { return nil }
-
     var isUnfinished: Bool?
 
     if autoplayed == true,
@@ -120,13 +112,21 @@ public final class PlaybackService: PlaybackServiceProtocol {
       isUnfinished = true
     }
 
-    guard
-      let nextItem = self.libraryService.findFirstItem(
-        in: parentFolder,
-        afterRank: orderRank,
-        isUnfinished: isUnfinished
-      )
-    else {
+    /// Same visible-order walk as `getPlayableItem(before:)` — "next" is
+    /// whatever sits below this item in the list. The unfinished filter (set
+    /// only for autoplay without restart-finished) skips finished siblings,
+    /// folders included, matching the old rank-cursor predicate.
+    let nextItem: SimpleLibraryItem? = {
+      guard
+        let siblings = self.libraryService.fetchContents(at: parentFolder, limit: nil, offset: nil),
+        let currentIndex = siblings.firstIndex(where: { $0.relativePath == relativePath })
+      else { return nil }
+      return siblings[siblings.index(after: currentIndex)...].first { candidate in
+        isUnfinished == nil || !candidate.isFinished
+      }
+    }()
+
+    guard let nextItem else {
       if let parentFolderPath = parentFolder {
         let containerPathForParentFolder =
           self.libraryService.getItemProperty(

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -64,9 +64,10 @@ public final class PlaybackService: PlaybackServiceProtocol {
     /// Walk the parent's children in their EFFECTIVE (visible) order — the
     /// contract is "previous is whatever sits above this item in the list",
     /// under automatic sorts and Custom alike. Rank cursors can't express the
-    /// Finder-style collation, so we index into the ordered sibling list.
+    /// Finder-style collation, so we index into the ordered sibling list
+    /// (lightweight navigation entries — no full-row materialization).
     guard
-      let siblings = self.libraryService.fetchContents(at: parentFolder, limit: nil, offset: nil),
+      let siblings = self.libraryService.getOrderedSiblings(in: parentFolder),
       let currentIndex = siblings.firstIndex(where: { $0.relativePath == relativePath })
     else { return nil }
 
@@ -86,16 +87,7 @@ public final class PlaybackService: PlaybackServiceProtocol {
       return nil
     }
 
-    let previousItem = siblings[currentIndex - 1]
-
-    if previousItem.type == .folder {
-      return try? getFirstPlayableItem(
-        in: previousItem,
-        isUnfinished: nil
-      )
-    }
-
-    return try? getPlayableItem(from: previousItem)
+    return resolvePlayableItem(from: siblings[currentIndex - 1], isUnfinished: nil)
   }
 
   public func getPlayableItem(
@@ -116,15 +108,18 @@ public final class PlaybackService: PlaybackServiceProtocol {
     /// whatever sits below this item in the list. The unfinished filter (set
     /// only for autoplay without restart-finished) skips finished siblings,
     /// folders included, matching the old rank-cursor predicate.
-    let nextItem: SimpleLibraryItem? = {
-      guard
-        let siblings = self.libraryService.fetchContents(at: parentFolder, limit: nil, offset: nil),
-        let currentIndex = siblings.firstIndex(where: { $0.relativePath == relativePath })
-      else { return nil }
-      return siblings[siblings.index(after: currentIndex)...].first { candidate in
-        isUnfinished == nil || !candidate.isFinished
-      }
-    }()
+    guard
+      let siblings = self.libraryService.getOrderedSiblings(in: parentFolder),
+      let currentIndex = siblings.firstIndex(where: { $0.relativePath == relativePath })
+    else {
+      /// Current item unknown here (deleted/moved mid-playback): stop, same
+      /// as `getPlayableItem(before:)` — never hop out of a stale folder.
+      return nil
+    }
+
+    let nextItem = siblings[siblings.index(after: currentIndex)...].first { candidate in
+      isUnfinished == nil || !candidate.isFinished
+    }
 
     guard let nextItem else {
       if let parentFolderPath = parentFolder {
@@ -144,14 +139,26 @@ public final class PlaybackService: PlaybackServiceProtocol {
       return nil
     }
 
-    if nextItem.type == .folder {
+    return resolvePlayableItem(from: nextItem, isUnfinished: isUnfinished)
+  }
+
+  /// Materializes a navigation entry into a `PlayableItem`, descending into
+  /// plain folders (matching the old cursor behavior: only `.folder` descends;
+  /// `.bound` plays as a single unit).
+  private func resolvePlayableItem(
+    from entry: SimpleNavigationItem,
+    isUnfinished: Bool?
+  ) -> PlayableItem? {
+    guard let item = self.libraryService.getSimpleItem(with: entry.relativePath) else { return nil }
+
+    if item.type == .folder {
       return try? getFirstPlayableItem(
-        in: nextItem,
+        in: item,
         isUnfinished: isUnfinished
       )
     }
 
-    return try? getPlayableItem(from: nextItem)
+    return try? getPlayableItem(from: item)
   }
 
   public func getFirstPlayableItem(in folder: SimpleLibraryItem, isUnfinished: Bool?) throws -> PlayableItem? {

--- a/Shared/Services/Preferences/PreferencesSyncService.swift
+++ b/Shared/Services/Preferences/PreferencesSyncService.swift
@@ -78,7 +78,10 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
       encode: { key, defaults in
         ["sort": defaults.string(forKey: key) ?? ""]
       },
-      sideEffect: .resort
+      // No service-side work: order is derived from the pref at query time,
+      // so applying the value is the whole job. The `preferencesChanged`
+      // publish (pull loop) triggers the visible list's re-fetch.
+      sideEffect: .none
     ),
     PreferenceSchema(
       prefix: Constants.UserDefaults.libraryDisplayPrefix,
@@ -539,41 +542,13 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
   /// Runs the schema's declared side effect after a remote-pulled value
   /// changes a tracked key. `@AppStorage` subscribers re-render on their
   /// own — this is for service-internal work that needs to follow the
-  /// new value (e.g. re-ranking items when sort changes).
+  /// new value. (Sort keys need none: order is derived at query time, and
+  /// the pull loop's `preferencesChanged` publish drives the list re-fetch.)
   private func dispatchSideEffect(forKey key: String) async {
     guard let schema = schema(forKey: key) else { return }
     switch schema.sideEffect {
-    case .resort:
-      await dispatchResort(forKey: key)
     case .none:
       break
-    }
-  }
-
-  private func dispatchResort(forKey key: String) async {
-    let location: SortLocation
-    if key == Constants.UserDefaults.librarySortDefault {
-      location = .libraryRoot
-    } else if key.hasPrefix(Constants.UserDefaults.librarySortPrefix) {
-      let uuid = String(key.dropFirst(Constants.UserDefaults.librarySortPrefix.count))
-      guard Constants.isRealUuid(uuid) else { return }
-      // Look up the relativePath for this folder uuid (best-effort; if folder
-      // hasn't synced down yet, we just cache the pref and skip the re-sort).
-      guard let relativePath = libraryService.getRelativePath(forUuid: uuid) else { return }
-      // Route through `makeLocation` rather than constructing `.folder(...)`
-      // directly, so bound-folder + placeholder-UUID gates apply uniformly
-      // even on the server-driven path.
-      location = libraryService.makeLocation(forRelativePath: relativePath)
-    } else {
-      return
-    }
-
-    guard
-      case .automatic(let sort) = effectiveSort(forLocation: location)
-    else { return }
-
-    await MainActor.run {
-      libraryService.sortContents(in: location, by: sort)
     }
   }
 
@@ -686,9 +661,9 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
 /// The `dispatchSideEffect` switch in `PreferencesSyncService` is the
 /// single place that maps cases to implementations.
 private enum PreferenceSideEffect {
-  /// Re-rank the affected library location's contents.
-  case resort
   /// No service-side action — `@AppStorage` subscribers handle it.
+  /// (The old `resort` case died with rank materialization: order is now
+  /// derived from the pref at query time.)
   case none
 }
 

--- a/Shared/Services/Preferences/PreferencesSyncService.swift
+++ b/Shared/Services/Preferences/PreferencesSyncService.swift
@@ -56,14 +56,12 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
   // MARK: - State
 
   /// Single source of truth for every synced preference family. Each entry
-  /// owns its prefix, the static keys observed at bootstrap, the value-shape
-  /// codec used by `applyServerSnapshot` / `flush`, and the side effect to
-  /// run after a remote-pulled value lands in `UserDefaults`.
+  /// owns its prefix, the static keys observed at bootstrap, and the
+  /// value-shape codec used by `applyServerSnapshot` / `flush`.
   ///
   /// Adding a new family (e.g. `audio_eq:`) is a single entry append: declare
-  /// the prefix + keys in `Constants.UserDefaults`, plug the decode/encode
-  /// closures, and pick a `PreferenceSideEffect` (or extend the enum if a new
-  /// kind of side effect is needed).
+  /// the prefix + keys in `Constants.UserDefaults` and plug the decode/encode
+  /// closures.
   private let schemas: [PreferenceSchema] = [
     PreferenceSchema(
       prefix: Constants.UserDefaults.librarySortPrefix,
@@ -77,11 +75,7 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
       },
       encode: { key, defaults in
         ["sort": defaults.string(forKey: key) ?? ""]
-      },
-      // No service-side work: order is derived from the pref at query time,
-      // so applying the value is the whole job. The `preferencesChanged`
-      // publish (pull loop) triggers the visible list's re-fetch.
-      sideEffect: .none
+      }
     ),
     PreferenceSchema(
       prefix: Constants.UserDefaults.libraryDisplayPrefix,
@@ -102,8 +96,7 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
       },
       encode: { key, defaults in
         ["value": defaults.bool(forKey: key)]
-      },
-      sideEffect: .none
+      }
     ),
   ]
 
@@ -284,6 +277,8 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
   }
 
   public func handleLogout() {
+    freezeAutomaticSortsBeforeWipe()
+
     lock.lock()
     defer { lock.unlock() }
 
@@ -305,6 +300,34 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
       }
     }
     defaults.removeObject(forKey: Constants.UserDefaults.userPreferencesDirty)
+  }
+
+  /// Signing out wipes every `library_sort:*` key, and under query-time
+  /// sorting that would visibly re-scramble the library back to the latent
+  /// rank order. Freeze each automatically-sorted location's visible order
+  /// into ranks first, so the list the user sees survives sign-out.
+  /// Runs BEFORE the teardown lock is taken: the freeze goes through
+  /// `setSort(.custom)`, whose KVO callback takes the same lock. Any sync
+  /// updates it emits are dropped downstream — `SyncService.isActive` is
+  /// false by the time the debounced collect delivers them.
+  private func freezeAutomaticSortsBeforeWipe() {
+    let sortKeys = defaults.dictionaryRepresentation().keys.filter {
+      $0.hasPrefix(Constants.UserDefaults.librarySortPrefix)
+    }
+    for key in sortKeys {
+      guard
+        let rawValue = defaults.string(forKey: key),
+        case .automatic = EffectiveSort(rawValue: rawValue) ?? .custom
+      else { continue }
+
+      if key == Constants.UserDefaults.librarySortDefault {
+        libraryService.adoptCurrentOrderAsCustom(at: nil)
+      } else {
+        let uuid = String(key.dropFirst(Constants.UserDefaults.librarySortPrefix.count))
+        guard let relativePath = libraryService.getRelativePath(forUuid: uuid) else { continue }
+        libraryService.adoptCurrentOrderAsCustom(at: relativePath)
+      }
+    }
   }
 
   // MARK: - SortPreferencesResolving
@@ -398,17 +421,16 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
     lastSuccessfulPull = Date()
     lock.unlock()
 
-    // Walk applied keys and run the per-key side effect (resort for sort
-    // keys, no-op for display keys). For each key whose value actually
-    // changed, emit `preferencesChanged` so subscribers (e.g. `ItemListView`)
-    // can refresh. The KVO observer doesn't publish here because
-    // `applyServerSnapshot` sets `isApplyingRemoteUpdate` to suppress
-    // echo loops.
+    // For each applied key whose value actually changed, emit
+    // `preferencesChanged` so subscribers (e.g. `ItemListView`) re-fetch —
+    // that's the entire application step: sort order is derived from the
+    // stored pref at query time. The KVO observer doesn't publish here
+    // because `applyServerSnapshot` sets `isApplyingRemoteUpdate` to
+    // suppress echo loops.
     for key in appliedKeys {
       let oldValue = beforeSnapshot[key]
       let newValue = currentValue(forKey: key)
       if oldValue == newValue { continue }
-      await dispatchSideEffect(forKey: key)
       preferencesChanged.send(key)
     }
   }
@@ -539,19 +561,6 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
     schema(forKey: key)?.encode(key, defaults)
   }
 
-  /// Runs the schema's declared side effect after a remote-pulled value
-  /// changes a tracked key. `@AppStorage` subscribers re-render on their
-  /// own — this is for service-internal work that needs to follow the
-  /// new value. (Sort keys need none: order is derived at query time, and
-  /// the pull loop's `preferencesChanged` publish drives the list re-fetch.)
-  private func dispatchSideEffect(forKey key: String) async {
-    guard let schema = schema(forKey: key) else { return }
-    switch schema.sideEffect {
-    case .none:
-      break
-    }
-  }
-
   // MARK: - Flush
 
   private func scheduleFlush() {
@@ -652,27 +661,13 @@ public final class PreferencesSyncService: NSObject, PreferencesSyncServiceProto
 
 // MARK: - Preference schema
 
-/// Service-internal action to run after a remote-pulled value writes to
-/// `UserDefaults`. The view layer reacts to UserDefaults changes via
-/// `@AppStorage` automatically; this enum names the work that the
-/// **service** still has to do (e.g. re-rank items when sort changes).
-///
-/// Add a new case when a new preference family needs a new kind of work.
-/// The `dispatchSideEffect` switch in `PreferencesSyncService` is the
-/// single place that maps cases to implementations.
-private enum PreferenceSideEffect {
-  /// No service-side action — `@AppStorage` subscribers handle it.
-  /// (The old `resort` case died with rank materialization: order is now
-  /// derived from the pref at query time.)
-  case none
-}
-
 /// Declarative description of a synced-preference family.
 ///
 /// `PreferencesSyncService` holds an array of these and uses them as the
-/// single source of truth for tracked prefixes, observed static keys, the
-/// per-prefix codec used to talk to the server, and the side effect to run
-/// after a remote update lands.
+/// single source of truth for tracked prefixes, observed static keys, and the
+/// per-prefix codec used to talk to the server. No service-side work follows
+/// a remote update: sort order is derived from the pref at query time, and
+/// the pull loop's `preferencesChanged` publish drives the visible re-fetch.
 private struct PreferenceSchema {
   /// All keys under this family share this prefix. KVO observation and
   /// the logout wipe both key off it.
@@ -692,10 +687,6 @@ private struct PreferenceSchema {
   /// Reads the current local value for `key` from `defaults` and produces
   /// the dictionary the server expects under the entry's `value` field.
   let encode: (_ key: String, _ defaults: UserDefaults) -> [String: Any]
-
-  /// Service-internal work to run after a remote update changes a key in
-  /// this family. View-layer refresh is handled by `@AppStorage`, not here.
-  let sideEffect: PreferenceSideEffect
 }
 
 // MARK: - Wire types

--- a/Shared/Services/SortType.swift
+++ b/Shared/Services/SortType.swift
@@ -31,6 +31,37 @@ public enum SortType: String, Codable, CaseIterable {
     return properties
   }
 
+  /// Fetch-time sort descriptors for this rule — the query-time counterpart of
+  /// `sortItems(_:)`, pinned equivalent by `QueryTimeSortSpikeTests`.
+  /// `localizedStandardCompare:` is one of the selectors the SQLite store
+  /// evaluates natively, and SQLite sorts NULL last under DESC, matching
+  /// `sortItems`' `lastPlayDate ?? .distantPast`. The trailing `orderRank`
+  /// tie-breaker keeps equal keys in the latent custom order and makes
+  /// pagination deterministic (the in-memory sort was not stable).
+  var sortDescriptors: [NSSortDescriptor] {
+    let primary: NSSortDescriptor
+    switch self {
+    case .metadataTitle:
+      primary = NSSortDescriptor(
+        key: #keyPath(LibraryItem.title),
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare(_:))
+      )
+    case .fileName:
+      primary = NSSortDescriptor(
+        key: #keyPath(LibraryItem.originalFileName),
+        ascending: true,
+        selector: #selector(NSString.localizedStandardCompare(_:))
+      )
+    case .mostRecent:
+      primary = NSSortDescriptor(key: #keyPath(LibraryItem.lastPlayDate), ascending: false)
+    }
+    return [
+      primary,
+      NSSortDescriptor(key: #keyPath(LibraryItem.orderRank), ascending: true),
+    ]
+  }
+
   func sortItems(_ items: [LibraryItem]) -> [LibraryItem] {
     switch self {
     case .fileName:

--- a/Shared/Services/Sync/SyncService.swift
+++ b/Shared/Services/Sync/SyncService.swift
@@ -568,20 +568,9 @@ extension SyncService {
       let relativePath = params["relativePath"] as? String
     else { return }
 
-    // Decision 9: drop `orderRank`-only updates when the item's parent location
-    // has an automatic sticky sort. Other devices recompute ranks locally from
-    // (item set + sort rule), so syncing the rank churn would be redundant.
-    let identifierKeys: Set<String> = [
-      #keyPath(LibraryItem.relativePath),
-      #keyPath(LibraryItem.uuid),
-    ]
-    let dataKeys = Set(params.keys).subtracting(identifierKeys)
-    let isOrderRankOnly = dataKeys == [#keyPath(LibraryItem.orderRank)]
-    if isOrderRankOnly,
-       libraryService.isParentLocationAutoSorted(itemRelativePath: relativePath) {
-      return
-    }
-
+    // No orderRank suppression here: automatic sorts are applied at query time
+    // and never write ranks, so every rank update that reaches this point is a
+    // genuine custom-arrangement change and must sync.
     Task {
       var params = params
 


### PR DESCRIPTION
## What this is

Phase 1 of the query-time-sort refactor (built on the Phase 0 spike + characterization safety net from #1581). This is the fix for the Pro-user scramble: with a sticky sort selected, any contents pull copied stale server `orderRank` values over local rows and the list re-rendered in server order, because the sort was materialized into the rank column and the only compensating re-sort ran on inserts.

## The new model (matches Android)

**`orderRank` means exactly one thing: the user's custom arrangement.** It is written only by custom-arrangement mutations (drag, reverse, Custom-freeze, one-shot sorts) and by sync. Automatic sticky sorts are applied **at fetch time**:

- `SortType.sortDescriptors` — per-rule fetch descriptors (`localizedStandardCompare:` is SQLite-store-native, proven by the Phase 0 spike; the `orderRank` tie-break makes ordering deterministic and pagination stable).
- `LibraryService.resolveSortDescriptors` — single resolution choke point; fetches take `.effective` (user-facing) or `.byRank` (internal reconciliation). **CarPlay and the move-to-folder picker inherit the sticky sort for free**; bound-book timelines stay rank-ordered by construction (`.unresolved`); watchOS (no preferences service) keeps today's rank-order fallback.

## Deleted

- The import / move / sync-insert re-sort hooks (Hooks 2–4).
- Decision 9 (`orderRank`-only sync suppression + `isParentLocationAutoSorted`) — every surviving rank write is custom-meaningful and always syncs.
- The preference pull's resort side effect (`dispatchResort`) — applying the pulled value is the whole job; the existing `preferencesChanged` publish drives the visible list's re-fetch.
- `reorderItem(with:)` (no production caller) and the rank-cursor `findFirstItem(before/afterRank:)` variants.

## Behavior notes

- **Picking Custom now freezes the visible order into ranks** (`adoptCurrentOrderAsCustom`) — WYSIWYG, Android parity, and it self-heals the stale/scrambled ranks sitting in prod the first time it runs.
- **Drag and Reverse operate on the visible order**: effective descriptors are resolved *before* the pref flips to `.custom` (capture-before-flip — flipping first would act on the hidden rank order), then the rearranged view freezes into ranks.
- **Playback prev/next walks the visible sibling order** via `fetchContents` (rank cursors can't express Finder-style collation), preserving parent-folder recursion, folder descent, the unfinished autoplay filter, and the non-audiovisual skip. "Next" now always matches what the list shows — on iPhone and CarPlay, under every sort.
- **Fixed by construction:** "Most recent" now reflects playback/renames immediately (previously nothing re-ranked on those, so the list went stale), and equal sort keys no longer shuffle nondeterministically.
- The sync pull's rank write stays deliberately unguarded — server ranks are the synced custom arrangement; the screen just no longer reads them under automatic sorts.

## Testing

- **`QueryTimeSortRefactorTests`** (new): the scramble regression (pull overwrites ranks, rendered order unchanged), pref-only sort picks, sync insert without rank rewrite, Custom-freeze + idempotence, drag-on-visible-order, live most-recent, sort-aware prev/next, watch fallback.
- **All 15 `SortCharacterizationTests` pass unchanged** — the user-visible behavior pinned in Phase 0 is preserved.
- Rank-cursor tests replaced with PlaybackService-level navigation tests; the mixed-prefix pull test now asserts exactly one `preferencesChanged` per applied key and zero rank mutations.
- Mocks regenerated via Sourcery; CLAUDE.md ordering-model invariants updated in-PR.
- Full `Unit Tests` plan green locally; `BookPlayerWatchKit` builds for watchOS.

## Manual QA before release (no XCUITest target)

Pull-to-refresh + foreground under each sort (no reorder); second-device sort propagation; drag freezes WYSIWYG and syncs; CarPlay order + prev/next; watch list + prev/next; bound-book chapter order unchanged under any root sort; autoplay lands on the visually-next unfinished book; upgrade from 5.21 with a sort selected shows identical order.