### PR TITLE
Refresh most-recent sort on book playback

### DIFF
--- a/BookPlayer.xcodeproj/project.pbxproj
+++ b/BookPlayer.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		5163037679ED3EE0D1866A8F /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC8B923A5506F865253B97C /* AppServices.swift */; };
 		52AA441379FD94339FEECB55 /* SortPreferencesResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6BC9E7E76B9BAB7A0D88D2 /* SortPreferencesResolving.swift */; };
 		59384C1A0B33B9EB42AE4C75 /* ChaptersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F496A2BF4CBFFC745C453D42 /* ChaptersViewModelTests.swift */; };
+		A1B2C3D4E5F60001LISTV01 /* ItemListViewModelReloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002LISTV01 /* ItemListViewModelReloadTests.swift */; };
 		5A9506FC8DAB858289E0EF89 /* IntegrationServerAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623E13D0C96857091397B5EF /* IntegrationServerAddressTests.swift */; };
 		5E20E8B93A65A58C51F1FF52 /* PKCETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A989BA90E16F60920A1DB0 /* PKCETests.swift */; };
 		62793611272CBE910097837D /* ImportFileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4163E3102148606600072AA2 /* ImportFileItem.swift */; };
@@ -1862,6 +1863,7 @@
 		F1E6918C51C370C2E89B24F9 /* PreferencesAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferencesAPI.swift; sourceTree = "<group>"; };
 		F4388D9707FA7C85F9D07E75 /* WebAuthenticatingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebAuthenticatingTests.swift; sourceTree = "<group>"; };
 		F496A2BF4CBFFC745C453D42 /* ChaptersViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChaptersViewModelTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60002LISTV01 /* ItemListViewModelReloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ItemListViewModelReloadTests.swift; sourceTree = "<group>"; };
 		F5A989BA90E16F60920A1DB0 /* PKCETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PKCETests.swift; sourceTree = "<group>"; };
 		F6F0D505E060FDAEB6DB68E3 /* IntegrationLibraryListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntegrationLibraryListView.swift; sourceTree = "<group>"; };
 		F78387C7EDD9105363712F34 /* VideoFullscreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFullscreenViewController.swift; sourceTree = "<group>"; };
@@ -3241,6 +3243,7 @@
 			isa = PBXGroup;
 			children = (
 				F496A2BF4CBFFC745C453D42 /* ChaptersViewModelTests.swift */,
+				A1B2C3D4E5F60002LISTV01 /* ItemListViewModelReloadTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -5009,6 +5012,7 @@
 				1A26F7D72FFD6D625A313FC5 /* AudioMetadataServiceTests.swift in Sources */,
 				466E4B7066F10717C8CE7B3E /* LibraryServiceReloadChaptersTests.swift in Sources */,
 				59384C1A0B33B9EB42AE4C75 /* ChaptersViewModelTests.swift in Sources */,
+				A1B2C3D4E5F60001LISTV01 /* ItemListViewModelReloadTests.swift in Sources */,
 				5E20E8B93A65A58C51F1FF52 /* PKCETests.swift in Sources */,
 				02C668174D24A70B4CD6FCB1 /* IntegrationConnectionStoreTests.swift in Sources */,
 				8A0883CB5B4914B2DCB70A5E /* AudiobookShelfOIDCFlowTests.swift in Sources */,

--- a/BookPlayer/Library/ItemList/ItemListView.swift
+++ b/BookPlayer/Library/ItemList/ItemListView.swift
@@ -90,6 +90,17 @@ struct ItemListView: View {
         guard model.libraryNode.matchesSortPrefKey(key) else { return }
         listState.reloadAll()
       }
+      .onReceive(NotificationCenter.default.publisher(for: .bookPlayed)) { _ in
+        guard isSortedByMostRecent, !model.isFiltering, !model.editMode.isEditing else { return }
+        model.reloadItemsPreservingOffset()
+      }
+  }
+
+  private var isSortedByMostRecent: Bool {
+    guard case .automatic(.mostRecent) = preferencesService.effectiveSort(forLocation: currentLocation) else {
+      return false
+    }
+    return true
   }
 
   @ViewBuilder

--- a/BookPlayer/Library/ItemList/ItemListViewModel.swift
+++ b/BookPlayer/Library/ItemList/ItemListViewModel.swift
@@ -171,6 +171,31 @@ final class ItemListViewModel: ObservableObject {
     isLoading = false
   }
 
+  /// Re-fetches the currently-visible window so a live sort key ("Most recent"
+  /// while playing) can reorder rows without resetting the user's scroll position
+  /// to the top of a long list. Fetches from offset 0 covering all loaded items.
+  @MainActor
+  func reloadItemsPreservingOffset() {
+    guard !items.isEmpty else {
+      reloadItems()
+      return
+    }
+
+    isLoading = true
+
+    let limit = items.count + offset
+    let fetchedItems =
+      libraryService.fetchContents(
+        at: libraryNode.folderRelativePath,
+        limit: limit,
+        offset: 0
+      ) ?? []
+
+    items = fetchedItems
+    canLoadMore = fetchedItems.count == limit
+    isLoading = false
+  }
+
   // MARK: - Search
 
   /// Reacts to query/scope changes: debounces then runs a scoped database search, or restores the

