### PR TITLE
Wire the sticky library sort into the watch app

### DIFF
--- a/BookPlayerWatch/CoreServices.swift
+++ b/BookPlayerWatch/CoreServices.swift
@@ -18,6 +18,10 @@ class CoreServices: ObservableObject {
   let playerManager: PlayerManager
   let playerLoaderService: PlayerLoaderService
   let watchConnectivityService: WatchConnectivityService
+  /// Pull-only on watchOS: resolves the sticky library sort so the list and
+  /// playback navigation match the phone. Nothing on the watch writes sort
+  /// preferences, and its pull is gated on the account's sync entitlement.
+  let preferencesService: PreferencesSyncServiceProtocol
 
   @Published var hasSyncEnabled = false
 
@@ -29,7 +33,8 @@ class CoreServices: ObservableObject {
     playbackService: PlaybackServiceProtocol,
     playerManager: PlayerManager,
     playerLoaderService: PlayerLoaderService,
-    watchConnectivityService: WatchConnectivityService
+    watchConnectivityService: WatchConnectivityService,
+    preferencesService: PreferencesSyncServiceProtocol
   ) {
     self.dataManager = dataManager
     self.accountService = accountService
@@ -40,6 +45,7 @@ class CoreServices: ObservableObject {
     self.playerManager = playerManager
     self.playerLoaderService = playerLoaderService
     self.watchConnectivityService = watchConnectivityService
+    self.preferencesService = preferencesService
   }
 
   func checkAndReloadIfSyncIsEnabled() {

--- a/BookPlayerWatch/ExtensionDelegate.swift
+++ b/BookPlayerWatch/ExtensionDelegate.swift
@@ -94,6 +94,18 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate, ObservableObject {
         playbackService: playbackService,
         playerManager: playerManager
       )
+      let preferencesService = PreferencesSyncService()
+      preferencesService.setup(
+        accountService: accountService,
+        libraryService: libraryService
+      )
+      /// Wires the sticky-sort resolver into the fetch pipeline: with this set,
+      /// `resolveSortDescriptors` renders the same order as the phone instead
+      /// of falling back to `orderRank`.
+      libraryService.preferencesService = preferencesService
+      Task {
+        await preferencesService.bootstrap()
+      }
       let coreServices = CoreServices(
         dataManager: dataManager,
         accountService: accountService,
@@ -102,7 +114,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate, ObservableObject {
         playbackService: playbackService,
         playerManager: playerManager,
         playerLoaderService: playerLoaderService,
-        watchConnectivityService: ExtensionDelegate.contextManager.watchConnectivityService
+        watchConnectivityService: ExtensionDelegate.contextManager.watchConnectivityService,
+        preferencesService: preferencesService
       )
 
       self.coreServices = coreServices

--- a/BookPlayerWatch/LocalPlayback/RemoteItemList/RemoteItemListViewModel.swift
+++ b/BookPlayerWatch/LocalPlayback/RemoteItemList/RemoteItemListViewModel.swift
@@ -90,12 +90,27 @@ final class RemoteItemListViewModel: ObservableObject {
   }
 
   func syncListContents(ignoreLastTimestamp: Bool) async throws {
+    /// Refresh the sticky-sort prefs first (entitlement-gated, 60s cooldown)
+    /// so the refetch below renders with the latest rules — same ordering as
+    /// the phone's `ListSyncRefreshService`.
+    await coreServices.preferencesService.pullFromServer(force: false)
+
     guard
       await coreServices.syncService.canSyncListContents(
         at: folderRelativePath,
         ignoreLastTimestamp: ignoreLastTimestamp
       )
-    else { return }
+    else {
+      /// Contents are fresh, but the pref pull may have changed the sort —
+      /// re-render from the store either way.
+      items =
+        coreServices.libraryService.fetchContents(
+          at: folderRelativePath,
+          limit: nil,
+          offset: nil
+        ) ?? []
+      return
+    }
 
     do {
       try await coreServices.syncService.syncListContents(at: folderRelativePath)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,8 +390,10 @@ data, and share the error type `MediaServerIntegration/IntegrationError.swift` (
   location's effective sort to `SortType.sortDescriptors` (`localizedStandardCompare:` + `orderRank` tie-break);
   sync may overwrite ranks freely — the rendered order only follows ranks where the effective sort resolves to
   rank order: Custom, `.unresolved`/bound locations, and any target with no `preferencesService` wired.
-  **watchOS is such a target** (only the iOS app assigns `preferencesService`), so the watch renders rank order
-  for a folder the phone renders rule-sorted — a known, deliberate platform fork (same as Android Wear). Rank
+  **watchOS wires a pull-only `PreferencesSyncService`** (constructed in `ExtensionDelegate`, bootstrapped at
+  launch, refreshed before each list sync in `RemoteItemListViewModel`), so the watch renders the same sticky
+  sort as the phone; nothing on the watch writes sort prefs, and the pull is gated on the sync entitlement so
+  free accounts never make the request. Rank
   updates always sync (no auto-sort suppression exists anymore). **Both mutation invariants live in
   `freezeVisibleOrder(at:transform:)`** — the single core of `reorderItems`/`reverseContents`/
   `adoptCurrentOrderAsCustom`: (1) capture-before-flip — the effective (visible) descriptors are resolved


### PR DESCRIPTION
## What this is

The follow-up the query-time-sort refactor (#1582) deferred: watchOS rendered the latent rank order because its `LibraryService` had no `preferencesService` — a folder sorted by Title on the phone listed in custom/import order on the watch, and watch prev/next walked that different order.

## How it works

Pull-only reuse of the existing `PreferencesSyncService` (already compiled into `BookPlayerWatchKit`, already platform-guarded):

- `ExtensionDelegate` constructs it, wires it into `LibraryService`, and bootstraps it at launch — from then on `resolveSortDescriptors` renders the same sticky sort as the phone, per folder, and playback prev/next follows the visible order via the shared `PlaybackService`.
- `RemoteItemListViewModel.syncListContents` refreshes the prefs before each list sync (mirroring the phone's `ListSyncRefreshService` ordering; 60s pull cooldown keeps folder navigation cheap) and re-renders on the fresh-contents early return, so a sort changed on the phone lands on the next watch appearance even when contents are already synced.
- Nothing on the watch writes sort preferences, so the service's push pipeline stays idle; `pullFromServer` is gated on `hasSyncEnabled()`, so free accounts never make the request — consistent with the full library list being Pro-only (free users only see the last-played list, which is unaffected).
- The logout freeze-before-wipe from #1582 now also protects the watch's visible order.

No Shared/iOS code changes; no protocol changes; no server changes. CLAUDE.md's ordering-model note updated (the documented watch rank-order fork is gone).

## Testing

`BookPlayerWatch` scheme builds clean. The sort mechanics, entitlement gating, and malformed-payload handling are covered by the existing suites from #1581/#1582; there is no watch test target, so device QA is the verification:

- Phone sets Title → watch app foreground → library list reorders to match
- Per-folder override on the phone → same folder on watch follows it
- Free account: recent list unchanged, no preferences request
- Standalone watch (phone away): pull works over Wi-Fi/LTE
- Watch prev/next and end-of-book autoplay follow the visible order