### PR TITLE
Own the App Store review prompt cooldown client-side

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -649,6 +649,8 @@
 		6906A55021720FDF00A9E0B2 /* BookSortServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */; };
 		6906A553217211C600A9E0B2 /* StubFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6906A552217211C600A9E0B2 /* StubFactory.swift */; };
 		69343D332133844D000C425E /* VoiceOverService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D322133844D000C425E /* VoiceOverService.swift */; };
+		FBE2B360883B414695A54628 /* ReviewPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C80A51B636D4C7381529505 /* ReviewPromptService.swift */; };
+		058C840BB5E944B2899BC769 /* ReviewPromptServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F83542FF9A240EC87E55AC8 /* ReviewPromptServiceTests.swift */; };
 		69343D36213A07B4000C425E /* VoiceOverServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */; };
 		6C25A0E1ADBF2325CA78E8A4 /* mp3_NO_toc_v23.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 1BA32C89144C68DD64FD0B62 /* mp3_NO_toc_v23.mp3 */; };
 		6DF751D96098B1A3224FDF43 /* IntegrationServerAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FFF7B7B6E62B274D230C207 /* IntegrationServerAddress.swift */; };
@@ -1642,6 +1644,8 @@
 		6906A54F21720FDF00A9E0B2 /* BookSortServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSortServiceTest.swift; sourceTree = "<group>"; };
 		6906A552217211C600A9E0B2 /* StubFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubFactory.swift; sourceTree = "<group>"; };
 		69343D322133844D000C425E /* VoiceOverService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverService.swift; sourceTree = "<group>"; };
+		3C80A51B636D4C7381529505 /* ReviewPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPromptService.swift; sourceTree = "<group>"; };
+		6F83542FF9A240EC87E55AC8 /* ReviewPromptServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPromptServiceTests.swift; sourceTree = "<group>"; };
 		69343D35213A07B4000C425E /* VoiceOverServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverServiceTest.swift; sourceTree = "<group>"; };
 		6FB91B577BC77F45EDB2AAAA /* IntegrationConnectionFormViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationConnectionFormViewModel.swift; sourceTree = "<group>"; };
 		700DFD61111AC10253D6EBAA /* SyncTasksStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncTasksStorageTests.swift; sourceTree = "<group>"; };
@@ -3201,6 +3205,7 @@
 			isa = PBXGroup;
 			children = (
 				69343D322133844D000C425E /* VoiceOverService.swift */,
+				3C80A51B636D4C7381529505 /* ReviewPromptService.swift */,
 				419723FF21874D5F00AB1190 /* UserActivityManager.swift */,
 				41D39D40215F177D00B65290 /* BookActivityItemProvider.swift */,
 				41B30A32230232D200025D69 /* CarPlayManager.swift */,
@@ -3222,6 +3227,7 @@
 				53AE3D4C955A493470C8EAA9 /* QueryTimeSortSpikeTests.swift */,
 				F448E8BBF01860FC65EB697A /* SortCharacterizationTests.swift */,
 				9FC1E4662815091A00522FA8 /* AccountServiceTests.swift */,
+				6F83542FF9A240EC87E55AC8 /* ReviewPromptServiceTests.swift */,
 				9FC1E4762815F97E00522FA8 /* KeychainServiceTests.swift */,
 				700DFD61111AC10253D6EBAA /* SyncTasksStorageTests.swift */,
 				0EA09FE5A35CEA0B87F83EF3 /* PreferencesSyncServiceTests.swift */,
@@ -4772,6 +4778,7 @@
 				634BA5972C161FBE0015314D /* StoryView.swift in Sources */,
 				6356F9C52AC86D9200B7A027 /* BPAppShortcuts.swift in Sources */,
 				69343D332133844D000C425E /* VoiceOverService.swift in Sources */,
+				FBE2B360883B414695A54628 /* ReviewPromptService.swift in Sources */,
 				6304CF672B4B595400055285 /* SettingsAutoplayViewModel.swift in Sources */,
 				63B4A2FD2E91828B00784A22 /* ItemListView+Sheets.swift in Sources */,
 				63B4A2FE2E91828B00784A22 /* ItemListView+Alerts.swift in Sources */,
@@ -4988,6 +4995,7 @@
 				FED52673ACD975949EF9E219 /* PreferencesSyncServiceTests.swift in Sources */,
 				9FC1E4632814F80000522FA8 /* AccountServiceMock.swift in Sources */,
 				9FC1E4672815091A00522FA8 /* AccountServiceTests.swift in Sources */,