--- a/BookPlayerTests/ViewModels/ItemListViewModelReloadTests.swift
+++ b/BookPlayerTests/ViewModels/ItemListViewModelReloadTests.swift
@@ -1,0 +1,198 @@
+//
+//  ItemListViewModelReloadTests.swift
+//  BookPlayerTests
+//
+//  Tests for `reloadItemsPreservingOffset` — the method that re-fetches the
+//  currently-visible window without resetting the scroll position to the top.
+//  Uses `SortIntegrationHarness` for a real LibraryService + PreferencesSyncService
+//  so the sort-resolution path (effectiveSort → fetchContents sort descriptors)
+//  is production-faithful.
+//
+
+@testable import BookPlayer
+@testable import BookPlayerKit
+import XCTest
+
+@MainActor
+final class ItemListViewModelReloadTests: XCTestCase {
+  private var harness: SortIntegrationHarness!
+  private var viewModel: ItemListViewModel!
+
+  override func setUp() {
+    super.setUp()
+    DataTestUtils.clearFolderContents(url: DataManager.getProcessedFolderURL())
+
+    harness = SortIntegrationHarness()
+
+    let playbackService = PlaybackService()
+    playbackService.setup(libraryService: harness.libraryService)
+
+    let playerManager = PlayerManager(
+      libraryService: harness.libraryService,
+      playbackService: playbackService,
+      syncService: SyncService(),
+      speedService: SpeedService(libraryService: harness.libraryService),
+      shakeMotionService: ShakeMotionServiceProtocolMock(),
+      widgetReloadService: WidgetReloadService()
+    )
+
+    let listSyncRefreshService = ListSyncRefreshService(
+      playerManager: playerManager,
+      syncService: SyncService(),
+      playerLoaderService: PlayerLoaderService(),
+      preferencesService: harness.preferences
+    )
+
+    let singleFileDownloadService = SingleFileDownloadService(
+      networkClient: NetworkClientMock(mockedResponse: Empty())
+    )
+
+    viewModel = ItemListViewModel(
+      libraryNode: .root,
+      libraryService: harness.libraryService,
+      playbackService: playbackService,
+      playerManager: playerManager,
+      syncService: SyncService(),
+      listSyncRefreshService: listSyncRefreshService,
+      loadingState: LoadingOverlayState(),
+      listState: ListStateManager(),
+      singleFileDownloadService: singleFileDownloadService
+    )
+  }
+
+  override func tearDown() {
+    harness.tearDown()
+    harness = nil
+    viewModel = nil
+    super.tearDown()
+  }
+
+  // MARK: - reloadItemsPreservingOffset
+
+  /// Empty list: falls back to `reloadItems()` which fetches from offset 0.
+  func testReloadPreservingOffsetOnEmptyListFetchesFromStart() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.save()
+
+    XCTAssertTrue(viewModel.items.isEmpty)
+
+    viewModel.reloadItemsPreservingOffset()
+
+    XCTAssertEqual(viewModel.items.count, 2)
+    XCTAssertEqual(viewModel.offset, 0)
+  }
+
+  /// Loaded window of 2 items (offset 0): re-fetch covers the same range.
+  func testReloadPreservingOffsetCoversLoadedWindow() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.seedBook(relativePath: "c.txt", rank: 2)
+    harness.save()
+
+    // Simulate loading the first 2 items
+    let firstPage = harness.libraryService.fetchContents(at: nil, limit: 2, offset: 0) ?? []
+    viewModel.items = firstPage
+    viewModel.offset = firstPage.count
+    viewModel.canLoadMore = true
+
+    viewModel.reloadItemsPreservingOffset()
+
+    XCTAssertEqual(viewModel.items.count, 2, "same window size")
+    XCTAssertEqual(viewModel.offset, 2, "offset unchanged")
+    XCTAssertTrue(viewModel.canLoadMore, "more items remain beyond the window")
+  }
+
+  /// Scrolled into the list (offset > 0): re-fetch covers from offset 0 to
+  /// offset + loaded count, so the entire visible range is refreshed —
+  /// the user does not lose their scroll position.
+  func testReloadPreservingOffsetCoversFullVisibleRangeAfterScroll() {
+    let total = 30
+    for i in 0..<total {
+      harness.seedBook(relativePath: "book\(i).txt", rank: Int16(i))
+    }
+    harness.save()
+
+    // Simulate user scrolled: loaded 2 pages (26 items), offset = 26
+    let loaded = harness.libraryService.fetchContents(at: nil, limit: 26, offset: 0) ?? []
+    viewModel.items = loaded
+    viewModel.offset = loaded.count
+    viewModel.canLoadMore = true
+
+    viewModel.reloadItemsPreservingOffset()
+
+    XCTAssertEqual(viewModel.items.count, 26, "full visible range re-fetched")
+    XCTAssertEqual(viewModel.offset, 26, "offset preserved")
+    XCTAssertTrue(viewModel.canLoadMore, "4 more items remain")
+  }
+
+  /// After re-sort, the visible items reflect the new order, not the old one.
+  func testReloadPreservingOffsetReflectsUpdatedSortOrder() {
+    let now = Date()
+    let oldDate = now.addingTimeInterval(-200)
+    let newerDate = now.addingTimeInterval(-100)
+
+    harness.seedBook(relativePath: "a.txt", rank: 0, lastPlayDate: oldDate)
+    harness.seedBook(relativePath: "b.txt", rank: 1, lastPlayDate: newerDate)
+    harness.save()
+
+    // Default sort is by rank (custom): a, b
+    let loaded = harness.libraryService.fetchContents(at: nil, limit: nil, offset: nil) ?? []
+    viewModel.items = loaded
+    viewModel.offset = loaded.count
+
+    XCTAssertEqual(viewModel.items.map(\.relativePath), ["a.txt", "b.txt"])
+
+    // Switch to most-recent sort
+    harness.preferences.setSort(.automatic(.mostRecent), forLocation: .libraryRoot)
+
+    viewModel.reloadItemsPreservingOffset()
+
+    XCTAssertEqual(
+      viewModel.items.map(\.relativePath),
+      ["b.txt", "a.txt"],
+      "re-fetch reflects the new sort order"
+    )
+  }
+
+  /// If the store has fewer items than the window (e.g. items were deleted),
+  /// `canLoadMore` is correctly set to false.
+  func testReloadPreservingOffsetSetsCanLoadMoreFalseWhenExhausted() {
+    harness.seedBook(relativePath: "a.txt", rank: 0)
+    harness.seedBook(relativePath: "b.txt", rank: 1)
+    harness.save()
+
+    viewModel.items = harness.libraryService.fetchContents(at: nil, limit: nil, offset: nil) ?? []
+    viewModel.offset = viewModel.items.count
+    viewModel.canLoadMore = true // stale state
+
+    viewModel.reloadItemsPreservingOffset()
+
+    XCTAssertFalse(viewModel.canLoadMore, "no more items to load")
+  }
+
+  // MARK: - reloadItems (for comparison)
+
+  /// `reloadItems` resets offset to 0 and fetches only the first page —
+  /// the behaviour that `reloadItemsPreservingOffset` is designed to avoid.
+  func testReloadItemsResetsOffsetToZero() {
+    let total = 30
+    for i in 0..<total {
+      harness.seedBook(relativePath: "book\(i).txt", rank: Int16(i))
+    }
+    harness.save()
+
+    // Simulate scrolled state
+    let loaded = harness.libraryService.fetchContents(at: nil, limit: 26, offset: 0) ?? []
+    viewModel.items = loaded
+    viewModel.offset = 26
+    viewModel.canLoadMore = true
+
+    viewModel.reloadItems()
+
+    XCTAssertEqual(viewModel.offset, viewModel.items.count, "offset reset to first-page count")
+    // reloadItems fetches items.count + 0 padding = 26 items
+    XCTAssertEqual(viewModel.items.count, 26)
+    XCTAssertTrue(viewModel.canLoadMore)
+  }
+}


