### PR TITLE
Keep typed text in the connection host field; normalize only the model

### DIFF
--- a/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
+++ b/BookPlayer/MediaServerIntegration/Connection Screen/IntegrationConnectionFlowView.swift
@@ -160,10 +160,12 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
   /// The port as typed. Kept as text so emptying the field is representable; parsed on change.
   @State private var portText: String
 
-  /// The host field's display text, mirrored from `address.hostField` rather than bound to it
-  /// directly. A focused `TextField` shows its live edit buffer and won't re-read a computed
-  /// binding whose setter changed the value — so a decomposed paste kept displaying the full URL
-  /// until focus left. A plain `@State` is something the field does refresh from immediately.
+  /// The host field's display text: what the user typed, as its own state rather than a binding to
+  /// the model's computed `hostField`. Two reasons. A focused `TextField` shows its live edit buffer
+  /// and won't re-read a computed binding whose setter changed the value — so a decomposed paste kept
+  /// displaying the full URL until focus left; a plain `@State` is something the field does refresh
+  /// from immediately. And the model normalizes for assembly (subpath slashes, encoding, IPv6
+  /// brackets), which must not be echoed into the field while typing — it deleted a just-typed `/`.
   @State private var hostText: String
 
   @EnvironmentObject var theme: ThemeViewModel
@@ -231,12 +233,14 @@ struct IntegrationAddressScreen<VM: IntegrationConnectionViewModelProtocol>: Vie
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .onChange(of: hostText) { _, newValue in
-              address.hostField = newValue
-              // The setter normalizes — a pasted URL decomposes, IPv6 gains brackets. Reflect that
-              // in the visible text at once instead of on focus loss. Settles in one extra pass:
-              // re-setting an already-normalized value changes nothing.
-              if address.hostField != newValue {
-                hostText = address.hostField
+              // The field keeps the typed text; the model normalizes for assembly and the footer
+              // shows the result. The text is rewritten only when the edit moved something into
+              // another field — a pasted URL's scheme and port, a peeled `host:port` — which
+              // `applyHostField` reports by returning the remaining host + subpath. Settles in one
+              // extra pass: re-applying that value changes nothing.
+              let display = address.applyHostField(newValue)
+              if display != newValue {
+                hostText = display
               }
             }
           }

