### PR TITLE
Resolve chapter neighbours by position, not by the chapter's index

### DIFF
--- a/BookPlayerTests/PlayableItemTests.swift
+++ b/BookPlayerTests/PlayableItemTests.swift
@@ -115,4 +115,139 @@ class PlayableItemTests: XCTestCase {
 
     XCTAssertFalse(sut.isNearChapterStart)
   }
+
+  // MARK: - Chapter navigation
+
+  /// A single-file book whose chapter list is exactly `chapters`.
+  private func makeItem(chapters: [PlayableChapter]) -> PlayableItem {
+    PlayableItem(
+      title: "test book",
+      author: "test author",
+      chapters: chapters,
+      currentTime: 0,
+      duration: chapters.last?.end ?? 0,
+      relativePath: "book.m4b",
+      uuid: "LEGACY_UUID",
+      parentFolder: nil,
+      percentCompleted: 0,
+      lastPlayDate: nil,
+      isFinished: false,
+      isBoundBook: false
+    )
+  }
+
+  private func makeChapter(
+    _ title: String,
+    index: Int16,
+    start: TimeInterval,
+    duration: TimeInterval = 100
+  ) -> PlayableChapter {
+    PlayableChapter(
+      title: title,
+      author: "test author",
+      start: start,
+      duration: duration,
+      relativePath: "book.m4b",
+      remoteURL: nil,
+      index: index
+    )
+  }
+
+  func testChapterNavigationWalksTheListInOrder() {
+    let first = makeChapter("one", index: 1, start: 0)
+    let second = makeChapter("two", index: 2, start: 100)
+    let third = makeChapter("three", index: 3, start: 200)
+    let item = makeItem(chapters: [first, second, third])
+
+    XCTAssertNil(item.previousChapter(before: first))
+    XCTAssertEqual(item.nextChapter(after: first), second)
+    XCTAssertEqual(item.previousChapter(before: second), first)
+    XCTAssertEqual(item.nextChapter(after: second), third)
+    XCTAssertEqual(item.previousChapter(before: third), second)
+    XCTAssertNil(item.nextChapter(after: third))
+
+    XCTAssertFalse(item.hasChapter(before: first))
+    XCTAssertTrue(item.hasChapter(after: first))
+    XCTAssertTrue(item.hasChapter(before: third))
+    XCTAssertFalse(item.hasChapter(after: third))
+  }
+
+  func testChapterNavigationDoesNotTrustZeroBasedIndices() {
+    /// The stored `index` is metadata, not an array offset. A 0-based list used to
+    /// send `previousChapter(before: second)` to `chapters[-1]`.
+    let first = makeChapter("one", index: 0, start: 0)
+    let second = makeChapter("two", index: 1, start: 100)
+    let third = makeChapter("three", index: 2, start: 200)
+    let item = makeItem(chapters: [first, second, third])
+
+    XCTAssertNil(item.previousChapter(before: first))
+    XCTAssertEqual(item.nextChapter(after: first), second)
+    XCTAssertEqual(item.previousChapter(before: second), first)
+    XCTAssertEqual(item.nextChapter(after: second), third)
+    XCTAssertEqual(item.previousChapter(before: third), second)
+    XCTAssertNil(item.nextChapter(after: third))
+  }
+
+  func testChapterNavigationWithDuplicateIndices() {
+    /// Two chapters sharing `index` 1 (the shape of this file's own `setUp` fixture) used to
+    /// send `previousChapter(before: second)` to `chapters[-1]`.
+    let first = makeChapter("one", index: 1, start: 0)
+    let second = makeChapter("two", index: 1, start: 100)
+    let item = makeItem(chapters: [first, second])
+
+    XCTAssertNil(item.previousChapter(before: first))
+    XCTAssertEqual(item.nextChapter(after: first), second)
+    XCTAssertEqual(item.previousChapter(before: second), first)
+    XCTAssertNil(item.nextChapter(after: second))
+  }
+
+  func testChapterNavigationWithStaleChapterResolvesByTime() {
+    /// After "reload chapters" the player item is rebuilt, but a `PlayableChapter` captured
+    /// from the old item can still be handed in. It is not `==` to any new chapter, so the old
+    /// `chapter == chapters.first` guard failed and `Int(chapter.index) - 2` went negative.
+    let first = makeChapter("Chapter 1", index: 1, start: 0)
+    let second = makeChapter("Chapter 2", index: 2, start: 100)
+    let third = makeChapter("Chapter 3", index: 3, start: 200)
+    let item = makeItem(chapters: [first, second, third])
+
+    let staleFirst = makeChapter("old single chapter", index: 1, start: 0, duration: 300)
+    XCTAssertNil(item.previousChapter(before: staleFirst))
+    XCTAssertEqual(item.nextChapter(after: staleFirst), second)
+
+    let staleMiddle = makeChapter("old chapter", index: 7, start: 150, duration: 10)
+    XCTAssertEqual(item.previousChapter(before: staleMiddle), first)
+    XCTAssertEqual(item.nextChapter(after: staleMiddle), third)
+  }
+
+  func testChapterNavigationWithChapterOutsideTheBookReturnsNil() {
+    /// A chapter from another book, or one past the end of this one, has no neighbours here.
+    /// `nextChapter` used to index `chapters[Int(chapter.index)]` and overrun the array.
+    let first = makeChapter("one", index: 1, start: 0)
+    let second = makeChapter("two", index: 2, start: 100)
+    let item = makeItem(chapters: [first, second])
+
+    let foreign = makeChapter("elsewhere", index: 99, start: 5_000)
+    XCTAssertNil(item.previousChapter(before: foreign))
+    XCTAssertNil(item.nextChapter(after: foreign))
+    XCTAssertFalse(item.hasChapter(before: foreign))
+    XCTAssertFalse(item.hasChapter(after: foreign))
+  }
+
+  func testChapterNavigationOnSingleChapterBook() {
+    let only = makeChapter("only", index: 1, start: 0)
+    let item = makeItem(chapters: [only])
+
+    XCTAssertNil(item.previousChapter(before: only))
+    XCTAssertNil(item.nextChapter(after: only))
+  }
+
+  func testPlaybackServiceNextChapterMatchesItemNavigation() {
+    let first = makeChapter("one", index: 0, start: 0)
+    let second = makeChapter("two", index: 1, start: 100)
+    let item = makeItem(chapters: [first, second])
+    let service = PlaybackService()
+
+    XCTAssertEqual(service.getNextChapter(from: item, after: first), second)
+    XCTAssertNil(service.getNextChapter(from: item, after: second))
+  }
 }