### PR DESCRIPTION
## Purpose

When the library is sorted by **Most recent**, the order comes directly from `lastPlayDate` in the fetch request.

Starting playback updates `lastPlayDate`, but the visible list is not fetched again. Because of that, the book the user just started does not move to the top until the screen is reopened or manually refreshed.

This change refreshes the **Most recent** list when playback starts, while keeping the current scroll position

## Approach

* `ItemListView.swift`

  * Listen for `.bookPlayed`.
  * Refresh only when the current location is sorted by `mostRecent`.
  * Skip the refresh while searching or editing.

* `ItemListViewModel.swift`

  * Add `reloadItemsPreservingOffset()`.
  * It reloads the currently visible range instead of resetting the list to the first page, so long lists keep their scroll position.

* `ItemListViewModelReloadTests.swift`

  * Add coverage for empty and unscrolled lists, scrolled lists, re-sorting, exhausted pagination, and the difference from the existing `reloadItems()` behavior.

`.bookPlayed` is used intentionally instead of `.bookPlaying` or playback progress updates. `lastPlayDate` is updated every second during playback, so reacting to those events would constantly re-fetch and reorder the list. Refreshing once when playback starts is enough.

## Things to be aware of / Things to focus on

* `reloadItemsPreservingOffset()` currently sets `canLoadMore` based on whether the fetch returned exactly the requested limit. At a page boundary, a re-sort could theoretically make the returned window smaller and stop pagination early.
* `.bookPlayed` also fires when autoplay starts the next book. This is expected and keeps that book near the top as well.
* The subscription stays active while another tab is selected, so a background refresh can happen before the user returns to the list.
* Query-time sorting by `lastPlayDate` is already covered by `testMostRecentReflectsPlaybackImmediately`. The new tests focus on the ViewModel reload behavior and pagination state.