+				058C840BB5E944B2899BC769 /* ReviewPromptServiceTests.swift in Sources */,
 				9FC1E4772815F97E00522FA8 /* KeychainServiceTests.swift in Sources */,
 				63432B592AC1E6F7002619D0 /* MockNavigationController.swift in Sources */,
 				4137BBD0272DEBEC009ED9FE /* LoadingCoordinatorTests.swift in Sources */,

--- a/BookPlayer/Player/PlayerManager.swift
+++ b/BookPlayer/Player/PlayerManager.swift
@@ -509,12 +509,6 @@ final class PlayerManager: NSObject, PlayerManagerProtocol, ObservableObject {
 
     MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
 
-    // stop timer if the book is finished
-    if Int(currentTime) == Int(currentItem.duration) {
-      // Once book a book is finished, ask for a review
-      UserDefaults.standard.set(true, forKey: "ask_review")
-    }
-
     NotificationCenter.default.post(name: .bookPlaying, object: nil, userInfo: nil)
   }
 
@@ -1408,6 +1402,9 @@ extension PlayerManager {
         self.libraryService.setLibraryLastBook(with: nil)
 
         self.markAsCompleted(true)
+
+        /// Arm the review prompt; `ReviewPromptService` evaluates eligibility when consumed
+        UserDefaults.standard.set(true, forKey: Constants.UserDefaults.pendingReviewPrompt)
 
         self.playNextItem(autoPlayed: true, shouldAutoplay: !endOfChapterActive)
 

--- a/BookPlayer/Player/ViewModels/PlayerViewModel.swift
+++ b/BookPlayer/Player/ViewModels/PlayerViewModel.swift
@@ -609,17 +609,11 @@ final class PlayerViewModel: ObservableObject {
   }
   
   func requestReview() {
-    // don't do anything if flag isn't true
-    guard UserDefaults.standard.bool(forKey: "ask_review") else { return }
-    
-    // request for review if app is active
+    /// Evaluate only while active, so the pending flag isn't consumed
+    /// when the prompt has no chance of being shown
     guard UIApplication.shared.applicationState == .active else { return }
-    
-#if RELEASE
-    AppServices.shared.requestReview()
-#endif
-    
-    UserDefaults.standard.set(false, forKey: "ask_review")
+
+    AppServices.shared.reviewPromptService.requestReviewIfEligible()
   }
   
   func handleAutolockStatus(forceDisable: Bool = false) {

--- a/BookPlayer/Services/ReviewPromptService.swift
+++ b/BookPlayer/Services/ReviewPromptService.swift
@@ -1,0 +1,107 @@
+//
+//  ReviewPromptService.swift
+//  BookPlayer
+//
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import BookPlayerKit
+import Foundation
+import StoreKit
+import UIKit
+
+/// Owns the cooldown for the App Store review prompt.
+///
+/// Finishing a book arms `Constants.UserDefaults.pendingReviewPrompt`; this service consumes
+/// the flag and forwards to StoreKit at most once per app version and once per cooldown window,
+/// since the system's own 3-per-365-days throttle effectively resets across app updates.
+///
+/// Callers must only evaluate while the app is active, so the armed flag isn't consumed when
+/// the prompt has no chance of being shown.
+@MainActor
+final class ReviewPromptService {
+  /// Self-imposed cap of ~3 prompts per year, independent of the system throttle
+  private static let cooldownInterval: TimeInterval = 120 * 24 * 60 * 60
+
+  private let defaults: UserDefaults
+  private let dateProvider: () -> Date
+  private let versionProvider: () -> String?
+  private let presentPromptOverride: (() -> Void)?
+
+  init(
+    defaults: UserDefaults = .standard,
+    dateProvider: @escaping () -> Date = { Date() },
+    versionProvider: @escaping () -> String? = {
+      Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    },
+    presentPrompt: (() -> Void)? = nil
+  ) {
+    self.defaults = defaults
+    self.dateProvider = dateProvider
+    self.versionProvider = versionProvider
+    self.presentPromptOverride = presentPrompt
+  }
+
+  func requestReviewIfEligible() {
+    guard defaults.bool(forKey: Constants.UserDefaults.pendingReviewPrompt) else { return }
+
+    /// Consume the flag even when ineligible, so a prompt only ever fires
+    /// within one session of an actual book finish
+    defaults.set(false, forKey: Constants.UserDefaults.pendingReviewPrompt)
+
+    guard hasCooldownElapsed(), isNewVersionSinceLastRequest() else { return }
+
+    if let presentPromptOverride {
+      presentPromptOverride()
+    } else {
+      presentSystemPrompt()
+    }
+
+    /// There's no callback for whether the prompt was actually shown; the request itself
+    /// spends the cooldown window
+    defaults.set(dateProvider(), forKey: Constants.UserDefaults.lastReviewRequestDate)
+    defaults.set(versionProvider(), forKey: Constants.UserDefaults.lastReviewRequestVersion)
+  }
+
+  private func hasCooldownElapsed() -> Bool {
+    guard
+      let lastRequest = defaults.object(
+        forKey: Constants.UserDefaults.lastReviewRequestDate
+      ) as? Date
+    else {
+      return true
+    }
+
+    let now = dateProvider()
+
+    guard lastRequest <= now else {
+      /// The clock moved backwards; rewrite the stored date so the cooldown can elapse again
+      defaults.set(now, forKey: Constants.UserDefaults.lastReviewRequestDate)
+      return false
+    }
+
+    return now.timeIntervalSince(lastRequest) >= Self.cooldownInterval
+  }
+
+  private func isNewVersionSinceLastRequest() -> Bool {
+    guard
+      let lastVersion = defaults.string(
+        forKey: Constants.UserDefaults.lastReviewRequestVersion
+      )
+    else {
+      return true
+    }
+
+    return versionProvider() != lastVersion
+  }
+
+  private func presentSystemPrompt() {
+#if RELEASE
+    if let scene = UIApplication.shared.connectedScenes.first(where: {
+      $0.activationState == .foregroundActive
+    }) as? UIWindowScene {
+      AppStore.requestReview(in: scene)
+    }
+#endif
+  }
+}

--- a/BookPlayer/Utils/AppServices.swift
+++ b/BookPlayer/Utils/AppServices.swift
@@ -11,7 +11,6 @@ import BookPlayerKit
 import Combine
 import CoreData
 import Foundation
-import StoreKit
 import UIKit
 
 @MainActor
@@ -28,6 +27,8 @@ final class AppServices: BPLogger {
   var pendingURLActions = [Action]()
 
   let playerState = PlayerState()
+
+  let reviewPromptService = ReviewPromptService()
 
   private init() {}
 
@@ -157,14 +158,6 @@ final class AppServices: BPLogger {
     }
 
     playerState.showPlayer = true
-  }
-
-  func requestReview() {
-    if let scene = UIApplication.shared.connectedScenes.first(where: {
-      $0.activationState == .foregroundActive
-    }) as? UIWindowScene {
-      AppStore.requestReview(in: scene)
-    }
   }
 
   // MARK: - Background Playback

--- a/BookPlayerTests/Services/ReviewPromptServiceTests.swift
+++ b/BookPlayerTests/Services/ReviewPromptServiceTests.swift
@@ -1,0 +1,159 @@
+//
+//  ReviewPromptServiceTests.swift
+//  BookPlayerTests
+//
+//  Copyright © 2026 BookPlayer LLC. All rights reserved.
+//
+
+import Foundation
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import XCTest
+
+@MainActor
+final class ReviewPromptServiceTests: XCTestCase {
+  var defaults: UserDefaults!
+  var promptCount = 0
+
+  static let cooldown: TimeInterval = 120 * 24 * 60 * 60
+
+  override func setUp() {
+    super.setUp()
+    defaults = UserDefaults(suiteName: "ReviewPromptServiceTests")!
+    defaults.removePersistentDomain(forName: "ReviewPromptServiceTests")
+    promptCount = 0
+  }
+
+  override func tearDown() {
+    defaults.removePersistentDomain(forName: "ReviewPromptServiceTests")
+    super.tearDown()
+  }
+
+  func makeSUT(now: Date, version: String? = "1.0.0") -> ReviewPromptService {
+    return ReviewPromptService(
+      defaults: defaults,
+      dateProvider: { now },
+      versionProvider: { version },
+      presentPrompt: { self.promptCount += 1 }
+    )
+  }
+
+  func arm() {
+    defaults.set(true, forKey: Constants.UserDefaults.pendingReviewPrompt)
+  }
+
+  func testNotArmedDoesNothing() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    makeSUT(now: now).requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 0)
+    XCTAssertNil(defaults.object(forKey: Constants.UserDefaults.lastReviewRequestDate))
+  }
+
+  func testFirstRequestPromptsAndRecords() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    arm()
+
+    makeSUT(now: now, version: "1.2.3").requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 1)
+    XCTAssertFalse(defaults.bool(forKey: Constants.UserDefaults.pendingReviewPrompt))
+    XCTAssertEqual(
+      defaults.object(forKey: Constants.UserDefaults.lastReviewRequestDate) as? Date,
+      now
+    )
+    XCTAssertEqual(
+      defaults.string(forKey: Constants.UserDefaults.lastReviewRequestVersion),
+      "1.2.3"
+    )
+  }
+
+  func testCooldownBlocksAndConsumesFlag() {
+    let lastRequest = Date(timeIntervalSince1970: 1_000_000)
+    defaults.set(lastRequest, forKey: Constants.UserDefaults.lastReviewRequestDate)
+    defaults.set("1.0.0", forKey: Constants.UserDefaults.lastReviewRequestVersion)
+    arm()
+
+    let now = lastRequest.addingTimeInterval(Self.cooldown - 1)
+    makeSUT(now: now, version: "2.0.0").requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 0)
+    /// The flag is consumed on failure, so a stale arm can't fire a prompt much later
+    XCTAssertFalse(defaults.bool(forKey: Constants.UserDefaults.pendingReviewPrompt))
+    /// The stored request date is not overwritten by a blocked evaluation
+    XCTAssertEqual(
+      defaults.object(forKey: Constants.UserDefaults.lastReviewRequestDate) as? Date,
+      lastRequest
+    )
+  }
+
+  func testSameVersionBlocksAfterCooldown() {
+    let lastRequest = Date(timeIntervalSince1970: 1_000_000)
+    defaults.set(lastRequest, forKey: Constants.UserDefaults.lastReviewRequestDate)
+    defaults.set("1.0.0", forKey: Constants.UserDefaults.lastReviewRequestVersion)
+    arm()
+
+    let now = lastRequest.addingTimeInterval(Self.cooldown + 1)
+    makeSUT(now: now, version: "1.0.0").requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 0)
+    XCTAssertFalse(defaults.bool(forKey: Constants.UserDefaults.pendingReviewPrompt))
+  }
+
+  func testCooldownElapsedAndNewVersionPrompts() {
+    let lastRequest = Date(timeIntervalSince1970: 1_000_000)
+    defaults.set(lastRequest, forKey: Constants.UserDefaults.lastReviewRequestDate)
+    defaults.set("1.0.0", forKey: Constants.UserDefaults.lastReviewRequestVersion)
+    arm()
+
+    let now = lastRequest.addingTimeInterval(Self.cooldown + 1)
+    makeSUT(now: now, version: "1.1.0").requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 1)
+    XCTAssertEqual(
+      defaults.object(forKey: Constants.UserDefaults.lastReviewRequestDate) as? Date,
+      now
+    )
+    XCTAssertEqual(
+      defaults.string(forKey: Constants.UserDefaults.lastReviewRequestVersion),
+      "1.1.0"
+    )
+  }
+
+  func testFutureLastRequestDateSelfHeals() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let futureRequest = now.addingTimeInterval(60 * 60)
+    defaults.set(futureRequest, forKey: Constants.UserDefaults.lastReviewRequestDate)
+    defaults.set("1.0.0", forKey: Constants.UserDefaults.lastReviewRequestVersion)
+    arm()
+
+    makeSUT(now: now, version: "2.0.0").requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 0)
+    XCTAssertFalse(defaults.bool(forKey: Constants.UserDefaults.pendingReviewPrompt))
+    /// The stored date is rewritten to `now` so the cooldown can elapse again
+    XCTAssertEqual(
+      defaults.object(forKey: Constants.UserDefaults.lastReviewRequestDate) as? Date,
+      now
+    )
+
+    /// A full cooldown after the healed date, the prompt fires again
+    arm()
+    let later = now.addingTimeInterval(Self.cooldown + 1)
+    makeSUT(now: later, version: "2.0.0").requestReviewIfEligible()
+    XCTAssertEqual(promptCount, 1)
+  }
+
+  func testConsecutiveFinishesOnlyPromptOnce() {
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let sut = makeSUT(now: now, version: "1.0.0")
+
+    arm()
+    sut.requestReviewIfEligible()
+    arm()
+    sut.requestReviewIfEligible()
+
+    XCTAssertEqual(promptCount, 1)
+  }
+}