--- a/Shared/CoreData/Lightweight-Models/PlayableItem.swift
+++ b/Shared/CoreData/Lightweight-Models/PlayableItem.swift
@@ -186,23 +186,35 @@ public final class PlayableItem: NSObject, Identifiable {
   }
 
   public func nextChapter(after chapter: PlayableChapter) -> PlayableChapter? {
-    guard !self.chapters.isEmpty else {
-      return nil
-    }
+    guard let position = self.position(of: chapter) else { return nil }
 
-    if chapter == self.chapters.last { return nil }
+    let next = self.chapters.index(after: position)
 
-    return self.chapters[Int(chapter.index)]
+    return next < self.chapters.endIndex ? self.chapters[next] : nil
   }
 
   public func previousChapter(before chapter: PlayableChapter) -> PlayableChapter? {
-    guard !self.chapters.isEmpty else {
-      return nil
+    guard
+      let position = self.position(of: chapter),
+      position > self.chapters.startIndex
+    else { return nil }
+
+    return self.chapters[self.chapters.index(before: position)]
+  }
+
+  /// Where `chapter` sits in `chapters`.
+  ///
+  /// `PlayableChapter.index` is display metadata produced by several sources (embedded chapter
+  /// tracks, folder walks, media servers) and is not guaranteed to be 1-based, unique, or in step
+  /// with this list, so it is never used as an array offset. A chapter that is not in the list
+  /// (for example one captured before "reload chapters" rebuilt the item) is placed by the
+  /// chapter that now covers its start time; a chapter outside this book's timeline has no position.
+  private func position(of chapter: PlayableChapter) -> Int? {
+    if let exact = self.chapters.firstIndex(of: chapter) {
+      return exact
     }
 
-    if chapter == self.chapters.first { return nil }
-
-    return self.chapters[Int(chapter.index) - 2]
+    return self.chapters.firstIndex { chapter.start < $0.end && $0.start <= chapter.start }
   }
 }
 