--- a/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
+++ b/BookPlayer/MediaServerIntegration/Connection/IntegrationServerAddress.swift
@@ -121,54 +121,79 @@ struct IntegrationServerAddress: Equatable, Sendable {
   /// `[http:]//100.81.227.12:13378` and assembled garbage.
   var hostField: String {
     get { host + path }
-    set {
-      // A full URL (pasted, or typed through): distribute across ALL the fields — the scheme
-      // control flips, the port moves to its row, the host keeps only the host and subpath.
-      if newValue.contains("://") {
-        if let pasted = IntegrationServerAddress(parsing: newValue) {
-          self = pasted
-        } else {
-          // Mid-typing through the scheme, or an unparseable paste: hold the raw text so nothing
-          // is mangled or lost. `url` stays nil (a colon-bearing host never assembles), which
-          // keeps Connect disabled until the text resolves into something real.
-          host = newValue
-          path = ""
-        }
-        return
+    set { applyHostField(newValue) }
+  }
+
+  /// Applies text typed or pasted into the Host row and returns what the row should display.
+  ///
+  /// The returned text is the input itself unless the edit moved something into *another* field — a
+  /// full URL whose scheme and port were distributed to their controls, or a scheme-less `host:port`
+  /// whose port was peeled off — in which case it is the remaining host + subpath, so the port is not
+  /// shown twice. Every other normalization (trailing and leading slash, percent-encoding, IPv6
+  /// brackets) applies to the model only. Echoing the normalized form back into a focused field
+  /// deleted the `/` the user had just typed — a reverse-proxy subpath could not be typed at all,
+  /// only pasted — and showed `myserver.com:` or `http:` as an IPv6 literal on the way to a port or
+  /// a scheme. The assembled URL in the footer is where the normalized form belongs.
+  @discardableResult
+  mutating func applyHostField(_ text: String) -> String {
+    // A full URL (pasted, or typed through): distribute across ALL the fields — the scheme
+    // control flips, the port moves to its row, the host keeps only the host and subpath.
+    if text.contains("://") {
+      if let pasted = IntegrationServerAddress(parsing: text) {
+        self = pasted
+        return hostField
       }
-      // Scheme-less: peel the subpath off first, then a trailing port off the host part —
-      // `host:port` and `host:port/path` are both the mockups' scheme-less paste.
-      var rawHost = newValue
-      var rawPath = ""
-      if let slash = newValue.firstIndex(of: "/") {
-        rawHost = String(newValue[..<slash])
-        rawPath = String(newValue[slash...])
-      }
-      // Exactly one colon with a valid port after it can't be an IPv6 literal (those carry two or
-      // more colons); a bracketed literal announces its port with `]:`.
-      let colonParts = rawHost.split(separator: ":", omittingEmptySubsequences: false)
-      if colonParts.count == 2, let pastedPort = Int(colonParts[1]),
-         (1...65535).contains(pastedPort), !colonParts[0].isEmpty, !colonParts[0].contains("[") {
-        port = pastedPort
-        rawHost = String(colonParts[0])
-      } else if rawHost.hasPrefix("["), let bracket = rawHost.range(of: "]:"),
-                let pastedPort = Int(rawHost[bracket.upperBound...]), (1...65535).contains(pastedPort) {
-        port = pastedPort
-        rawHost = String(rawHost[..<bracket.upperBound].dropLast())
-      }
-      host = Self.normalizedHost(rawHost)
-      path = Self.normalizedPath(rawPath)
+      // Mid-typing through the scheme, or an unparseable paste: hold the raw text so nothing
+      // is mangled or lost. `url` stays nil (a colon-bearing host never assembles), which
+      // keeps Connect disabled until the text resolves into something real.
+      host = text
+      path = ""
+      return text
     }
+    // Scheme-less: peel the subpath off first, then a trailing port off the host part —
+    // `host:port` and `host:port/path` are both the mockups' scheme-less paste.
+    var rawHost = text
+    var rawPath = ""
+    if let slash = text.firstIndex(of: "/") {
+      rawHost = String(text[..<slash])
+      rawPath = String(text[slash...])
+    }
+    // Exactly one colon with a valid port after it can't be an IPv6 literal (those carry two or
+    // more colons); a bracketed literal announces its port with `]:`.
+    var peeledPort = false
+    let colonParts = rawHost.split(separator: ":", omittingEmptySubsequences: false)
+    if colonParts.count == 2, let pastedPort = Int(colonParts[1]),
+       (1...65535).contains(pastedPort), !colonParts[0].isEmpty, !colonParts[0].contains("[") {
+      port = pastedPort
+      rawHost = String(colonParts[0])
+      peeledPort = true
+    } else if rawHost.hasPrefix("["), let bracket = rawHost.range(of: "]:"),
+              let pastedPort = Int(rawHost[bracket.upperBound...]), (1...65535).contains(pastedPort) {
+      port = pastedPort
+      rawHost = String(rawHost[..<bracket.upperBound].dropLast())
+      peeledPort = true
+    }
+    host = Self.normalizedHost(rawHost)
+    path = Self.normalizedPath(rawPath)
+    return peeledPort ? hostField : text
   }
 
   // MARK: - Helpers
 
   /// A bare IPv6 literal gains its brackets: `URLComponents` refuses to assemble a host containing
-  /// a colon without them, so a bare `"::1"` would make `url` silently nil. No other legitimate host
-  /// contains a colon — ports live in their own field — so the wrap cannot misfire.
+  /// a colon without them, so a bare `"::1"` would make `url` silently nil. Only text that *looks*
+  /// like an IPv6 literal is wrapped — two or more colons and nothing but hex digits, dots and colons
+  /// (a `%zone` suffix aside). A hostname with a stray colon (`myserver.com:` on the way to a port,
+  /// `http:` on the way to a scheme) is left as typed; `url` stays nil until the text resolves.
   private static func normalizedHost(_ raw: String) -> String {
-    guard raw.contains(":"), !raw.hasPrefix("[") else { return raw }
+    guard !raw.hasPrefix("["), looksLikeIPv6(raw) else { return raw }
     return "[" + raw + "]"
+  }
+
+  private static func looksLikeIPv6(_ text: String) -> Bool {
+    let literal = text.split(separator: "%", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? text
+    return literal.filter { $0 == ":" }.count >= 2
+      && literal.allSatisfy { $0.isHexDigit || $0 == ":" || $0 == "." }
   }
 
   /// Empty stays empty; anything else gains a leading slash and loses trailing ones, so

--- a/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
+++ b/BookPlayerTests/MediaServerIntegration/IntegrationServerAddressTests.swift
@@ -233,4 +233,88 @@ final class IntegrationServerAddressTests: XCTestCase {
     XCTAssertEqual(address.host, "direct.example.com")
     XCTAssertEqual(address.path, "")
   }
+
+  // MARK: - Typing into the host field
+
+  /// The field shows what was typed; the model normalizes for assembly. Echoing the normalized form
+  /// back deleted the `/` a user had just typed, so a reverse-proxy subpath could only be pasted.
+  func testTypingASubpathKeepsTheSlashInTheFieldAndNormalizesOnlyTheModel() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("media.example.com/"), "media.example.com/")
+    XCTAssertEqual(address.path, "", "the model drops the trailing slash for assembly")
+    XCTAssertEqual(address.urlString, "https://media.example.com")
+
+    XCTAssertEqual(address.applyHostField("media.example.com/abs"), "media.example.com/abs")
+    XCTAssertEqual(address.path, "/abs")
+    XCTAssertEqual(address.urlString, "https://media.example.com/abs")
+  }
+
+  func testTypingAColonTowardAPortIsNeitherBracketedNorAssembled() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("media.example.com:"), "media.example.com:")
+    XCTAssertEqual(address.host, "media.example.com:", "a hostname with a colon is not an IPv6 literal")
+    XCTAssertNil(address.url, "Connect stays disabled until the text resolves")
+    XCTAssertNil(address.port)
+  }
+
+  /// Once a digit follows the colon it is a `host:port`, and the port moves to its own row — the
+  /// field text follows, so the port is not shown twice.
+  func testAPortTypedIntoTheHostFieldPeelsOffAndRewritesTheField() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("media.example.com:8096/abs"), "media.example.com/abs")
+    XCTAssertEqual(address.host, "media.example.com")
+    XCTAssertEqual(address.port, 8096)
+    XCTAssertEqual(address.path, "/abs")
+  }
+
+  func testTypingASchemeThroughIsNotMangledAndSnapsOnceItParses() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("http:"), "http:")
+    XCTAssertEqual(address.host, "http:", "not bracketed as IPv6")
+    XCTAssertNil(address.url)
+
+    XCTAssertEqual(address.applyHostField("http://"), "http://")
+    XCTAssertNil(address.url)
+
+    XCTAssertEqual(address.applyHostField("http://x"), "x", "a parseable URL distributes: the field keeps host + subpath")
+    XCTAssertEqual(address.scheme, .http)
+    XCTAssertEqual(address.host, "x")
+  }
+
+  func testAPastedFullURLRewritesTheFieldToHostAndSubpath() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("http://100.81.227.12:13378/abs"), "100.81.227.12/abs")
+    XCTAssertEqual(address.scheme, .http)
+    XCTAssertEqual(address.port, 13378)
+    XCTAssertEqual(address.urlString, "http://100.81.227.12:13378/abs")
+  }
+
+  func testABareIPv6LiteralStaysAsTypedInTheFieldButAssemblesBracketed() {
+    var address = IntegrationServerAddress(scheme: .http, host: "")
+
+    XCTAssertEqual(address.applyHostField("2001:db8::1"), "2001:db8::1")
+    XCTAssertEqual(address.host, "[2001:db8::1]")
+    XCTAssertEqual(address.urlString, "http://[2001:db8::1]")
+    XCTAssertEqual(address.applyHostField("fe80::1%25en0"), "fe80::1%25en0", "a zone id does not stop the literal being recognized")
+    XCTAssertEqual(address.host, "[fe80::1%25en0]")
+  }
+
+  func testATypedSpaceInASubpathIsEncodedInTheURLNotInTheField() {
+    var address = IntegrationServerAddress(scheme: .https, host: "")
+
+    XCTAssertEqual(address.applyHostField("x.example/audio books"), "x.example/audio books")
+    XCTAssertEqual(address.urlString, "https://x.example/audio%20books")
+  }
+
+  func testOnlyIPv6LookingHostsGainBrackets() {
+    XCTAssertEqual(IntegrationServerAddress(scheme: .http, host: "::1").host, "[::1]")
+    XCTAssertEqual(IntegrationServerAddress(scheme: .http, host: "myserver.com:").host, "myserver.com:")
+    XCTAssertEqual(IntegrationServerAddress(scheme: .http, host: "http:").host, "http:")
+    XCTAssertEqual(IntegrationServerAddress(scheme: .http, host: "my:host:name").host, "my:host:name", "letters beyond hex are not an IPv6 literal")
+  }
 }