--- a/BookPlayerWatch/LocalPlayback/Player/PlayerManager.swift
+++ b/BookPlayerWatch/LocalPlayback/Player/PlayerManager.swift
@@ -483,12 +483,6 @@ final class PlayerManager: NSObject, PlayerManagerProtocol, ObservableObject {
 
     MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
 
-    // stop timer if the book is finished
-    if Int(currentTime) == Int(currentItem.duration) {
-      // Once book a book is finished, ask for a review
-      UserDefaults.standard.set(true, forKey: "ask_review")
-    }
-
     NotificationCenter.default.post(name: .bookPlaying, object: nil, userInfo: nil)
   }
 

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -16,6 +16,13 @@ public enum Constants {
     public static let lastSyncTimestamp = "lastSyncTimestamp"
     public static let hasScheduledLibraryContents = "hasScheduledLibraryContents"
 
+    /// Armed when a book finishes playing; consumed on the next review-prompt evaluation
+    public static let pendingReviewPrompt = "userPendingReviewPrompt"
+    /// Date of the last App Store review prompt request
+    public static let lastReviewRequestDate = "userLastReviewRequestDate"
+    /// App version of the last App Store review prompt request
+    public static let lastReviewRequestVersion = "userLastReviewRequestVersion"
+
     // User preferences
     public static let themeBrightnessEnabled = "userSettingsBrightnessEnabled"
     public static let themeBrightnessThreshold = "userSettingsBrightnessThreshold"


### PR DESCRIPTION
## What this is

Users complain about being review-prompted non-stop. The old flow re-armed a one-shot `ask_review` flag on **every** finished book and forwarded straight to StoreKit with zero client-side state — no last-prompt date, no version, no count — trusting the system's documented 3-per-365-days throttle. That throttle effectively resets across app updates (Apple's own sample code persists a `lastVersionPromptedForReview` for exactly this reason), so with our release cadence heavy listeners were eligible again every version. The nagging feel was amplified by delivery timing: audiobooks almost always finish while the phone is locked, so the deferred prompt landed at the **next app open**.