--- a/Shared/Services/PlaybackService.swift
+++ b/Shared/Services/PlaybackService.swift
@@ -53,11 +53,9 @@ public final class PlaybackService: PlaybackServiceProtocol {
   }
 
   public func getNextChapter(from item: PlayableItem, after chapter: PlayableChapter) -> PlayableChapter? {
-    guard !item.chapters.isEmpty else { return nil }
-
-    if chapter == item.chapters.last { return nil }
-
-    return item.chapters[Int(chapter.index)]
+    /// The item owns chapter ordering; indexing `item.chapters` by `chapter.index` here used
+    /// to overrun the array for chapter lists that are not 1-based and gapless.
+    return item.nextChapter(after: chapter)
   }
 
   public func getPlayableItem(before relativePath: String, parentFolder: String?) -> PlayableItem? {


### PR DESCRIPTION
## What this is

Sentry [BOOKPLAYER-133X](https://tortuga-power.sentry.io/issues/BOOKPLAYER-133X) (248 users / 30 days, still present on 5.22.0) plus 1377 (`nextChapter`, same drag) and the old-player groupings 113G and 114R: `EXC_BREAKPOINT` in `PlayableItem.previousChapter` / `nextChapter` via `PlayerViewModel.handleSliderDragChanged → hasChapter(before:/after:)`.

`nextChapter(after:)` / `previousChapter(before:)` treated `PlayableChapter.index` as an array offset:

```swift
if chapter == self.chapters.first { return nil }
return self.chapters[Int(chapter.index) - 2]
```

`index` is display metadata that comes from several producers (embedded chapter tracks, folder walks, media servers) and is not guaranteed to be 1-based, unique, or in step with the list. The `== first` / `== last` guards only work when the caller's chapter is byte-identical to the stored one — `PlayableChapter` equality includes `title` and `start`. Anything else goes negative or past the end:

- a 0-based list sends `previousChapter(before: second)` to `chapters[-1]`, and `nextChapter(after:)` returns the *same* chapter (so "next" never advances);
- duplicate `index` values (the shape of `PlayableItemTests`' own `setUp` fixture) crash the same way;
- a chapter captured before "reload chapters" rebuilt the item is not `==` to any new chapter, so the guard fails and the arithmetic runs on a list it doesn't belong to;
- a chapter from another book indexes past `endIndex`.

`PlaybackService.getNextChapter(from:after:)` (bound-book auto-advance, phone and watch) was a copy of the same arithmetic.

## The fix

`PlayableItem` resolves the chapter's **position** and walks the array from there:

1. exact match (`firstIndex(of:)`) — the normal case, since callers pass chapters obtained from the same item;
2. otherwise the chapter that now covers the incoming chapter's `start` — so a stale reference after a reload still gets sensible neighbours;
3. otherwise `nil` — a chapter outside this book has no neighbours, and both `hasChapter` checks turn false.

No arithmetic on `index` remains. `PlaybackService.getNextChapter` delegates to `item.nextChapter(after:)`. `Shared/` compiles into both frameworks, so the watch player picks this up too (pure stdlib change, no platform code).

## Testing

- 7 new tests in `PlayableItemTests` (`// MARK: - Chapter navigation`): ordered walk + `hasChapter` mirror, 0-based indices, duplicate indices, stale chapter after reload (resolves by time), chapter outside the book returns `nil`, single-chapter book, and `PlaybackService.getNextChapter` parity.
- **Against `develop` before the fix** the runner died four times with `Swift/ContiguousArrayBuffer.swift:692: Fatal error: Index out of range` (0-based, duplicate, stale, outside-book cases) and the 0-based `PlaybackService` case returned the wrong chapter — that is the crash this PR removes.
- After the fix: `PlayableItemTests` 12/12 green, and the full `Unit Tests` plan (`-only-testing:BookPlayerTests`, iPhone 17 simulator) green.

## After merge

Resolve BOOKPLAYER-133X / 1377 / 113G / 114R in Sentry **in the release** that ships this (REST `statusDetails.inRelease`), not before.