### PR DESCRIPTION
## What this is

The connection flow's address screen (#1577) mirrors the address model back into the Host field after every keystroke, so the field shows the *normalized* model rather than what was typed. Two of the model's normalizations make that destructive while typing:

- `normalizedPath` strips trailing slashes for assembly. Type `media.example.com/` and the `/` is deleted the moment it lands, so **a reverse-proxy subpath cannot be typed at all — only pasted.** Typing `media.example.com/abs` character by character ends up as `media.example.comabs`.
- `normalizedHost` bracketed **any** host containing a colon as an IPv6 literal. `myserver.com:` on the way to a port became `[myserver.com:]`; `http:` on the way to a scheme became `[http:]`, after which the `/` was eaten again — so typing a URL through was impossible too.

Found while bringing Android to parity; Android kept the typed text verbatim from the start.

## The fix

- **The field keeps what the user typed.** New `IntegrationServerAddress.applyHostField(_:)` applies the text to the model and returns what the row should display. That is the input itself, unless the edit moved something into *another* field — a full URL whose scheme and port were distributed to their controls, or a scheme-less `host:port` whose port was peeled off — in which case it returns the remaining host + subpath so the port is not shown twice. The `hostField` setter now delegates to it, so existing callers and tests are unchanged.
- **Every other normalization is model-only** (trailing/leading slash, percent-encoding, IPv6 brackets) and shows where it belongs: the footer's assembled URL.
- **`normalizedHost` brackets only IPv6-looking text** (two or more colons; hex digits, dots, colons, an optional `%zone`). A hostname with a stray colon stays as typed and `url` stays nil, so Connect is disabled until the text resolves — no more `[myserver.com:]`.
- `IntegrationAddressScreen.onChange(of: hostText)` uses the returned display text; the doc comments on `hostText` and the setter say why.

Behavior on a paste is unchanged: `http://100.81.227.12:13378/abs` still flips the scheme, moves the port to its row and leaves `100.81.227.12/abs` in the field. Typing a URL through now snaps the same way once it parses (`http://x` → scheme http, field `x`).

## Testing

- `IntegrationServerAddressTests` +8: subpath slash kept in the field and dropped only in the model; colon toward a port neither bracketed nor assembled; port typed into the host field peels off and rewrites the field; scheme typed through (`http:` → `http://` → `http://x`); pasted full URL; bare IPv6 as typed but assembled bracketed (incl. zone id); typed space encoded in the URL, not the field; bracket rule (`::1` yes, `myserver.com:` / `http:` / `my:host:name` no).
- Suite: 31/31 green on the iPhone 17 simulator; no new warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