## The new model

`ReviewPromptService` (app target) owns eligibility end-to-end:

1. **Consume the armed flag first, pass or fail** — a prompt can only ever fire within one session of an actual book finish; a stale arm can never fire at a random app-open weeks later. The first book-end *after* the cooldown expires re-arms and gets through.
2. **Cooldown:** ≥ 120 days since the last request (self-caps at ~3/year regardless of how the system throttle behaves).
3. **Version guard:** never twice on the same `CFBundleShortVersionString` — this is the piece that neutralizes the resets-per-update problem.
4. On pass: request (still `#if RELEASE`-gated) and **record date + version immediately** — StoreKit gives no shown/not-shown callback, so the request itself spends the cooldown window.

Edge cases: a stored request date in the future (clock moved backwards) self-heals by rewriting to now and blocking until a real cooldown elapses; a nil bundle version fails open on the version gate but stays capped by the cooldown. Defaults, clock, version, and the prompt call are constructor-injectable.

## Arming moved to the actual book finish

- Off `updateTime`'s per-second tick, which re-fired every tick of a book's final second, on scrub-to-end, and on **every repeat-mode loop**; now armed once in `playerDidFinishPlaying`'s natural-end branch.
- Deliberately **not** in `markAsCompleted`: it's reachable from manual mark-as-finished and posts `.bookEnd` even when *un*-finishing.
- `PlayerViewModel.requestReview` keeps only the app-active guard (an evaluation while backgrounded can't waste the armed flag) and delegates. The `sceneDidBecomeActive` deferred-delivery path stays — it's the main delivery path since books finish locked — but is now harmless under the cooldown.
- `AppServices` drops `requestReview()` + the StoreKit import and owns the service instance.

## Behavior notes

- Net effect: at most one prompt per app version, at most ~3/year, always within one session of finishing a book.
- **Legacy `ask_review` key abandoned on purpose** (new `userPendingReviewPrompt` key): existing users with a stale armed flag start fresh instead of getting prompted at app-open right after updating.
- Removed the dead watch-side `ask_review` write — nothing consumed it and watchOS has no review-prompt API.
- Repeat-mode loops no longer count as finishes (previously each loop re-armed the flag).

## Testing

- New `ReviewPromptServiceTests` (7 tests, isolated `UserDefaults` suite, injected clock/version/prompt spy): first-request prompts + records, not-armed no-op, cooldown blocks + consumes the flag without clobbering the stored date, same-version blocks after cooldown, cooldown + new version prompts, future-date self-heal then re-prompt a full cooldown later, consecutive finishes prompt once.
- `build-for-testing` clean (no new warnings in touched files); suite green on the iPhone 17 simulator.
- Watch target change is a pure block deletion, not compiled by the app scheme — next watch build confirms.